### PR TITLE
Add Community post-merge Huit Dimensions handoff

### DIFF
--- a/reports/domain-progress/community/post-merge-huit-dimensions-handoff.md
+++ b/reports/domain-progress/community/post-merge-huit-dimensions-handoff.md
@@ -1,0 +1,12 @@
+# Community post-merge handoff to Huit Dimensions
+
+- Community production merge commit: `ffbcbb66e6fa3fe809d9b94e47ef9c8bf8d19ddb`
+- Domain status: `complete_to_ir_with_reservations`
+- Available symbols: canonical Community source objects plus reconciled symbol-only mappings to `TLC-SO-MASTER-001` and `TLC-SO-DISCIPLE-001`
+- Available contracts: 8 validated Community contracts for canonical feature IDs `001, 003, 004, 005, 006, 007, 008, 009`
+- Available IR: 8 validated `engineering_candidate` IR artifacts
+- Reservations to preserve: all 29 Community unresolved records; Community-006 execution semantics; Community-008 symbol-only upstream semantics
+- Readiness: ready for Huit Dimensions reconciliation; not ready for implementation planning or code generation
+- Recommended next task: `reconcile_huit_dimensions_preparation_after_community_merge`
+
+This handoff does not reconcile or produce Huit Dimensions artifacts.


### PR DESCRIPTION
Adds the required post-merge handoff report after Community reached complete_to_ir_with_reservations. No scientific or executable artifact is changed.

## Summary by Sourcery

Documentation:
- Introduce a Community post-merge handoff markdown report summarizing merge commit, available artifacts, reservations, and recommended next task.