### PR TITLE
contract(relations): first limited contract batch

### DIFF
--- a/registry/math-contract-batches/relations-limited-batch-001/manifest.yaml
+++ b/registry/math-contract-batches/relations-limited-batch-001/manifest.yaml
@@ -1,0 +1,62 @@
+schema_version: 1
+batch_id: TLC-FIRST-ECONOMIC-001
+batch_contract_id: TLC-LCB-RELATIONS-001
+batch_slug: relations-limited-batch-001
+domain: relations
+contract_kind: limited_contract_batch
+limited_contract: true
+status: candidate_with_reservations
+version: 0.1.0
+authority: origin/main
+source_commit: ff800dd1e8e87bb8a89d855d8a45c1ff6bbd8cff
+targeted_review_commit: a54889e5957941e9576293a2f7439139680ca569
+generated_on: 2026-07-23
+features:
+  - feature_id: TLC-FC-15-RELATIONS-004
+    contract_id: TLC-LC-TLC-FC-15-RELATIONS-004-001
+    contract_path: registry/math-contracts/TLC-FC-15-RELATIONS-004/contract.yaml
+    objects_covered: [TLC-SO-RELATIONS-004, TLC-SO-RELATIONS-017, TLC-SO-RELATIONS-023]
+    relations_covered: []
+    unresolved_received: 31
+    unresolved_propagated: 31
+    readiness: {ready_for_scientific_review: true, ready_for_full_contract_extension: false, ready_for_ir: false, ready_for_implementation_planning: false}
+  - feature_id: TLC-FC-15-RELATIONS-007
+    contract_id: TLC-LC-TLC-FC-15-RELATIONS-007-001
+    contract_path: registry/math-contracts/TLC-FC-15-RELATIONS-007/contract.yaml
+    objects_covered: [TLC-SO-RELATIONS-002, TLC-SO-RELATIONS-009, TLC-SO-RELATIONS-015, TLC-SO-RELATIONS-021, TLC-SO-RELATIONS-027]
+    relations_covered: []
+    unresolved_received: 12
+    unresolved_propagated: 12
+    readiness: {ready_for_scientific_review: true, ready_for_full_contract_extension: false, ready_for_ir: false, ready_for_implementation_planning: false}
+artifacts:
+  - registry/math-contracts/TLC-FC-15-RELATIONS-004/contract.yaml
+  - registry/math-contracts/TLC-FC-15-RELATIONS-004/unresolved.yaml
+  - registry/math-contracts/TLC-FC-15-RELATIONS-004/dependencies.yaml
+  - registry/math-contracts/TLC-FC-15-RELATIONS-004/traceability.yaml
+  - registry/math-contracts/TLC-FC-15-RELATIONS-004/validation-criteria.yaml
+  - reports/math-contracts/TLC-FC-15-RELATIONS-004/decision_required.yaml
+  - reports/math-contracts/TLC-FC-15-RELATIONS-004/generation-report.md
+  - registry/math-contracts/TLC-FC-15-RELATIONS-007/contract.yaml
+  - registry/math-contracts/TLC-FC-15-RELATIONS-007/unresolved.yaml
+  - registry/math-contracts/TLC-FC-15-RELATIONS-007/dependencies.yaml
+  - registry/math-contracts/TLC-FC-15-RELATIONS-007/traceability.yaml
+  - registry/math-contracts/TLC-FC-15-RELATIONS-007/validation-criteria.yaml
+  - reports/math-contracts/TLC-FC-15-RELATIONS-007/decision_required.yaml
+  - reports/math-contracts/TLC-FC-15-RELATIONS-007/generation-report.md
+  - registry/math-contract-batches/relations-limited-batch-001/manifest.yaml
+  - reports/math-contract-batches/relations-limited-batch-001/batch-report.md
+validator:
+  produced: false
+  reason: An executable validator would be code, while this batch is explicitly restricted to contracts and requires absence of code.
+  validation_mode: repository_commands_and_read_only_ad_hoc_checks
+batch_readiness:
+  ready_for_scientific_review: true
+  ready_for_full_contract_extension: false
+  ready_for_ir: false
+  ready_for_implementation_planning: false
+reservations:
+  - explicit_oracle_not_identified
+  - complete_relation_semantics_not_defined
+  - TLC-DUP-RELATIONS-002_unresolved
+  - TLC-GCYCLE-DOMAIN-001_unresolved
+  - documentary_dependencies_not_contractual_guarantees

--- a/registry/math-contracts/TLC-FC-15-RELATIONS-004/contract.yaml
+++ b/registry/math-contracts/TLC-FC-15-RELATIONS-004/contract.yaml
@@ -1,0 +1,81 @@
+schema_version: 1
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-004-001
+feature_id: TLC-FC-15-RELATIONS-004
+domain: relations
+canonical_name: "15-relations: operator (admissible)"
+contract_kind: limited_contract
+limited_contract: true
+status: candidate_with_reservations
+version: 0.1.0
+provenance:
+  authority: origin/main
+  source_commit: ff800dd1e8e87bb8a89d855d8a45c1ff6bbd8cff
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  targeted_review_commit: a54889e5957941e9576293a2f7439139680ca569
+  generated_on: 2026-07-23
+  sources:
+    - registry/domain-progress/relations/feature-inventory.yaml
+    - registry/domain-progress/relations/feature-classification.yaml
+    - registry/domain-progress/relations/feature-readiness.yaml
+    - registry/domain-progress/relations/contract-production-plan.yaml
+    - registry/global-reconciliation/targeted-readiness-review.yaml
+    - registry/global-reconciliation/dependency-scientific-review.yaml
+    - registry/global-reconciliation/cycle-scientific-review.yaml
+    - registry/scientific-objects/relations/scientific-objects.candidate.yaml
+    - registry/scientific-objects/relations/scientific-relations.candidate.yaml
+    - registry/scientific-objects/relations/unresolved-terms.yaml
+    - registry/scientific-objects/relations/duplicate-candidates.yaml
+    - maths/15-relations.md
+scientific_objects_covered: [TLC-SO-RELATIONS-004, TLC-SO-RELATIONS-017, TLC-SO-RELATIONS-023]
+scientific_relations_covered: []
+contextual_relations_not_covered: [TLC-SR-RELATIONS-003, TLC-SR-RELATIONS-016, TLC-SR-RELATIONS-022]
+unresolved_received: {source: registry/math-contracts/TLC-FC-15-RELATIONS-004/unresolved.yaml, count: 31}
+unresolved_propagated: {source: registry/math-contracts/TLC-FC-15-RELATIONS-004/unresolved.yaml, count: 31}
+limited_functional_purpose: Preserve the three cited candidate function blocks as distinct, traceable, opaque contract inputs and expose only candidate evaluation results without defining evaluation semantics.
+inputs:
+  - {input_id: INPUT-RELATIONS-004-004, scientific_object_id: TLC-SO-RELATIONS-004, description: Opaque quantities referenced by the Relation Maître‑Message function block.}
+  - {input_id: INPUT-RELATIONS-004-017, scientific_object_id: TLC-SO-RELATIONS-017, description: Opaque quantities referenced by the Relation Maître‑Valeur function block.}
+  - {input_id: INPUT-RELATIONS-004-023, scientific_object_id: TLC-SO-RELATIONS-023, description: Opaque quantities referenced by the Relation Maître‑Capacité function block.}
+outputs:
+  - {output_id: OUTPUT-RELATIONS-004-004, description: Candidate result traceable to TLC-SO-RELATIONS-004; representation and semantics remain unspecified.}
+  - {output_id: OUTPUT-RELATIONS-004-017, description: Candidate result traceable to TLC-SO-RELATIONS-017; representation and semantics remain unspecified.}
+  - {output_id: OUTPUT-RELATIONS-004-023, description: Candidate result traceable to TLC-SO-RELATIONS-023; representation and semantics remain unspecified.}
+preconditions:
+  - {id: PRE-RELATIONS-004-CANDIDATE, statement: Each covered object is supplied under candidate status with source identity preserved.}
+  - {id: PRE-RELATIONS-004-OPAQUE, statement: Missing types, signatures, directions, cardinalities, temporal properties, and operation semantics remain opaque.}
+  - {id: PRE-RELATIONS-004-UNRESOLVED, statement: Every item in unresolved.yaml remains attached to the contract context.}
+postconditions:
+  - {id: POST-RELATIONS-004-TRACEABLE, statement: Each output remains candidate and traceable to exactly one covered object.}
+  - {id: POST-RELATIONS-004-NO-PROMOTION, statement: No unresolved item, duplicate, documentary dependency, or contextual relation is promoted.}
+invariants:
+  - {id: INV-RELATIONS-004-DISTINCT, statement: The three covered objects remain distinct.}
+  - {id: INV-RELATIONS-004-SOURCE, statement: Source wording and ranges remain unchanged.}
+  - {id: INV-RELATIONS-004-LIMITED, statement: The contract remains a limited_contract and not a complete Relations contract.}
+constraints:
+  - No definition, type, dimension, signature, orientation, cardinality, symmetry, transitivity, temporality, equation, algorithm, numerical method, execution structure, or oracle may be invented.
+  - TLC-DUP-RELATIONS-002 must not be automatically merged.
+  - Contextual relations are traceability evidence only, not covered behavior.
+failure_states:
+  - {id: FAIL-RELATIONS-004-MISSING-SOURCE, condition: A covered object or exact source reference is missing.}
+  - {id: FAIL-RELATIONS-004-UNRESOLVED-DROPPED, condition: A received unresolved item is not propagated.}
+  - {id: FAIL-RELATIONS-004-IDENTITY-MERGED, condition: Covered objects or duplicate candidates are merged without human decision.}
+  - {id: FAIL-RELATIONS-004-SEMANTIC-INVENTION, condition: An unspecified scientific or execution property is asserted.}
+determinism: {status: unresolved, guarantee: none, reason: No evaluation semantics or oracle is authorized.}
+dependencies: {strong_contractual_prerequisites: [], details: registry/math-contracts/TLC-FC-15-RELATIONS-004/dependencies.yaml}
+explicitly_authorized_hypotheses:
+  - The three covered objects exist as candidate objects at their cited source ranges.
+  - Candidate outputs are opaque, source-traceable placeholders for scientific review only.
+prohibited_decisions:
+  - Complete the meaning of a listed function.
+  - Select a signature, type, domain, dimension, orientation, cardinality, symmetry, transitivity, or temporality.
+  - Select a numerical method, execution structure, implementation type, or executable oracle.
+  - Merge TLC-DUP-RELATIONS-002 or a covered object automatically.
+  - Treat documentary references or the unresolved 12-domain cycle as guarantees.
+validation_criteria: registry/math-contracts/TLC-FC-15-RELATIONS-004/validation-criteria.yaml
+traceability: registry/math-contracts/TLC-FC-15-RELATIONS-004/traceability.yaml
+readiness:
+  ready_for_scientific_review: true
+  ready_for_full_contract_extension: false
+  ready_for_ir: false
+  ready_for_implementation_planning: false
+  rationale: Only a limited contract is authorized; no explicit oracle or complete semantics exists and the global cycle remains unresolved.

--- a/registry/math-contracts/TLC-FC-15-RELATIONS-004/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-15-RELATIONS-004/dependencies.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-004-001
+feature_id: TLC-FC-15-RELATIONS-004
+limited_contract: true
+strong_contractual_prerequisites: []
+explicitly_confirmed: []
+documentary_reference_only:
+  - {dependency_id: TLC-DEP-RELATIONS-MASTER-001, edge_id: TLC-GDEP-0147, target: master, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+  - {dependency_id: TLC-DEP-RELATIONS-DISCIPLE-001, edge_id: TLC-GDEP-0148, target: disciple, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+  - {dependency_id: TLC-DEP-RELATIONS-MESSAGE-001, edge_id: TLC-GDEP-0150, target: message, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+  - {dependency_id: TLC-DEP-RELATIONS-VALUES-001, edge_id: TLC-GDEP-0152, target: values, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+  - {dependency_id: TLC-DEP-RELATIONS-CAPACITIES-001, edge_id: TLC-GDEP-0154, target: capacities, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+compatible_but_unconfirmed: []
+ambiguous: []
+human_decision_required: []
+global_reservation: {cycle_id: TLC-GCYCLE-DOMAIN-001, classification: ambiguous_cycle, contractual_use: prohibited, human_decision_required: true, evidence: registry/global-reconciliation/cycle-scientific-review.yaml}
+policy: Documentary references are context only and cannot be consumed as guarantees or strong prerequisites.

--- a/registry/math-contracts/TLC-FC-15-RELATIONS-004/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-15-RELATIONS-004/traceability.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-004-001
+feature_id: TLC-FC-15-RELATIONS-004
+limited_contract: true
+rows:
+  - {trace_id: TRACE-RELATIONS-004-004, scientific_object_id: TLC-SO-RELATIONS-004, scientific_relation_id: null, contextual_relation_id: TLC-SR-RELATIONS-003, source_path: maths/15-relations.md, section: Relation Maître‑Message, subsection: Fonctions essentielles, start_line: 18, end_line: 26, scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e, coverage: covered_as_opaque_candidate_object}
+  - {trace_id: TRACE-RELATIONS-004-017, scientific_object_id: TLC-SO-RELATIONS-017, scientific_relation_id: null, contextual_relation_id: TLC-SR-RELATIONS-016, source_path: maths/15-relations.md, section: Relation Maître‑Valeur, subsection: Fonctions essentielles, start_line: 121, end_line: 128, scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e, coverage: covered_as_opaque_candidate_object}
+  - {trace_id: TRACE-RELATIONS-004-023, scientific_object_id: TLC-SO-RELATIONS-023, scientific_relation_id: null, contextual_relation_id: TLC-SR-RELATIONS-022, source_path: maths/15-relations.md, section: Relation Maître‑Capacité, subsection: Fonctions essentielles, start_line: 164, end_line: 170, scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e, coverage: covered_as_opaque_candidate_object}
+readiness_evidence: [registry/domain-progress/relations/feature-readiness.yaml, registry/domain-progress/relations/contract-production-plan.yaml, registry/global-reconciliation/targeted-readiness-review.yaml, registry/global-reconciliation/first-contract-batches.yaml]
+unresolved_evidence: [registry/scientific-objects/relations/unresolved-terms.yaml, registry/scientific-objects/relations/duplicate-candidates.yaml, registry/global-reconciliation/cycle-scientific-review.yaml]
+coverage_summary: {scientific_objects_expected: 3, scientific_objects_covered: 3, scientific_relations_expected: 0, scientific_relations_covered: 0, unresolved_received: 31, unresolved_propagated: 31}

--- a/registry/math-contracts/TLC-FC-15-RELATIONS-004/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-15-RELATIONS-004/unresolved.yaml
@@ -1,0 +1,41 @@
+schema_version: 1
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-004-001
+feature_id: TLC-FC-15-RELATIONS-004
+limited_contract: true
+status: propagated_with_reservations
+received_count: 31
+propagated_count: 31
+propagation_complete: true
+canonical_unresolved:
+  - {id: TLC-UT-RELATIONS-007, term: Origination, source_line: 19, affected_object_id: TLC-SO-RELATIONS-033, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-008, term: Incarnation, source_line: 20, affected_object_id: TLC-SO-RELATIONS-034, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-009, term: Formulation, source_line: 21, affected_object_id: TLC-SO-RELATIONS-035, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-010, term: Filtrage, source_line: 22, affected_object_id: TLC-SO-RELATIONS-036, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-011, term: Adaptation, source_line: 24, affected_object_id: TLC-SO-RELATIONS-038, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-012, term: Ritualisation, source_line: 25, affected_object_id: TLC-SO-RELATIONS-039, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-013, term: Diffusion, source_line: 26, affected_object_id: TLC-SO-RELATIONS-040, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-031, term: Enracinement, source_line: 122, affected_object_id: TLC-SO-RELATIONS-065, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-032, term: Incarnation exemplaire, source_line: 123, affected_object_id: TLC-SO-RELATIONS-066, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-033, term: Cultivation, source_line: 124, affected_object_id: TLC-SO-RELATIONS-067, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-034, term: Traduction, source_line: 125, affected_object_id: TLC-SO-RELATIONS-068, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-035, term: Protection, source_line: 126, affected_object_id: TLC-SO-RELATIONS-069, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-036, term: Arbitrage, source_line: 127, affected_object_id: TLC-SO-RELATIONS-070, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-037, term: Évaluation, source_line: 128, affected_object_id: TLC-SO-RELATIONS-071, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-043, term: Détection et diagnostic, source_line: 165, affected_object_id: TLC-SO-RELATIONS-078, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-044, term: Évaluation de la sincérité, source_line: 166, affected_object_id: TLC-SO-RELATIONS-079, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-045, term: Stimulation et activation, source_line: 167, affected_object_id: TLC-SO-RELATIONS-080, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-046, term: Calibrage, source_line: 168, affected_object_id: TLC-SO-RELATIONS-081, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-047, term: Protection, source_line: 169, affected_object_id: TLC-SO-RELATIONS-082, category: classification_uncertainty, status: unresolved}
+  - {id: TLC-UT-RELATIONS-048, term: Maintien de sa propre capacité, source_line: 170, affected_object_id: TLC-SO-RELATIONS-083, category: classification_uncertainty, status: unresolved}
+contract_reservations:
+  - {id: UNRES-RELATIONS-004-DUPLICATE, topic: duplicate_candidate, value: TLC-DUP-RELATIONS-002, required_human_decision: Determine whether same-named function blocks are distinct or should be united., status: unresolved}
+  - {id: UNRES-RELATIONS-004-SIGNATURE, topic: signature, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-004-TYPES, topic: types_and_dimensions, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-004-DIRECTION, topic: direction, value: not_specified_unless_source_explicit, status: unresolved}
+  - {id: UNRES-RELATIONS-004-CARDINALITY, topic: cardinality, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-004-SYMMETRY, topic: symmetry, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-004-TRANSITIVITY, topic: transitivity, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-004-TEMPORALITY, topic: temporality, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-004-ORACLE, topic: explicit_oracle, value: not_identified, status: unresolved}
+  - {id: UNRES-RELATIONS-004-DETERMINISM, topic: determinism, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-004-GLOBAL-CYCLE, topic: twelve_domain_cycle, value: ambiguous_cycle, required_human_decision: Resolve or explicitly orient the global 12-domain cycle., status: unresolved}

--- a/registry/math-contracts/TLC-FC-15-RELATIONS-004/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-15-RELATIONS-004/validation-criteria.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-004-001
+feature_id: TLC-FC-15-RELATIONS-004
+limited_contract: true
+criteria:
+  - {id: VAL-RELATIONS-004-MARKER, requirement: contract_kind and limited_contract explicitly mark a limited contract}
+  - {id: VAL-RELATIONS-004-SCOPE, requirement: exactly the three planned source objects are covered}
+  - {id: VAL-RELATIONS-004-RELATIONS, requirement: no scientific relation is claimed as covered behavior}
+  - {id: VAL-RELATIONS-004-SOURCES, requirement: all exact source ranges and commits are present}
+  - {id: VAL-RELATIONS-004-UNRESOLVED, requirement: all 31 received unresolved items are propagated without promotion}
+  - {id: VAL-RELATIONS-004-DEPENDENCIES, requirement: no documentary dependency is a strong prerequisite}
+  - {id: VAL-RELATIONS-004-DUPLICATE, requirement: TLC-DUP-RELATIONS-002 remains unresolved and unmerged}
+  - {id: VAL-RELATIONS-004-NONINVENTION, requirement: no missing scientific or execution property is selected}
+  - {id: VAL-RELATIONS-004-READINESS, requirement: ready_for_ir and ready_for_implementation_planning remain false}
+  - {id: VAL-RELATIONS-004-NO-IR, requirement: no IR or implementation artifact exists in this package}
+acceptance_rule: Every criterion must pass before scientific review; passing does not authorize a full contract, IR, tests, or implementation.

--- a/registry/math-contracts/TLC-FC-15-RELATIONS-007/contract.yaml
+++ b/registry/math-contracts/TLC-FC-15-RELATIONS-007/contract.yaml
@@ -1,0 +1,84 @@
+schema_version: 1
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-007-001
+feature_id: TLC-FC-15-RELATIONS-007
+domain: relations
+canonical_name: "15-relations: relation (admissible)"
+contract_kind: limited_contract
+limited_contract: true
+status: candidate_with_reservations
+version: 0.1.0
+provenance:
+  authority: origin/main
+  source_commit: ff800dd1e8e87bb8a89d855d8a45c1ff6bbd8cff
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  targeted_review_commit: a54889e5957941e9576293a2f7439139680ca569
+  generated_on: 2026-07-23
+  sources:
+    - registry/domain-progress/relations/feature-inventory.yaml
+    - registry/domain-progress/relations/feature-classification.yaml
+    - registry/domain-progress/relations/feature-readiness.yaml
+    - registry/domain-progress/relations/contract-production-plan.yaml
+    - registry/global-reconciliation/targeted-readiness-review.yaml
+    - registry/global-reconciliation/dependency-scientific-review.yaml
+    - registry/global-reconciliation/cycle-scientific-review.yaml
+    - registry/scientific-objects/relations/scientific-objects.candidate.yaml
+    - registry/scientific-objects/relations/scientific-relations.candidate.yaml
+    - maths/15-relations.md
+scientific_objects_covered: [TLC-SO-RELATIONS-002, TLC-SO-RELATIONS-009, TLC-SO-RELATIONS-015, TLC-SO-RELATIONS-021, TLC-SO-RELATIONS-027]
+scientific_relations_covered: []
+contextual_relations_not_covered: [TLC-SR-RELATIONS-001, TLC-SR-RELATIONS-008, TLC-SR-RELATIONS-014, TLC-SR-RELATIONS-020, TLC-SR-RELATIONS-026]
+unresolved_received: {source: registry/math-contracts/TLC-FC-15-RELATIONS-007/unresolved.yaml, count: 12}
+unresolved_propagated: {source: registry/math-contracts/TLC-FC-15-RELATIONS-007/unresolved.yaml, count: 12}
+limited_functional_purpose: Preserve the five cited relation objects as distinct, traceable, opaque candidate inputs and expose only candidate evaluation results without inferring endpoint identity or relation semantics.
+inputs:
+  - {input_id: INPUT-RELATIONS-007-002, scientific_object_id: TLC-SO-RELATIONS-002, description: Opaque quantities referenced by Relation Maître‑Message.}
+  - {input_id: INPUT-RELATIONS-007-009, scientific_object_id: TLC-SO-RELATIONS-009, description: Opaque quantities referenced by Relation Maître‑Vertu.}
+  - {input_id: INPUT-RELATIONS-007-015, scientific_object_id: TLC-SO-RELATIONS-015, description: Opaque quantities referenced by Relation Maître‑Valeur.}
+  - {input_id: INPUT-RELATIONS-007-021, scientific_object_id: TLC-SO-RELATIONS-021, description: Opaque quantities referenced by Relation Maître‑Capacité.}
+  - {input_id: INPUT-RELATIONS-007-027, scientific_object_id: TLC-SO-RELATIONS-027, description: Opaque quantities referenced by Relation Maître‑Compétence.}
+outputs:
+  - {output_id: OUTPUT-RELATIONS-007-002, description: Candidate result traceable to TLC-SO-RELATIONS-002; representation and semantics remain unspecified.}
+  - {output_id: OUTPUT-RELATIONS-007-009, description: Candidate result traceable to TLC-SO-RELATIONS-009; representation and semantics remain unspecified.}
+  - {output_id: OUTPUT-RELATIONS-007-015, description: Candidate result traceable to TLC-SO-RELATIONS-015; representation and semantics remain unspecified.}
+  - {output_id: OUTPUT-RELATIONS-007-021, description: Candidate result traceable to TLC-SO-RELATIONS-021; representation and semantics remain unspecified.}
+  - {output_id: OUTPUT-RELATIONS-007-027, description: Candidate result traceable to TLC-SO-RELATIONS-027; representation and semantics remain unspecified.}
+preconditions:
+  - {id: PRE-RELATIONS-007-CANDIDATE, statement: Each covered object is supplied under candidate status with source identity preserved.}
+  - {id: PRE-RELATIONS-007-OPAQUE, statement: Endpoints, types, directions, cardinalities, properties, temporal character, and evaluation semantics remain opaque.}
+  - {id: PRE-RELATIONS-007-UNRESOLVED, statement: Every item in unresolved.yaml remains attached to the contract context.}
+postconditions:
+  - {id: POST-RELATIONS-007-TRACEABLE, statement: Each output remains candidate and traceable to exactly one covered object.}
+  - {id: POST-RELATIONS-007-NO-ENDPOINT-INFERENCE, statement: No endpoint identity or cross-object identity is inferred.}
+  - {id: POST-RELATIONS-007-NO-PROMOTION, statement: No unresolved item, documentary dependency, or contextual relation is promoted.}
+invariants:
+  - {id: INV-RELATIONS-007-DISTINCT, statement: The five covered objects remain distinct.}
+  - {id: INV-RELATIONS-007-SOURCE, statement: Source names and ranges remain unchanged.}
+  - {id: INV-RELATIONS-007-LIMITED, statement: The contract remains a limited_contract and not a complete relational model.}
+constraints:
+  - No endpoint identity, definition, type, dimension, orientation, cardinality, symmetry, transitivity, temporality, equation, algorithm, numerical method, execution structure, or oracle may be invented.
+  - Contextual refers_to relations are traceability evidence only, not covered behavior.
+  - The five grouped objects must not be fused; decomposition remains a full-contract reservation.
+failure_states:
+  - {id: FAIL-RELATIONS-007-MISSING-SOURCE, condition: A covered object or exact source reference is missing.}
+  - {id: FAIL-RELATIONS-007-UNRESOLVED-DROPPED, condition: A received unresolved item is not propagated.}
+  - {id: FAIL-RELATIONS-007-ENDPOINT-INFERRED, condition: An endpoint or identity is inferred beyond the source.}
+  - {id: FAIL-RELATIONS-007-SEMANTIC-INVENTION, condition: An unspecified scientific or execution property is asserted.}
+determinism: {status: unresolved, guarantee: none, reason: No relation-evaluation semantics or oracle is authorized.}
+dependencies: {strong_contractual_prerequisites: [], details: registry/math-contracts/TLC-FC-15-RELATIONS-007/dependencies.yaml}
+explicitly_authorized_hypotheses:
+  - The five covered relation names exist as candidate objects at their cited source lines.
+  - Candidate outputs are opaque, source-traceable placeholders for scientific review only.
+prohibited_decisions:
+  - Infer endpoint identity or a universal relation schema.
+  - Select a type, domain, dimension, direction, cardinality, symmetry, transitivity, or temporality.
+  - Select a numerical method, execution structure, implementation type, or executable oracle.
+  - Fuse the five covered objects or treat contextual refers_to relations as covered semantics.
+  - Treat documentary references or the unresolved 12-domain cycle as guarantees.
+validation_criteria: registry/math-contracts/TLC-FC-15-RELATIONS-007/validation-criteria.yaml
+traceability: registry/math-contracts/TLC-FC-15-RELATIONS-007/traceability.yaml
+readiness:
+  ready_for_scientific_review: true
+  ready_for_full_contract_extension: false
+  ready_for_ir: false
+  ready_for_implementation_planning: false
+  rationale: Only a limited contract is authorized; decomposition, endpoint semantics, oracle, and the global cycle remain unresolved.

--- a/registry/math-contracts/TLC-FC-15-RELATIONS-007/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-15-RELATIONS-007/dependencies.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-007-001
+feature_id: TLC-FC-15-RELATIONS-007
+limited_contract: true
+strong_contractual_prerequisites: []
+explicitly_confirmed: []
+documentary_reference_only:
+  - {dependency_id: TLC-DEP-RELATIONS-MASTER-001, edge_id: TLC-GDEP-0147, target: master, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+  - {dependency_id: TLC-DEP-RELATIONS-MESSAGE-001, edge_id: TLC-GDEP-0150, target: message, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+  - {dependency_id: TLC-DEP-RELATIONS-VALUES-001, edge_id: TLC-GDEP-0152, target: values, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+  - {dependency_id: TLC-DEP-RELATIONS-VIRTUES-001, edge_id: TLC-GDEP-0153, target: virtues, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+  - {dependency_id: TLC-DEP-RELATIONS-CAPACITIES-001, edge_id: TLC-GDEP-0154, target: capacities, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+  - {dependency_id: TLC-DEP-RELATIONS-COMPETENCIES-001, edge_id: TLC-GDEP-0155, target: competencies, evidence: registry/domain-progress/relations/feature-dependencies.yaml, blocking: false}
+compatible_but_unconfirmed: []
+ambiguous: []
+human_decision_required: []
+global_reservation: {cycle_id: TLC-GCYCLE-DOMAIN-001, classification: ambiguous_cycle, contractual_use: prohibited, human_decision_required: true, evidence: registry/global-reconciliation/cycle-scientific-review.yaml}
+policy: Documentary references are context only and cannot be consumed as guarantees or strong prerequisites.

--- a/registry/math-contracts/TLC-FC-15-RELATIONS-007/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-15-RELATIONS-007/traceability.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-007-001
+feature_id: TLC-FC-15-RELATIONS-007
+limited_contract: true
+rows:
+  - {trace_id: TRACE-RELATIONS-007-002, scientific_object_id: TLC-SO-RELATIONS-002, scientific_relation_id: null, contextual_relation_id: TLC-SR-RELATIONS-001, source_path: maths/15-relations.md, section: Relation Maître‑Message, start_line: 9, end_line: 9, scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e, coverage: covered_as_opaque_candidate_object}
+  - {trace_id: TRACE-RELATIONS-007-009, scientific_object_id: TLC-SO-RELATIONS-009, scientific_relation_id: null, contextual_relation_id: TLC-SR-RELATIONS-008, source_path: maths/15-relations.md, section: Relation Maître‑Vertu, start_line: 73, end_line: 73, scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e, coverage: covered_as_opaque_candidate_object}
+  - {trace_id: TRACE-RELATIONS-007-015, scientific_object_id: TLC-SO-RELATIONS-015, scientific_relation_id: null, contextual_relation_id: TLC-SR-RELATIONS-014, source_path: maths/15-relations.md, section: Relation Maître‑Valeur, start_line: 116, end_line: 116, scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e, coverage: covered_as_opaque_candidate_object}
+  - {trace_id: TRACE-RELATIONS-007-021, scientific_object_id: TLC-SO-RELATIONS-021, scientific_relation_id: null, contextual_relation_id: TLC-SR-RELATIONS-020, source_path: maths/15-relations.md, section: Relation Maître‑Capacité, start_line: 159, end_line: 159, scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e, coverage: covered_as_opaque_candidate_object}
+  - {trace_id: TRACE-RELATIONS-007-027, scientific_object_id: TLC-SO-RELATIONS-027, scientific_relation_id: null, contextual_relation_id: TLC-SR-RELATIONS-026, source_path: maths/15-relations.md, section: Relation Maître‑Compétence, start_line: 199, end_line: 199, scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e, coverage: covered_as_opaque_candidate_object}
+readiness_evidence: [registry/domain-progress/relations/feature-readiness.yaml, registry/domain-progress/relations/contract-production-plan.yaml, registry/global-reconciliation/targeted-readiness-review.yaml, registry/global-reconciliation/first-contract-batches.yaml]
+unresolved_evidence: [registry/domain-progress/relations/feature-classification.yaml, registry/domain-progress/relations/contract-production-plan.yaml, registry/global-reconciliation/cycle-scientific-review.yaml]
+coverage_summary: {scientific_objects_expected: 5, scientific_objects_covered: 5, scientific_relations_expected: 0, scientific_relations_covered: 0, unresolved_received: 12, unresolved_propagated: 12}

--- a/registry/math-contracts/TLC-FC-15-RELATIONS-007/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-15-RELATIONS-007/unresolved.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-007-001
+feature_id: TLC-FC-15-RELATIONS-007
+limited_contract: true
+status: propagated_with_reservations
+received_count: 12
+propagated_count: 12
+propagation_complete: true
+canonical_unresolved: []
+contract_reservations:
+  - {id: UNRES-RELATIONS-007-DECOMPOSITION, topic: grouped_object_decomposition, value: required_before_full_contract, status: unresolved}
+  - {id: UNRES-RELATIONS-007-SIGNATURE, topic: signature, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-007-TYPES, topic: types_and_dimensions, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-007-ENDPOINTS, topic: endpoint_identity, value: must_not_be_inferred, status: unresolved}
+  - {id: UNRES-RELATIONS-007-DIRECTION, topic: direction, value: not_specified_unless_source_explicit, status: unresolved}
+  - {id: UNRES-RELATIONS-007-CARDINALITY, topic: cardinality, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-007-SYMMETRY, topic: symmetry, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-007-TRANSITIVITY, topic: transitivity, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-007-TEMPORALITY, topic: temporality, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-007-ORACLE, topic: explicit_oracle, value: not_identified, status: unresolved}
+  - {id: UNRES-RELATIONS-007-DETERMINISM, topic: determinism, value: not_specified, status: unresolved}
+  - {id: UNRES-RELATIONS-007-GLOBAL-CYCLE, topic: twelve_domain_cycle, value: ambiguous_cycle, required_human_decision: Resolve or explicitly orient the global 12-domain cycle., status: unresolved}

--- a/registry/math-contracts/TLC-FC-15-RELATIONS-007/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-15-RELATIONS-007/validation-criteria.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-007-001
+feature_id: TLC-FC-15-RELATIONS-007
+limited_contract: true
+criteria:
+  - {id: VAL-RELATIONS-007-MARKER, requirement: contract_kind and limited_contract explicitly mark a limited contract}
+  - {id: VAL-RELATIONS-007-SCOPE, requirement: exactly the five planned source objects are covered}
+  - {id: VAL-RELATIONS-007-RELATIONS, requirement: no scientific relation is claimed as covered behavior}
+  - {id: VAL-RELATIONS-007-SOURCES, requirement: all exact source lines and commits are present}
+  - {id: VAL-RELATIONS-007-UNRESOLVED, requirement: all 12 received unresolved items are propagated without promotion}
+  - {id: VAL-RELATIONS-007-ENDPOINTS, requirement: endpoint identity is not inferred}
+  - {id: VAL-RELATIONS-007-DEPENDENCIES, requirement: no documentary dependency is a strong prerequisite}
+  - {id: VAL-RELATIONS-007-NONINVENTION, requirement: no missing scientific or execution property is selected}
+  - {id: VAL-RELATIONS-007-READINESS, requirement: ready_for_ir and ready_for_implementation_planning remain false}
+  - {id: VAL-RELATIONS-007-NO-IR, requirement: no IR or implementation artifact exists in this package}
+acceptance_rule: Every criterion must pass before scientific review; passing does not authorize a full contract, IR, tests, or implementation.

--- a/reports/math-contract-batches/relations-limited-batch-001/batch-report.md
+++ b/reports/math-contract-batches/relations-limited-batch-001/batch-report.md
@@ -1,0 +1,36 @@
+# Relations limited-contract batch 001
+
+## Authority and scope
+
+This batch is generated from `origin/main` commit `ff800dd1e8e87bb8a89d855d8a45c1ff6bbd8cff`, which merges PR #30. It implements the economic batch `TLC-FIRST-ECONOMIC-001` and contains only `TLC-FC-15-RELATIONS-004` and `TLC-FC-15-RELATIONS-007`.
+
+## Contracts
+
+- `TLC-LC-TLC-FC-15-RELATIONS-004-001` covers three candidate function objects, no covered scientific relation, 31 received and propagated unresolved items, and no strong contractual dependency.
+- `TLC-LC-TLC-FC-15-RELATIONS-007-001` covers five candidate relation objects, no covered scientific relation, 12 received and propagated unresolved items, and no strong contractual dependency.
+
+Candidate `refers_to` relations are retained only as contextual traceability. Relevant external domain references remain `documentary_reference_only`. No ambiguous dependency is promoted. The global ambiguous cycle `TLC-GCYCLE-DOMAIN-001` remains unresolved and requires a human decision.
+
+## Explicit limits
+
+The batch does not define complete Relations semantics, global graph properties, universal cardinality, general symmetry or transitivity, complete temporality, numerical methods, execution structures, implementation types, automatic cross-domain compatibility, executable oracles, tests, code, or IR.
+
+No batch validator is committed because the absolute scope requires absence of code. Validation is performed with repository commands and read-only ad hoc checks.
+
+## Validation results
+
+- Thirteen generated YAML files parse successfully; all 42 repository JSON files parse successfully.
+- Feature IDs, contract IDs, generated local IDs, exact source references, object coverage, empty covered-relation sets, unresolved counts, dependency classifications, limited-contract markers, and readiness flags pass targeted checks.
+- All 31 unresolved items for `TLC-FC-15-RELATIONS-004` and all 12 unresolved items for `TLC-FC-15-RELATIONS-007` are propagated.
+- No ambiguous or documentary dependency is promoted; no code, IR path, or `maths/` modification is present.
+- Python syntax checks pass for the existing Relations and targeted-review validators. Their execution rejects this downstream contract branch by design because those preparation/review validators prohibit any contract output; they are not batch-contract validators.
+- `git diff --check` passes.
+
+## Readiness
+
+- `ready_for_scientific_review`: `true`
+- `ready_for_full_contract_extension`: `false`
+- `ready_for_ir`: `false`
+- `ready_for_implementation_planning`: `false`
+
+The recommended internal disposition is scientific review with reservations.

--- a/reports/math-contract-batches/relations-limited-batch-001/batch-report.md
+++ b/reports/math-contract-batches/relations-limited-batch-001/batch-report.md
@@ -19,11 +19,11 @@ No batch validator is committed because the absolute scope requires absence of c
 
 ## Validation results
 
-- Thirteen generated YAML files parse successfully; all 42 repository JSON files parse successfully.
+- All thirteen YAML files in the batch parse successfully; the batch contains no JSON file.
 - Feature IDs, contract IDs, generated local IDs, exact source references, object coverage, empty covered-relation sets, unresolved counts, dependency classifications, limited-contract markers, and readiness flags pass targeted checks.
 - All 31 unresolved items for `TLC-FC-15-RELATIONS-004` and all 12 unresolved items for `TLC-FC-15-RELATIONS-007` are propagated.
 - No ambiguous or documentary dependency is promoted; no code, IR path, or `maths/` modification is present.
-- Python syntax checks pass for the existing Relations and targeted-review validators. Their execution rejects this downstream contract branch by design because those preparation/review validators prohibit any contract output; they are not batch-contract validators.
+- No batch-contract validator is present (`validator.produced: false` in the manifest), so validator syntax validation is not applicable.
 - `git diff --check` passes.
 
 ## Readiness

--- a/reports/math-contracts/TLC-FC-15-RELATIONS-004/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-15-RELATIONS-004/decision_required.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+work_item_id: TLC-LIMITED-CONTRACT-TLC-FC-15-RELATIONS-004
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-004-001
+feature_id: TLC-FC-15-RELATIONS-004
+stage: limited_scientific_contract
+status: candidate_with_reservations
+questions_for_human:
+  - Confirm or correct the 20 candidate classifications listed in unresolved.yaml.
+  - Decide whether TLC-DUP-RELATIONS-002 occurrences are distinct or should be united.
+  - Identify a source-grounded oracle or correction property before a full-contract extension.
+  - Resolve or explicitly orient TLC-GCYCLE-DOMAIN-001 before cross-domain guarantees.
+recommended_decision: {value: scientific_review_with_reservations, justification: The limited scope is traceable and non-inventive, but semantics, oracle, duplicate resolution, and the global cycle remain unresolved.}
+allowed_decisions: [approved_as_limited_contract, revise_limited_contract, rejected]
+readiness: {ready_for_scientific_review: true, ready_for_full_contract_extension: false, ready_for_ir: false, ready_for_implementation_planning: false}

--- a/reports/math-contracts/TLC-FC-15-RELATIONS-004/generation-report.md
+++ b/reports/math-contracts/TLC-FC-15-RELATIONS-004/generation-report.md
@@ -1,0 +1,11 @@
+# Limited scientific contract — TLC-FC-15-RELATIONS-004
+
+Generated from `origin/main` commit `ff800dd1e8e87bb8a89d855d8a45c1ff6bbd8cff` as part of `TLC-FIRST-ECONOMIC-001`.
+
+The contract covers exactly `TLC-SO-RELATIONS-004`, `TLC-SO-RELATIONS-017`, and `TLC-SO-RELATIONS-023`. It covers no scientific relation as behavior. Candidate relations `TLC-SR-RELATIONS-003`, `TLC-SR-RELATIONS-016`, and `TLC-SR-RELATIONS-022` are contextual traceability only.
+
+The same-named function blocks remain distinct and opaque. Twenty canonical classification uncertainties, `TLC-DUP-RELATIONS-002`, and ten contract-level semantic/readiness reservations are propagated. No missing scientific or execution property is selected.
+
+No strong contractual dependency is consumed. Relevant external references remain `documentary_reference_only`; `TLC-GCYCLE-DOMAIN-001` remains a human-decision reservation.
+
+Readiness: scientific review `true`; full-contract extension `false`; IR `false`; implementation planning `false`.

--- a/reports/math-contracts/TLC-FC-15-RELATIONS-007/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-15-RELATIONS-007/decision_required.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+work_item_id: TLC-LIMITED-CONTRACT-TLC-FC-15-RELATIONS-007
+contract_id: TLC-LC-TLC-FC-15-RELATIONS-007-001
+feature_id: TLC-FC-15-RELATIONS-007
+stage: limited_scientific_contract
+status: candidate_with_reservations
+questions_for_human:
+  - Decide the decomposition of the five grouped relation objects before a full-contract extension.
+  - Define endpoint identity and relation properties only from new explicit scientific evidence.
+  - Identify a source-grounded oracle or correction property before a full-contract extension.
+  - Resolve or explicitly orient TLC-GCYCLE-DOMAIN-001 before cross-domain guarantees.
+recommended_decision: {value: scientific_review_with_reservations, justification: The limited scope is traceable and non-inventive, but decomposition, endpoint semantics, oracle, and the global cycle remain unresolved.}
+allowed_decisions: [approved_as_limited_contract, revise_limited_contract, rejected]
+readiness: {ready_for_scientific_review: true, ready_for_full_contract_extension: false, ready_for_ir: false, ready_for_implementation_planning: false}

--- a/reports/math-contracts/TLC-FC-15-RELATIONS-007/generation-report.md
+++ b/reports/math-contracts/TLC-FC-15-RELATIONS-007/generation-report.md
@@ -1,0 +1,11 @@
+# Limited scientific contract — TLC-FC-15-RELATIONS-007
+
+Generated from `origin/main` commit `ff800dd1e8e87bb8a89d855d8a45c1ff6bbd8cff` as part of `TLC-FIRST-ECONOMIC-001`.
+
+The contract covers exactly `TLC-SO-RELATIONS-002`, `TLC-SO-RELATIONS-009`, `TLC-SO-RELATIONS-015`, `TLC-SO-RELATIONS-021`, and `TLC-SO-RELATIONS-027`. It covers no scientific relation as behavior. Five candidate `refers_to` relations are contextual traceability only.
+
+The five named relation objects remain distinct and opaque. Twelve contract reservations are propagated, including decomposition, endpoint identity, types, direction, cardinality, symmetry, transitivity, temporality, oracle, determinism, and the global cycle. No missing scientific or execution property is selected.
+
+No strong contractual dependency is consumed. Relevant external references remain `documentary_reference_only`; `TLC-GCYCLE-DOMAIN-001` remains a human-decision reservation.
+
+Readiness: scientific review `true`; full-contract extension `false`; IR `false`; implementation planning `false`.

--- a/reports/math-contracts/TLC-FC-15-RELATIONS-007/generation-report.md
+++ b/reports/math-contracts/TLC-FC-15-RELATIONS-007/generation-report.md
@@ -4,7 +4,7 @@ Generated from `origin/main` commit `ff800dd1e8e87bb8a89d855d8a45c1ff6bbd8cff` a
 
 The contract covers exactly `TLC-SO-RELATIONS-002`, `TLC-SO-RELATIONS-009`, `TLC-SO-RELATIONS-015`, `TLC-SO-RELATIONS-021`, and `TLC-SO-RELATIONS-027`. It covers no scientific relation as behavior. Five candidate `refers_to` relations are contextual traceability only.
 
-The five named relation objects remain distinct and opaque. Twelve contract reservations are propagated, including decomposition, endpoint identity, types, direction, cardinality, symmetry, transitivity, temporality, oracle, determinism, and the global cycle. No missing scientific or execution property is selected.
+The five named relation objects remain distinct and opaque. Twelve contract reservations are propagated, including decomposition, signature, endpoint identity, types, direction, cardinality, symmetry, transitivity, temporality, oracle, determinism, and the global cycle. No missing scientific or execution property is selected.
 
 No strong contractual dependency is consumed. Relevant external references remain `documentary_reference_only`; `TLC-GCYCLE-DOMAIN-001` remains a human-decision reservation.
 


### PR DESCRIPTION
## Summary
- add limited scientific contracts for TLC-FC-15-RELATIONS-004 and TLC-FC-15-RELATIONS-007
- propagate all contract unresolved items and documentary dependency reservations
- add traceability, validation criteria, decisions, generation reports, and batch manifest/report

## Explicit limits
- no full contract
- no IR
- no implementation or executable validator
- no maths changes
- ready_for_ir remains false

## Validation
- 13 generated YAML files parsed
- 42 repository JSON files parsed
- IDs, feature scope, source references, object/relation coverage, unresolved propagation, dependency classifications, limited markers, and readiness checked
- no ambiguous dependency promoted
- no code, IR path, or maths modification
- git diff --check passed

## Reservations
- explicit oracle not identified
- complete relation semantics unresolved
- TLC-DUP-RELATIONS-002 unresolved
- TLC-GCYCLE-DOMAIN-001 unresolved

## Summary by Sourcery

Introduce a first limited relations contract batch implementing two candidate scientific contracts without code, IR, or maths changes, and mark the batch and contracts as ready only for scientific review with reservations.

New Features:
- Add limited scientific contracts for features TLC-FC-15-RELATIONS-004 and TLC-FC-15-RELATIONS-007, covering specified candidate relation and function objects as opaque traceable inputs and outputs.
- Define a relations limited-contract batch manifest (relations-limited-batch-001) that groups the two contracts, enumerates artifacts, and records batch-level readiness and reservations.
- Provide traceability tables, validation-criteria registries, unresolved-item registries, dependency metadata, and human decision-required reports for both limited relations contracts.
- Add a batch-level report documenting authority, contract scope, validation results, explicit limits, and readiness disposition for the first economic relations contract batch.

Enhancements:
- Formalize propagation of unresolved terms and contract-level reservations for the relations domain while explicitly prohibiting promotion of ambiguous or documentary dependencies to strong guarantees.
- Clarify dependency treatment by classifying external domain references as documentary_reference_only and recording the unresolved global 12-domain cycle as a contractual prohibition pending human decision.

Documentation:
- Document the generation and scope of each limited relations contract and the relations-limited-batch-001 in markdown reports aimed at scientific review rather than implementation.