### PR TITLE
contract(huit-dimensions): add limited engineering contracts

### DIFF
--- a/registry/math-contract-batches/huit-dimensions-engineering-batch-001/blocker-reclassification.yaml
+++ b/registry/math-contract-batches/huit-dimensions-engineering-batch-001/blocker-reclassification.yaml
@@ -1,0 +1,145 @@
+schema_version: 1
+batch_id: TLC-LCEB-HUIT-DIMENSIONS-001
+blockers:
+- blocker_id: TLC-GBLOCK-0035
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  - does_not_block_prototype_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: null
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+- blocker_id: TLC-GBLOCK-0036
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: feature_identity_or_boundary_not_yet_determinable
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+- blocker_id: TLC-GBLOCK-0037
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  - does_not_block_prototype_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: null
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+- blocker_id: TLC-GBLOCK-0038
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  - does_not_block_prototype_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: null
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+- blocker_id: TLC-GBLOCK-0039
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  - does_not_block_prototype_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: null
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+- blocker_id: TLC-GBLOCK-0040
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: feature_identity_or_boundary_not_yet_determinable
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+- blocker_id: TLC-GBLOCK-0041
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: feature_identity_or_boundary_not_yet_determinable
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+- blocker_id: TLC-GBLOCK-0042
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  - does_not_block_prototype_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: null
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+- blocker_id: TLC-GBLOCK-0043
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: feature_identity_or_boundary_not_yet_determinable
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+- blocker_id: TLC-GBLOCK-0044
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: feature_identity_or_boundary_not_yet_determinable
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+- blocker_id: TLC-GBLOCK-0045
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+  scientific_status: unresolved
+  engineering_effects:
+  - blocks_canonical_scientific_contract
+  - does_not_block_limited_engineering_contract
+  - blocks_canonical_ir
+  blocks_all_progress: false
+  prototype_ir_blocker: feature_identity_or_boundary_not_yet_determinable
+  evidence:
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+summary:
+  reclassified: 11
+  blocks_all_progress: 0
+  does_not_block_limited_engineering_contract: 11
+  does_not_block_prototype_ir: 5

--- a/registry/math-contract-batches/huit-dimensions-engineering-batch-001/manifest.yaml
+++ b/registry/math-contract-batches/huit-dimensions-engineering-batch-001/manifest.yaml
@@ -1,0 +1,277 @@
+schema_version: 1
+batch_id: TLC-LCEB-HUIT-DIMENSIONS-001
+batch_slug: huit-dimensions-engineering-batch-001
+domain: huit-dimensions
+contract_kind: limited_engineering_contract_batch
+status: limited_engineering_contract_with_reservations
+authority: origin/main
+source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+generated_on: '2026-07-24'
+features:
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-009
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-010
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-065
+  reservations_propagated: 8
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: true
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: true
+    human_validation_required_before_prototype_work: false
+    human_validation_required_before_canonical_release: true
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-011
+  reservations_propagated: 9
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: false
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: false
+    human_validation_required_before_prototype_work: true
+    human_validation_required_before_canonical_release: true
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-085
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-094
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-108
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-115
+  reservations_propagated: 8
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: true
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: true
+    human_validation_required_before_prototype_work: false
+    human_validation_required_before_canonical_release: true
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-068
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-084
+  reservations_propagated: 8
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: true
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: true
+    human_validation_required_before_prototype_work: false
+    human_validation_required_before_canonical_release: true
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-014
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-035
+  reservations_propagated: 8
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: true
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: true
+    human_validation_required_before_prototype_work: false
+    human_validation_required_before_canonical_release: true
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-073
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-110
+  reservations_propagated: 9
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: false
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: false
+    human_validation_required_before_prototype_work: true
+    human_validation_required_before_canonical_release: true
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-008
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-039
+  reservations_propagated: 9
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: false
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: false
+    human_validation_required_before_prototype_work: true
+    human_validation_required_before_canonical_release: true
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-023
+  reservations_propagated: 8
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: true
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: true
+    human_validation_required_before_prototype_work: false
+    human_validation_required_before_canonical_release: true
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-093
+  reservations_propagated: 9
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: false
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: false
+    human_validation_required_before_prototype_work: true
+    human_validation_required_before_canonical_release: true
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-089
+  reservations_propagated: 9
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: false
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: false
+    human_validation_required_before_prototype_work: true
+    human_validation_required_before_canonical_release: true
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013-001
+  contract_path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/contract.yaml
+  objects_covered:
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-090
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-116
+  - TLC-SO-HUIT-DIMENSIONS-DE-TL-117
+  reservations_propagated: 9
+  readiness:
+    ready_for_complete_scientific_contract: false
+    ready_for_limited_engineering_contract: true
+    ready_for_canonical_ir: false
+    ready_for_prototype_ir: false
+    ready_for_production_implementation: false
+    ready_for_reference_prototype: false
+    human_validation_required_before_prototype_work: true
+    human_validation_required_before_canonical_release: true
+artifacts:
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/generation-report.md
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/generation-report.md
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/generation-report.md
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/generation-report.md
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/generation-report.md
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/generation-report.md
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/generation-report.md
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/generation-report.md
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/generation-report.md
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/generation-report.md
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/contract.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/dependencies.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/unresolved.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/traceability.yaml
+- registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/validation-criteria.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/decision_required.yaml
+- reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/generation-report.md
+- registry/math-contract-batches/huit-dimensions-engineering-batch-001/manifest.yaml
+- registry/math-contract-batches/huit-dimensions-engineering-batch-001/blocker-reclassification.yaml
+- registry/math-contract-batches/huit-dimensions-engineering-batch-001/provisional-assumptions.yaml
+- registry/math-contract-batches/huit-dimensions-engineering-batch-001/prototype-ir-plan.yaml
+- reports/math-contract-batches/huit-dimensions-engineering-batch-001/batch-report.md
+batch_readiness:
+  ready_for_complete_scientific_contract_count: 0
+  ready_for_limited_engineering_contract_count: 11
+  ready_for_canonical_ir_count: 0
+  ready_for_prototype_ir_count: 5
+  ready_for_production_implementation_count: 0
+  blocks_all_progress_count: 0
+scientific_reservations_preserved: true

--- a/registry/math-contract-batches/huit-dimensions-engineering-batch-001/prototype-ir-plan.yaml
+++ b/registry/math-contract-batches/huit-dimensions-engineering-batch-001/prototype-ir-plan.yaml
@@ -1,0 +1,220 @@
+schema_version: 1
+batch_id: TLC-LCEB-HUIT-DIMENSIONS-001
+status: targeted_plan_only_no_ir_created
+features:
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001-001
+  ready_for_prototype_ir: true
+  prototype_ir_kind: engineering_prototype_with_opaque_types
+  expected_operations:
+  - opaque_constraint_check
+  required_types:
+  - OpaqueScientificObject<TFeature,TSource>
+  - OpaqueCandidateResult<TFeature,TSource>
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-001-TYPE
+  - TLC-UNRES-HUIT-001-SIGNATURE
+  - TLC-UNRES-HUIT-001-UNITS
+  - TLC-UNRES-HUIT-001-ORDER
+  - TLC-UNRES-HUIT-001-AGGREGATION
+  - TLC-UNRES-HUIT-001-NUMERICS
+  - TLC-UNRES-HUIT-001-ORACLE
+  - TLC-UNRES-HUIT-001-BOUNDARY
+  parallel_group: prototype-ready-independent
+  blocking_reason: null
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002-001
+  ready_for_prototype_ir: false
+  prototype_ir_kind: null
+  expected_operations: []
+  required_types: []
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-002-TYPE
+  - TLC-UNRES-HUIT-002-SIGNATURE
+  - TLC-UNRES-HUIT-002-UNITS
+  - TLC-UNRES-HUIT-002-ORDER
+  - TLC-UNRES-HUIT-002-AGGREGATION
+  - TLC-UNRES-HUIT-002-NUMERICS
+  - TLC-UNRES-HUIT-002-ORACLE
+  - TLC-UNRES-HUIT-002-BOUNDARY
+  - TLC-UNRES-HUIT-002-IDENTITY
+  parallel_group: deferred-boundary-review
+  blocking_reason: scientific feature identity or boundary remains not_yet_determinable
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005-001
+  ready_for_prototype_ir: true
+  prototype_ir_kind: engineering_prototype_with_opaque_types
+  expected_operations:
+  - opaque_evaluation
+  required_types:
+  - OpaqueScientificObject<TFeature,TSource>
+  - OpaqueCandidateResult<TFeature,TSource>
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-005-TYPE
+  - TLC-UNRES-HUIT-005-SIGNATURE
+  - TLC-UNRES-HUIT-005-UNITS
+  - TLC-UNRES-HUIT-005-ORDER
+  - TLC-UNRES-HUIT-005-AGGREGATION
+  - TLC-UNRES-HUIT-005-NUMERICS
+  - TLC-UNRES-HUIT-005-ORACLE
+  - TLC-UNRES-HUIT-005-BOUNDARY
+  parallel_group: prototype-ready-independent
+  blocking_reason: null
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006-001
+  ready_for_prototype_ir: true
+  prototype_ir_kind: engineering_prototype_with_opaque_types
+  expected_operations:
+  - opaque_evaluation
+  required_types:
+  - OpaqueScientificObject<TFeature,TSource>
+  - OpaqueCandidateResult<TFeature,TSource>
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-006-TYPE
+  - TLC-UNRES-HUIT-006-SIGNATURE
+  - TLC-UNRES-HUIT-006-UNITS
+  - TLC-UNRES-HUIT-006-ORDER
+  - TLC-UNRES-HUIT-006-AGGREGATION
+  - TLC-UNRES-HUIT-006-NUMERICS
+  - TLC-UNRES-HUIT-006-ORACLE
+  - TLC-UNRES-HUIT-006-BOUNDARY
+  parallel_group: prototype-ready-independent
+  blocking_reason: null
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007-001
+  ready_for_prototype_ir: true
+  prototype_ir_kind: engineering_prototype_with_opaque_types
+  expected_operations:
+  - opaque_invariant_check
+  required_types:
+  - OpaqueScientificObject<TFeature,TSource>
+  - OpaqueCandidateResult<TFeature,TSource>
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-007-TYPE
+  - TLC-UNRES-HUIT-007-SIGNATURE
+  - TLC-UNRES-HUIT-007-UNITS
+  - TLC-UNRES-HUIT-007-ORDER
+  - TLC-UNRES-HUIT-007-AGGREGATION
+  - TLC-UNRES-HUIT-007-NUMERICS
+  - TLC-UNRES-HUIT-007-ORACLE
+  - TLC-UNRES-HUIT-007-BOUNDARY
+  parallel_group: prototype-ready-independent
+  blocking_reason: null
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008-001
+  ready_for_prototype_ir: false
+  prototype_ir_kind: null
+  expected_operations: []
+  required_types: []
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-008-TYPE
+  - TLC-UNRES-HUIT-008-SIGNATURE
+  - TLC-UNRES-HUIT-008-UNITS
+  - TLC-UNRES-HUIT-008-ORDER
+  - TLC-UNRES-HUIT-008-AGGREGATION
+  - TLC-UNRES-HUIT-008-NUMERICS
+  - TLC-UNRES-HUIT-008-ORACLE
+  - TLC-UNRES-HUIT-008-BOUNDARY
+  - TLC-UNRES-HUIT-008-IDENTITY
+  parallel_group: deferred-boundary-review
+  blocking_reason: scientific feature identity or boundary remains not_yet_determinable
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009-001
+  ready_for_prototype_ir: false
+  prototype_ir_kind: null
+  expected_operations: []
+  required_types: []
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-009-TYPE
+  - TLC-UNRES-HUIT-009-SIGNATURE
+  - TLC-UNRES-HUIT-009-UNITS
+  - TLC-UNRES-HUIT-009-ORDER
+  - TLC-UNRES-HUIT-009-AGGREGATION
+  - TLC-UNRES-HUIT-009-NUMERICS
+  - TLC-UNRES-HUIT-009-ORACLE
+  - TLC-UNRES-HUIT-009-BOUNDARY
+  - TLC-UNRES-HUIT-009-IDENTITY
+  parallel_group: deferred-boundary-review
+  blocking_reason: scientific feature identity or boundary remains not_yet_determinable
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010-001
+  ready_for_prototype_ir: true
+  prototype_ir_kind: engineering_prototype_with_opaque_types
+  expected_operations:
+  - opaque_evaluation
+  required_types:
+  - OpaqueScientificObject<TFeature,TSource>
+  - OpaqueCandidateResult<TFeature,TSource>
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-010-TYPE
+  - TLC-UNRES-HUIT-010-SIGNATURE
+  - TLC-UNRES-HUIT-010-UNITS
+  - TLC-UNRES-HUIT-010-ORDER
+  - TLC-UNRES-HUIT-010-AGGREGATION
+  - TLC-UNRES-HUIT-010-NUMERICS
+  - TLC-UNRES-HUIT-010-ORACLE
+  - TLC-UNRES-HUIT-010-BOUNDARY
+  parallel_group: prototype-ready-independent
+  blocking_reason: null
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011-001
+  ready_for_prototype_ir: false
+  prototype_ir_kind: null
+  expected_operations: []
+  required_types: []
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-011-TYPE
+  - TLC-UNRES-HUIT-011-SIGNATURE
+  - TLC-UNRES-HUIT-011-UNITS
+  - TLC-UNRES-HUIT-011-ORDER
+  - TLC-UNRES-HUIT-011-AGGREGATION
+  - TLC-UNRES-HUIT-011-NUMERICS
+  - TLC-UNRES-HUIT-011-ORACLE
+  - TLC-UNRES-HUIT-011-BOUNDARY
+  - TLC-UNRES-HUIT-011-IDENTITY
+  parallel_group: deferred-boundary-review
+  blocking_reason: scientific feature identity or boundary remains not_yet_determinable
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012-001
+  ready_for_prototype_ir: false
+  prototype_ir_kind: null
+  expected_operations: []
+  required_types: []
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-012-TYPE
+  - TLC-UNRES-HUIT-012-SIGNATURE
+  - TLC-UNRES-HUIT-012-UNITS
+  - TLC-UNRES-HUIT-012-ORDER
+  - TLC-UNRES-HUIT-012-AGGREGATION
+  - TLC-UNRES-HUIT-012-NUMERICS
+  - TLC-UNRES-HUIT-012-ORACLE
+  - TLC-UNRES-HUIT-012-BOUNDARY
+  - TLC-UNRES-HUIT-012-IDENTITY
+  parallel_group: deferred-boundary-review
+  blocking_reason: scientific feature identity or boundary remains not_yet_determinable
+- feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+  contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013-001
+  ready_for_prototype_ir: false
+  prototype_ir_kind: null
+  expected_operations: []
+  required_types: []
+  reservations_to_propagate:
+  - TLC-UNRES-HUIT-013-TYPE
+  - TLC-UNRES-HUIT-013-SIGNATURE
+  - TLC-UNRES-HUIT-013-UNITS
+  - TLC-UNRES-HUIT-013-ORDER
+  - TLC-UNRES-HUIT-013-AGGREGATION
+  - TLC-UNRES-HUIT-013-NUMERICS
+  - TLC-UNRES-HUIT-013-ORACLE
+  - TLC-UNRES-HUIT-013-BOUNDARY
+  - TLC-UNRES-HUIT-013-IDENTITY
+  parallel_group: deferred-boundary-review
+  blocking_reason: scientific feature identity or boundary remains not_yet_determinable
+parallelizable_features:
+- TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+- TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+- TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+- TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+- TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+canonical_ir_authorized: false
+production_implementation_authorized: false

--- a/registry/math-contract-batches/huit-dimensions-engineering-batch-001/provisional-assumptions.yaml
+++ b/registry/math-contract-batches/huit-dimensions-engineering-batch-001/provisional-assumptions.yaml
@@ -1,0 +1,194 @@
+schema_version: 1
+batch_id: TLC-LCEB-HUIT-DIMENSIONS-001
+assumptions:
+- assumption_id: TLC-EA-HUIT-001-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: opaque nodes and operations only
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+- assumption_id: TLC-EA-HUIT-002-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+- assumption_id: TLC-EA-HUIT-005-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: opaque nodes and operations only
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+- assumption_id: TLC-EA-HUIT-006-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: opaque nodes and operations only
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+- assumption_id: TLC-EA-HUIT-007-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: opaque nodes and operations only
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+- assumption_id: TLC-EA-HUIT-008-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+- assumption_id: TLC-EA-HUIT-009-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+- assumption_id: TLC-EA-HUIT-010-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: opaque nodes and operations only
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+- assumption_id: TLC-EA-HUIT-011-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+- assumption_id: TLC-EA-HUIT-012-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+- assumption_id: TLC-EA-HUIT-013-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+summary:
+  count: 11
+  all_reversible: true
+  status: provisional_engineering_assumption

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/contract.yaml
@@ -1,0 +1,193 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: constraint (admissible)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-009
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-010
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-065
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-008
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-009
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-064
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-001-009
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-009
+  category: Hypothesis
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Principes (Principles)
+    subsection: Propriétés
+    start_line: 65
+    end_line: 70
+- input_id: INPUT-HUIT-001-010
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-010
+  category: Hypothesis
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Principes (Principles)
+    subsection: Rôle fonctionnel
+    start_line: 72
+    end_line: 75
+- input_id: INPUT-HUIT-001-065
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-065
+  category: Hypothesis
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Principes (Principles)
+    subsection: Propriétés
+    start_line: 68
+    end_line: 68
+outputs:
+- output_id: OUTPUT-HUIT-001-009
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-009
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-001-010
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-010
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-001-065
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-065
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-001-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-001-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-001-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-001-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-001-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-001-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-001-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-001-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-001-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-001-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-001-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/unresolved.yaml
+  count: 8
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-001-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: opaque nodes and operations only
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-001-TYPE
+- TLC-UNRES-HUIT-001-SIGNATURE
+- TLC-UNRES-HUIT-001-UNITS
+- TLC-UNRES-HUIT-001-ORDER
+- TLC-UNRES-HUIT-001-AGGREGATION
+- TLC-UNRES-HUIT-001-NUMERICS
+- TLC-UNRES-HUIT-001-ORACLE
+- TLC-UNRES-HUIT-001-BOUNDARY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: true
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: true
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/traceability.yaml
@@ -1,0 +1,65 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+rows:
+- trace_id: TRACE-HUIT-001-009
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-009
+  object_type: Hypothesis
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Principes (Principles)
+  subsection: Propriétés
+  start_line: 65
+  end_line: 70
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-001-010
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-010
+  object_type: Hypothesis
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Principes (Principles)
+  subsection: Rôle fonctionnel
+  start_line: 72
+  end_line: 75
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-001-065
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-065
+  object_type: Hypothesis
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Principes (Principles)
+  subsection: Propriétés
+  start_line: 68
+  end_line: 68
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-008
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Principes (Principles)
+    start_line: 65
+    end_line: 70
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-009
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Principes (Principles)
+    start_line: 72
+    end_line: 75
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-064
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Principes (Principles)
+    start_line: 68
+    end_line: 68
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 3
+  objects_covered: 3
+  relations_covered: 0
+  reservations_received: 8
+  reservations_propagated: 8

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/unresolved.yaml
@@ -1,0 +1,42 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-001-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-001-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-001-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-001-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-001-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-001-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-001-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-001-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+received_count: 8
+propagated_count: 8
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+criteria:
+- id: VAL-HUIT-001-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-001-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-001-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-001-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-001-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-001-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/contract.yaml
@@ -1,0 +1,150 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: constraint (provisionally_separated)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-011
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-010
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-002-011
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-011
+  category: Constraint
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Principes (Principles)
+    subsection: Dynamique Principe‑Message
+    start_line: 77
+    end_line: 84
+outputs:
+- output_id: OUTPUT-HUIT-002-011
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-011
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-002-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-002-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-002-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-002-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-002-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-002-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-002-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-002-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-002-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-002-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-002-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/unresolved.yaml
+  count: 9
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-002-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-002-TYPE
+- TLC-UNRES-HUIT-002-SIGNATURE
+- TLC-UNRES-HUIT-002-UNITS
+- TLC-UNRES-HUIT-002-ORDER
+- TLC-UNRES-HUIT-002-AGGREGATION
+- TLC-UNRES-HUIT-002-NUMERICS
+- TLC-UNRES-HUIT-002-ORACLE
+- TLC-UNRES-HUIT-002-BOUNDARY
+- TLC-UNRES-HUIT-002-IDENTITY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: false
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: false
+  human_validation_required_before_prototype_work: true
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/traceability.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+rows:
+- trace_id: TRACE-HUIT-002-011
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-011
+  object_type: Constraint
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Principes (Principles)
+  subsection: Dynamique Principe‑Message
+  start_line: 77
+  end_line: 84
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-010
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Principes (Principles)
+    start_line: 77
+    end_line: 84
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 1
+  objects_covered: 1
+  relations_covered: 0
+  reservations_received: 9
+  reservations_propagated: 9

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/unresolved.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-002-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-002-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-002-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-002-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-002-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-002-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-002-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-002-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-002-IDENTITY
+  topic: feature_identity_or_boundary
+  value: not_yet_determinable
+  status: unresolved
+  required_human_decision: Confirm the scientific identity and boundary before prototype IR generation.
+received_count: 9
+propagated_count: 9
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+criteria:
+- id: VAL-HUIT-002-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-002-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-002-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-002-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-002-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-002-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/contract.yaml
@@ -1,0 +1,215 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: dynamics (admissible)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-085
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-094
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-108
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-115
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-084
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-093
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-107
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-114
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-005-085
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-085
+  category: DifferentialEquation
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Vertus (Virtues)
+    subsection: Dynamique de développement
+    start_line: 138
+    end_line: 140
+- input_id: INPUT-HUIT-005-094
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-094
+  category: StochasticEquation
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Capacités (Capacities)
+    subsection: Évolution temporelle
+    start_line: 179
+    end_line: 181
+- input_id: INPUT-HUIT-005-108
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-108
+  category: DifferentialEquation
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: La Pratique (Practice)
+    subsection: Dynamique d’acquisition
+    start_line: 234
+    end_line: 236
+- input_id: INPUT-HUIT-005-115
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-115
+  category: DifferentialEquation
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: L’Expérience vécue (Lived Experience)
+    subsection: Évolution
+    start_line: 258
+    end_line: 260
+outputs:
+- output_id: OUTPUT-HUIT-005-085
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-085
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-005-094
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-094
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-005-108
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-108
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-005-115
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-115
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-005-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-005-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-005-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-005-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-005-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-005-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-005-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-005-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-005-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-005-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-005-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/unresolved.yaml
+  count: 8
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-005-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: opaque nodes and operations only
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-005-TYPE
+- TLC-UNRES-HUIT-005-SIGNATURE
+- TLC-UNRES-HUIT-005-UNITS
+- TLC-UNRES-HUIT-005-ORDER
+- TLC-UNRES-HUIT-005-AGGREGATION
+- TLC-UNRES-HUIT-005-NUMERICS
+- TLC-UNRES-HUIT-005-ORACLE
+- TLC-UNRES-HUIT-005-BOUNDARY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: true
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: true
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/traceability.yaml
@@ -1,0 +1,83 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+rows:
+- trace_id: TRACE-HUIT-005-085
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-085
+  object_type: DifferentialEquation
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Vertus (Virtues)
+  subsection: Dynamique de développement
+  start_line: 138
+  end_line: 140
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-005-094
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-094
+  object_type: StochasticEquation
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Capacités (Capacities)
+  subsection: Évolution temporelle
+  start_line: 179
+  end_line: 181
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-005-108
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-108
+  object_type: DifferentialEquation
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: La Pratique (Practice)
+  subsection: Dynamique d’acquisition
+  start_line: 234
+  end_line: 236
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-005-115
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-115
+  object_type: DifferentialEquation
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: L’Expérience vécue (Lived Experience)
+  subsection: Évolution
+  start_line: 258
+  end_line: 260
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-084
+  relation_type: depends_on
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Vertus (Virtues)
+    start_line: 138
+    end_line: 140
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-093
+  relation_type: depends_on
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Capacités (Capacities)
+    start_line: 179
+    end_line: 181
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-107
+  relation_type: depends_on
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: La Pratique (Practice)
+    start_line: 234
+    end_line: 236
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-114
+  relation_type: depends_on
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: L’Expérience vécue (Lived Experience)
+    start_line: 258
+    end_line: 260
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 4
+  objects_covered: 4
+  relations_covered: 0
+  reservations_received: 8
+  reservations_propagated: 8

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/unresolved.yaml
@@ -1,0 +1,42 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-005-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-005-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-005-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-005-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-005-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-005-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-005-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-005-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+received_count: 8
+propagated_count: 8
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+criteria:
+- id: VAL-HUIT-005-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-005-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-005-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-005-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-005-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-005-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/contract.yaml
@@ -1,0 +1,171 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: equation (admissible)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-068
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-084
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-067
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-083
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-006-068
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-068
+  category: Equation
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Principes (Principles)
+    subsection: Dynamique Principe‑Message
+    start_line: 79
+    end_line: 81
+- input_id: INPUT-HUIT-006-084
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-084
+  category: Equation
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Vertus (Virtues)
+    subsection: Doctrine du juste milieu
+    start_line: 133
+    end_line: 135
+outputs:
+- output_id: OUTPUT-HUIT-006-068
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-068
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-006-084
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-084
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-006-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-006-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-006-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-006-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-006-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-006-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-006-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-006-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-006-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-006-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-006-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/unresolved.yaml
+  count: 8
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-006-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: opaque nodes and operations only
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-006-TYPE
+- TLC-UNRES-HUIT-006-SIGNATURE
+- TLC-UNRES-HUIT-006-UNITS
+- TLC-UNRES-HUIT-006-ORDER
+- TLC-UNRES-HUIT-006-AGGREGATION
+- TLC-UNRES-HUIT-006-NUMERICS
+- TLC-UNRES-HUIT-006-ORACLE
+- TLC-UNRES-HUIT-006-BOUNDARY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: true
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: true
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/traceability.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+rows:
+- trace_id: TRACE-HUIT-006-068
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-068
+  object_type: Equation
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Principes (Principles)
+  subsection: Dynamique Principe‑Message
+  start_line: 79
+  end_line: 81
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-006-084
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-084
+  object_type: Equation
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Vertus (Virtues)
+  subsection: Doctrine du juste milieu
+  start_line: 133
+  end_line: 135
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-067
+  relation_type: depends_on
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Principes (Principles)
+    start_line: 79
+    end_line: 81
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-083
+  relation_type: depends_on
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Vertus (Virtues)
+    start_line: 133
+    end_line: 135
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 2
+  objects_covered: 2
+  relations_covered: 0
+  reservations_received: 8
+  reservations_propagated: 8

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/unresolved.yaml
@@ -1,0 +1,42 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-006-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-006-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-006-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-006-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-006-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-006-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-006-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-006-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+received_count: 8
+propagated_count: 8
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+criteria:
+- id: VAL-HUIT-006-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-006-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-006-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-006-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-006-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-006-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/contract.yaml
@@ -1,0 +1,171 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: invariant (admissible)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-014
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-035
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-013
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-034
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-007-014
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-014
+  category: Invariant
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Valeurs (Values)
+    subsection: Propriétés
+    start_line: 106
+    end_line: 111
+- input_id: INPUT-HUIT-007-035
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-035
+  category: Invariant
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: L’Expérience vécue (Lived Experience)
+    subsection: Propriétés
+    start_line: 250
+    end_line: 255
+outputs:
+- output_id: OUTPUT-HUIT-007-014
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-014
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-007-035
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-035
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-007-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-007-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-007-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-007-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-007-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-007-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-007-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-007-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-007-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-007-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-007-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/unresolved.yaml
+  count: 8
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-007-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: opaque nodes and operations only
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-007-TYPE
+- TLC-UNRES-HUIT-007-SIGNATURE
+- TLC-UNRES-HUIT-007-UNITS
+- TLC-UNRES-HUIT-007-ORDER
+- TLC-UNRES-HUIT-007-AGGREGATION
+- TLC-UNRES-HUIT-007-NUMERICS
+- TLC-UNRES-HUIT-007-ORACLE
+- TLC-UNRES-HUIT-007-BOUNDARY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: true
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: true
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/traceability.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+rows:
+- trace_id: TRACE-HUIT-007-014
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-014
+  object_type: Invariant
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Valeurs (Values)
+  subsection: Propriétés
+  start_line: 106
+  end_line: 111
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-007-035
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-035
+  object_type: Invariant
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: L’Expérience vécue (Lived Experience)
+  subsection: Propriétés
+  start_line: 250
+  end_line: 255
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-013
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Valeurs (Values)
+    start_line: 106
+    end_line: 111
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-034
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: L’Expérience vécue (Lived Experience)
+    start_line: 250
+    end_line: 255
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 2
+  objects_covered: 2
+  relations_covered: 0
+  reservations_received: 8
+  reservations_propagated: 8

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/unresolved.yaml
@@ -1,0 +1,42 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-007-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-007-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-007-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-007-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-007-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-007-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-007-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-007-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+received_count: 8
+propagated_count: 8
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+criteria:
+- id: VAL-HUIT-007-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-007-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-007-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-007-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-007-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-007-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/contract.yaml
@@ -1,0 +1,172 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: invariant (blocked_locally)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-073
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-110
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-072
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-109
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-008-073
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-073
+  category: Invariant
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Valeurs (Values)
+    subsection: Propriétés
+    start_line: 107
+    end_line: 107
+- input_id: INPUT-HUIT-008-110
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-110
+  category: Invariant
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: L’Expérience vécue (Lived Experience)
+    subsection: Propriétés
+    start_line: 251
+    end_line: 251
+outputs:
+- output_id: OUTPUT-HUIT-008-073
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-073
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-008-110
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-110
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-008-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-008-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-008-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-008-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-008-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-008-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-008-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-008-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-008-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-008-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-008-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/unresolved.yaml
+  count: 9
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-008-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-008-TYPE
+- TLC-UNRES-HUIT-008-SIGNATURE
+- TLC-UNRES-HUIT-008-UNITS
+- TLC-UNRES-HUIT-008-ORDER
+- TLC-UNRES-HUIT-008-AGGREGATION
+- TLC-UNRES-HUIT-008-NUMERICS
+- TLC-UNRES-HUIT-008-ORACLE
+- TLC-UNRES-HUIT-008-BOUNDARY
+- TLC-UNRES-HUIT-008-IDENTITY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: false
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: false
+  human_validation_required_before_prototype_work: true
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/traceability.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+rows:
+- trace_id: TRACE-HUIT-008-073
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-073
+  object_type: Invariant
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Valeurs (Values)
+  subsection: Propriétés
+  start_line: 107
+  end_line: 107
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-008-110
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-110
+  object_type: Invariant
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: L’Expérience vécue (Lived Experience)
+  subsection: Propriétés
+  start_line: 251
+  end_line: 251
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-072
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Valeurs (Values)
+    start_line: 107
+    end_line: 107
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-109
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: L’Expérience vécue (Lived Experience)
+    start_line: 251
+    end_line: 251
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 2
+  objects_covered: 2
+  relations_covered: 0
+  reservations_received: 9
+  reservations_propagated: 9

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/unresolved.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-008-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-008-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-008-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-008-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-008-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-008-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-008-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-008-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-008-IDENTITY
+  topic: feature_identity_or_boundary
+  value: not_yet_determinable
+  status: unresolved
+  required_human_decision: Confirm the scientific identity and boundary before prototype IR generation.
+received_count: 9
+propagated_count: 9
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+criteria:
+- id: VAL-HUIT-008-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-008-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-008-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-008-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-008-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-008-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/contract.yaml
@@ -1,0 +1,172 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: invariant (provisionally_separated)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-008
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-039
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-007
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-038
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-009-008
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-008
+  category: Invariant
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Principes (Principles)
+    subsection: Définition
+    start_line: 54
+    end_line: 55
+- input_id: INPUT-HUIT-009-039
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-039
+  category: Invariant
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Introduction
+    subsection: null
+    start_line: 10
+    end_line: 10
+outputs:
+- output_id: OUTPUT-HUIT-009-008
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-008
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-009-039
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-039
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-009-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-009-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-009-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-009-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-009-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-009-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-009-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-009-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-009-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-009-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-009-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/unresolved.yaml
+  count: 9
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-009-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-009-TYPE
+- TLC-UNRES-HUIT-009-SIGNATURE
+- TLC-UNRES-HUIT-009-UNITS
+- TLC-UNRES-HUIT-009-ORDER
+- TLC-UNRES-HUIT-009-AGGREGATION
+- TLC-UNRES-HUIT-009-NUMERICS
+- TLC-UNRES-HUIT-009-ORACLE
+- TLC-UNRES-HUIT-009-BOUNDARY
+- TLC-UNRES-HUIT-009-IDENTITY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: false
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: false
+  human_validation_required_before_prototype_work: true
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/traceability.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+rows:
+- trace_id: TRACE-HUIT-009-008
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-008
+  object_type: Invariant
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Principes (Principles)
+  subsection: Définition
+  start_line: 54
+  end_line: 55
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-009-039
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-039
+  object_type: Invariant
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Introduction
+  subsection: null
+  start_line: 10
+  end_line: 10
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-007
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Principes (Principles)
+    start_line: 54
+    end_line: 55
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-038
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Introduction
+    start_line: 10
+    end_line: 10
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 2
+  objects_covered: 2
+  relations_covered: 0
+  reservations_received: 9
+  reservations_propagated: 9

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/unresolved.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-009-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-009-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-009-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-009-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-009-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-009-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-009-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-009-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-009-IDENTITY
+  topic: feature_identity_or_boundary
+  value: not_yet_determinable
+  status: unresolved
+  required_human_decision: Confirm the scientific identity and boundary before prototype IR generation.
+received_count: 9
+propagated_count: 9
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+criteria:
+- id: VAL-HUIT-009-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-009-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-009-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-009-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-009-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-009-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/contract.yaml
@@ -1,0 +1,149 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: metric (admissible)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-023
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-022
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-010-023
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-023
+  category: Metric
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Capacités (Capacities)
+    subsection: Propriétés
+    start_line: 171
+    end_line: 176
+outputs:
+- output_id: OUTPUT-HUIT-010-023
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-023
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-010-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-010-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-010-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-010-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-010-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-010-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-010-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-010-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-010-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-010-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-010-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/unresolved.yaml
+  count: 8
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-010-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: opaque nodes and operations only
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-010-TYPE
+- TLC-UNRES-HUIT-010-SIGNATURE
+- TLC-UNRES-HUIT-010-UNITS
+- TLC-UNRES-HUIT-010-ORDER
+- TLC-UNRES-HUIT-010-AGGREGATION
+- TLC-UNRES-HUIT-010-NUMERICS
+- TLC-UNRES-HUIT-010-ORACLE
+- TLC-UNRES-HUIT-010-BOUNDARY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: true
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: true
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/traceability.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+rows:
+- trace_id: TRACE-HUIT-010-023
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-023
+  object_type: Metric
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Capacités (Capacities)
+  subsection: Propriétés
+  start_line: 171
+  end_line: 176
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-022
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Capacités (Capacities)
+    start_line: 171
+    end_line: 176
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 1
+  objects_covered: 1
+  relations_covered: 0
+  reservations_received: 8
+  reservations_propagated: 8

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/unresolved.yaml
@@ -1,0 +1,42 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-010-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-010-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-010-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-010-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-010-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-010-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-010-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-010-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+received_count: 8
+propagated_count: 8
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+criteria:
+- id: VAL-HUIT-010-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-010-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-010-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-010-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-010-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-010-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/contract.yaml
@@ -1,0 +1,150 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: metric (blocked_locally)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-093
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-092
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-011-093
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-093
+  category: Metric
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Capacités (Capacities)
+    subsection: Propriétés
+    start_line: 176
+    end_line: 176
+outputs:
+- output_id: OUTPUT-HUIT-011-093
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-093
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-011-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-011-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-011-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-011-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-011-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-011-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-011-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-011-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-011-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-011-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-011-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/unresolved.yaml
+  count: 9
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-011-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-011-TYPE
+- TLC-UNRES-HUIT-011-SIGNATURE
+- TLC-UNRES-HUIT-011-UNITS
+- TLC-UNRES-HUIT-011-ORDER
+- TLC-UNRES-HUIT-011-AGGREGATION
+- TLC-UNRES-HUIT-011-NUMERICS
+- TLC-UNRES-HUIT-011-ORACLE
+- TLC-UNRES-HUIT-011-BOUNDARY
+- TLC-UNRES-HUIT-011-IDENTITY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: false
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: false
+  human_validation_required_before_prototype_work: true
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/traceability.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+rows:
+- trace_id: TRACE-HUIT-011-093
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-093
+  object_type: Metric
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Capacités (Capacities)
+  subsection: Propriétés
+  start_line: 176
+  end_line: 176
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-092
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Capacités (Capacities)
+    start_line: 176
+    end_line: 176
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 1
+  objects_covered: 1
+  relations_covered: 0
+  reservations_received: 9
+  reservations_propagated: 9

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/unresolved.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-011-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-011-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-011-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-011-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-011-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-011-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-011-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-011-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-011-IDENTITY
+  topic: feature_identity_or_boundary
+  value: not_yet_determinable
+  status: unresolved
+  required_human_decision: Confirm the scientific identity and boundary before prototype IR generation.
+received_count: 9
+propagated_count: 9
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+criteria:
+- id: VAL-HUIT-011-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-011-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-011-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-011-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-011-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-011-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/contract.yaml
@@ -1,0 +1,150 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: metric (provisionally_separated)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-089
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-088
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-012-089
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-089
+  category: Metric
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Capacités (Capacities)
+    subsection: Propriétés
+    start_line: 172
+    end_line: 172
+outputs:
+- output_id: OUTPUT-HUIT-012-089
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-089
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-012-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-012-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-012-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-012-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-012-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-012-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-012-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-012-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-012-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-012-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-012-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/unresolved.yaml
+  count: 9
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-012-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-012-TYPE
+- TLC-UNRES-HUIT-012-SIGNATURE
+- TLC-UNRES-HUIT-012-UNITS
+- TLC-UNRES-HUIT-012-ORDER
+- TLC-UNRES-HUIT-012-AGGREGATION
+- TLC-UNRES-HUIT-012-NUMERICS
+- TLC-UNRES-HUIT-012-ORACLE
+- TLC-UNRES-HUIT-012-BOUNDARY
+- TLC-UNRES-HUIT-012-IDENTITY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: false
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: false
+  human_validation_required_before_prototype_work: true
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/traceability.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+rows:
+- trace_id: TRACE-HUIT-012-089
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-089
+  object_type: Metric
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Capacités (Capacities)
+  subsection: Propriétés
+  start_line: 172
+  end_line: 172
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-088
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Capacités (Capacities)
+    start_line: 172
+    end_line: 172
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 1
+  objects_covered: 1
+  relations_covered: 0
+  reservations_received: 9
+  reservations_propagated: 9

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/unresolved.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-012-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-012-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-012-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-012-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-012-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-012-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-012-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-012-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-012-IDENTITY
+  topic: feature_identity_or_boundary
+  value: not_yet_determinable
+  status: unresolved
+  required_human_decision: Confirm the scientific identity and boundary before prototype IR generation.
+received_count: 9
+propagated_count: 9
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+criteria:
+- id: VAL-HUIT-012-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-012-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-012-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-012-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-012-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-012-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/contract.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/contract.yaml
@@ -1,0 +1,194 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+domain: huit-dimensions
+canonical_name: '03-huit-dimensions-de-tl: operator (blocked_locally)'
+contract_kind: limited_engineering_contract
+scientific_authority: origin/main
+limited_engineering_contract: true
+complete_scientific_contract: false
+status: limited_engineering_contract_with_reservations
+version: 0.1.0
+provenance:
+  source_commit: f0a9b6578087e61dd0c7799d95ff0050627f95d6
+  generated_on: '2026-07-24'
+  sources:
+  - registry/domain-progress/huit-dimensions/feature-inventory.yaml
+  - registry/domain-progress/huit-dimensions/feature-classification.yaml
+  - registry/domain-progress/huit-dimensions/feature-status.yaml
+  - registry/domain-progress/huit-dimensions/contract-production-plan.yaml
+  - registry/domain-progress/huit-dimensions/feature-dependencies.yaml
+  - registry/domain-progress/huit-dimensions/unresolved-status.yaml
+  - registry/domain-progress/huit-dimensions/dimension-semantics.yaml
+  - registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-objects.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/scientific-relations.candidate.yaml
+  - registry/scientific-objects/huit-dimensions-de-tl/unresolved-terms.yaml
+  - maths/03-huit-dimensions-de-tl.md
+scientific_objects_covered:
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-090
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-116
+- TLC-SO-HUIT-DIMENSIONS-DE-TL-117
+scientific_relations_covered: []
+contextual_relations_not_covered:
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-089
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-115
+- TLC-SR-HUIT-DIMENSIONS-DE-TL-116
+limited_functional_purpose: Preserve the cited candidate scientific objects as distinct opaque inputs and expose only source-traceable
+  candidate results; no missing scientific semantics are completed.
+inputs:
+- input_id: INPUT-HUIT-013-090
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-090
+  category: Operator
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Les Capacités (Capacities)
+    subsection: Propriétés
+    start_line: 173
+    end_line: 173
+- input_id: INPUT-HUIT-013-116
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-116
+  category: Function
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Le théorème CNS (Complétude, Nécessité, Suffisance)
+    subsection: null
+    start_line: 271
+    end_line: 271
+- input_id: INPUT-HUIT-013-117
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-117
+  category: Function
+  representation: opaque_parameterized
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/03-huit-dimensions-de-tl.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl.md
+    source_branch: main
+    source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+    source_blob_sha: f2db0152d534a776e2bd7abeb19ddfb150f33dd8
+    document_title: Les huit dimensions de la tradition (Eight Dimensions)
+    section: Le théorème CNS (Complétude, Nécessité, Suffisance)
+    subsection: null
+    start_line: 272
+    end_line: 272
+outputs:
+- output_id: OUTPUT-HUIT-013-090
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-090
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-013-116
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-116
+  representation: opaque_candidate_result
+  semantics: unresolved
+- output_id: OUTPUT-HUIT-013-117
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-117
+  representation: opaque_candidate_result
+  semantics: unresolved
+preconditions:
+- id: PRE-HUIT-013-SOURCE
+  statement: Every covered object is supplied with its candidate identity and exact source reference preserved.
+- id: PRE-HUIT-013-OPAQUE
+  statement: Unspecified types, dimensions, units, order, aggregation, temporal and numerical semantics remain opaque.
+- id: PRE-HUIT-013-UNRESOLVED
+  statement: Every reservation in unresolved.yaml remains attached.
+postconditions:
+- id: POST-HUIT-013-TRACE
+  statement: Every result remains candidate and traceable to one covered source object.
+- id: POST-HUIT-013-NO-PROMOTION
+  statement: No provisional assumption or unresolved reservation is promoted to canonical science.
+invariants:
+- id: INV-HUIT-013-IDENTITY
+  statement: Covered scientific object identities remain distinct.
+- id: INV-HUIT-013-SOURCE
+  statement: Source statements and line ranges remain unchanged.
+- id: INV-HUIT-013-LIMITED
+  statement: This artifact remains a limited engineering contract, never a complete scientific contract.
+undefined_or_error_cases:
+- id: FAIL-HUIT-013-MISSING-SOURCE
+  condition: A covered object or exact source range is missing.
+- id: FAIL-HUIT-013-DROPPED-RESERVATION
+  condition: A reservation is omitted or declared resolved without an explicit source.
+- id: FAIL-HUIT-013-INVENTION
+  condition: An unspecified scientific, numerical, temporal, ordering, unit or cardinality property is asserted.
+unresolved_propagated:
+  path: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/unresolved.yaml
+  count: 9
+engineering_assumptions:
+- assumption_id: TLC-EA-HUIT-013-001
+  feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+  source: No canonical software representation is specified in the cited source ranges.
+  technical_reason: A prototype-facing interface requires a representable boundary without selecting scientific types.
+  minimal_choice: Represent every covered scientific object and candidate result as an opaque, identity-preserving parameterized
+    value.
+  alternatives_not_chosen:
+  - numeric scalar
+  - ordered tuple
+  - vector space
+  - probability distribution
+  - domain-specific concrete class
+  impact:
+    prototype_ir: prototype IR remains deferred until feature identity is reviewed
+    implementation: no production representation is authorized
+  reversible: true
+  status: provisional_engineering_assumption
+scientific_reservations:
+- TLC-UNRES-HUIT-013-TYPE
+- TLC-UNRES-HUIT-013-SIGNATURE
+- TLC-UNRES-HUIT-013-UNITS
+- TLC-UNRES-HUIT-013-ORDER
+- TLC-UNRES-HUIT-013-AGGREGATION
+- TLC-UNRES-HUIT-013-NUMERICS
+- TLC-UNRES-HUIT-013-ORACLE
+- TLC-UNRES-HUIT-013-BOUNDARY
+- TLC-UNRES-HUIT-013-IDENTITY
+strong_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  contractual_use: prohibited
+traceability: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/traceability.yaml
+validation_criteria: registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/validation-criteria.yaml
+readiness:
+  ready_for_complete_scientific_contract: false
+  ready_for_limited_engineering_contract: true
+  ready_for_canonical_ir: false
+  ready_for_prototype_ir: false
+  ready_for_production_implementation: false
+  ready_for_reference_prototype: false
+  human_validation_required_before_prototype_work: true
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/dependencies.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/dependencies.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+strong_dependencies: []
+internal_feature_dependencies: []
+documentary_references:
+- target_domain: message
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: principles
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: values
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: virtues
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: capacities
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: competencies
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: practice
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+- target_domain: lived-experience
+  status: explicit_component_domain_reference_candidate
+  blocking_limited_contract: false
+  evidence: registry/domain-progress/huit-dimensions/external-domain-dependencies.yaml
+policy: Named component domains are documentary context, not implementation guarantees.

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/traceability.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/traceability.yaml
@@ -1,0 +1,65 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+rows:
+- trace_id: TRACE-HUIT-013-090
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-090
+  object_type: Operator
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Les Capacités (Capacities)
+  subsection: Propriétés
+  start_line: 173
+  end_line: 173
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-013-116
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-116
+  object_type: Function
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Le théorème CNS (Complétude, Nécessité, Suffisance)
+  subsection: null
+  start_line: 271
+  end_line: 271
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+- trace_id: TRACE-HUIT-013-117
+  scientific_object_id: TLC-SO-HUIT-DIMENSIONS-DE-TL-117
+  object_type: Function
+  source_path: maths/03-huit-dimensions-de-tl.md
+  section: Le théorème CNS (Complétude, Nécessité, Suffisance)
+  subsection: null
+  start_line: 272
+  end_line: 272
+  scientific_source_commit: 68a4d4c728bab655631543b3e1788d4f0da31e8e
+  coverage: covered_as_opaque_candidate_object
+contextual_relations:
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-089
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Les Capacités (Capacities)
+    start_line: 173
+    end_line: 173
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-115
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Le théorème CNS (Complétude, Nécessité, Suffisance)
+    start_line: 271
+    end_line: 271
+  coverage: context_only_not_behavior
+- relation_id: TLC-SR-HUIT-DIMENSIONS-DE-TL-116
+  relation_type: refers_to
+  source_reference:
+    source_path: maths/03-huit-dimensions-de-tl.md
+    section: Le théorème CNS (Complétude, Nécessité, Suffisance)
+    start_line: 272
+    end_line: 272
+  coverage: context_only_not_behavior
+coverage_summary:
+  objects_expected: 3
+  objects_covered: 3
+  relations_covered: 0
+  reservations_received: 9
+  reservations_propagated: 9

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/unresolved.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/unresolved.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+status: propagated_with_reservations
+canonical_unresolved_directly_attached: []
+contract_reservations:
+- id: TLC-UNRES-HUIT-013-TYPE
+  topic: types_and_categories
+  value: opaque_parameterized
+  status: unresolved
+- id: TLC-UNRES-HUIT-013-SIGNATURE
+  topic: operation_signature
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-013-UNITS
+  topic: units_and_dimensions
+  value: not_specified
+  status: unresolved
+- id: TLC-UNRES-HUIT-013-ORDER
+  topic: ordering
+  value: not_specified_non_ordinal
+  status: unresolved
+- id: TLC-UNRES-HUIT-013-AGGREGATION
+  topic: aggregation
+  value: operator_unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-013-NUMERICS
+  topic: numerical_method
+  value: not_authorized
+  status: unresolved
+- id: TLC-UNRES-HUIT-013-ORACLE
+  topic: executable_oracle
+  value: not_identified
+  status: unresolved
+- id: TLC-UNRES-HUIT-013-BOUNDARY
+  topic: cross_domain_ownership
+  value: unresolved
+  status: unresolved
+- id: TLC-UNRES-HUIT-013-IDENTITY
+  topic: feature_identity_or_boundary
+  value: not_yet_determinable
+  status: unresolved
+  required_human_decision: Confirm the scientific identity and boundary before prototype IR generation.
+received_count: 9
+propagated_count: 9
+propagation_complete: true
+resolution_claimed: false

--- a/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/validation-criteria.yaml
+++ b/registry/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/validation-criteria.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+criteria:
+- id: VAL-HUIT-013-MARKER
+  requirement: contract is explicitly limited_engineering_contract_with_reservations and not complete
+- id: VAL-HUIT-013-SCOPE
+  requirement: exactly the planned scientific objects are covered
+- id: VAL-HUIT-013-TRACE
+  requirement: every object has an exact source range and commit
+- id: VAL-HUIT-013-UNRESOLVED
+  requirement: all received reservations are propagated and none is declared resolved
+- id: VAL-HUIT-013-OPAQUE
+  requirement: unspecified representation and operation semantics remain opaque
+- id: VAL-HUIT-013-IR
+  requirement: canonical IR and production implementation remain unauthorized
+acceptance_rule: Passing authorizes review of this limited engineering contract only.

--- a/reports/math-contract-batches/huit-dimensions-engineering-batch-001/batch-report.md
+++ b/reports/math-contract-batches/huit-dimensions-engineering-batch-001/batch-report.md
@@ -1,0 +1,11 @@
+# Huit Dimensions limited engineering batch 001
+
+- Source commit: `f0a9b6578087e61dd0c7799d95ff0050627f95d6`
+- Features treated: 11
+- Limited engineering contracts created: 11
+- Prototype-IR ready: 5
+- Canonical-IR ready: 0
+- Production implementation ready: 0
+- Blocked for all progress: 0
+
+All scientific reservations remain unresolved. The batch uses only opaque, parameterized, reversible engineering representations. No IR, test oracle, implementation, or scientific source modification is included.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-001-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-001-002
+  topic: feature_identity_and_boundary
+  required_before: canonical_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-001-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 3
+- Reservations propagated: 8
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: true
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-002-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-002-002
+  topic: feature_identity_and_boundary
+  required_before: prototype_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-002-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 1
+- Reservations propagated: 9
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: false
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-005-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-005-002
+  topic: feature_identity_and_boundary
+  required_before: canonical_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-005-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 4
+- Reservations propagated: 8
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: true
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-006-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-006-002
+  topic: feature_identity_and_boundary
+  required_before: canonical_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-006-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 2
+- Reservations propagated: 8
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: true
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-007-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-007-002
+  topic: feature_identity_and_boundary
+  required_before: canonical_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-007-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 2
+- Reservations propagated: 8
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: true
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-008-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-008-002
+  topic: feature_identity_and_boundary
+  required_before: prototype_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-008-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 2
+- Reservations propagated: 9
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: false
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-009-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-009-002
+  topic: feature_identity_and_boundary
+  required_before: prototype_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-009-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 2
+- Reservations propagated: 9
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: false
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-010-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-010-002
+  topic: feature_identity_and_boundary
+  required_before: canonical_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-010-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 1
+- Reservations propagated: 8
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: true
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-011-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-011-002
+  topic: feature_identity_and_boundary
+  required_before: prototype_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-011-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 1
+- Reservations propagated: 9
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: false
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-012-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-012-002
+  topic: feature_identity_and_boundary
+  required_before: prototype_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-012-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 1
+- Reservations propagated: 9
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: false
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/decision_required.yaml
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/decision_required.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013-001
+feature_id: TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+human_validation_required: true
+decisions:
+- decision_id: TLC-DEC-HUIT-013-001
+  topic: scientific_types_and_operation_semantics
+  required_before: canonical_scientific_contract
+  status: open
+- decision_id: TLC-DEC-HUIT-013-002
+  topic: feature_identity_and_boundary
+  required_before: prototype_ir
+  status: open

--- a/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/generation-report.md
+++ b/reports/math-contracts/TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013/generation-report.md
@@ -1,0 +1,12 @@
+# Limited engineering contract ? TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013
+
+- Contract: `TLC-LEC-TLC-FC-03-HUIT-DIMENSIONS-DE-TL-013-001`
+- Status: `limited_engineering_contract_with_reservations`
+- Objects covered: 3
+- Reservations propagated: 9
+- Ready for limited engineering contract: yes
+- Ready for prototype IR: false
+- Ready for canonical IR: false
+- Ready for production implementation: false
+
+No scientific ambiguity was resolved. All representations are opaque and reversible.


### PR DESCRIPTION
## What changed

- adds one limited engineering contract with explicit reservations for each of the 11 active Huit Dimensions features
- reclassifies blockers TLC-GBLOCK-0035 through TLC-GBLOCK-0045 for progressive engineering
- records 11 reversible opaque engineering assumptions
- adds dependency, unresolved, traceability, validation, decision, and report artifacts per feature
- adds a targeted prototype-IR plan without generating any IR

## Readiness

- limited engineering contracts: 11
- ready for prototype IR: 5 (`001`, `005`, `006`, `007`, `010`)
- ready for canonical IR: 0
- ready for production implementation: 0
- blocked for all progress: 0

## Scientific safety

All types, dimensions, units, ordering, aggregation, numerical methods, cross-domain ownership, feature-boundary questions, and oracle questions remain unresolved. Opaque parameterized representations are explicitly provisional and reversible. No `maths/` source, canonical contract from domains 00–02, Relations contract, IR, test oracle, or implementation was modified or created.

## Validation

- parsed 70 new YAML files
- checked 11 unique contract and feature IDs
- verified referenced source paths
- verified complete unresolved propagation
- verified no reservation is declared resolved
- verified no contract is marked scientifically complete
- verified canonical IR and production implementation remain unauthorized
- verified manifest/contract/report coherence and Git scope
- `git diff --check`: pass

## Summary by Sourcery

Introduce a first limited engineering contract batch for the huit-dimensions domain, covering 11 features with opaque, reversible representations and explicit scientific reservations, while keeping canonical IR and production implementation unauthorized.

New Features:
- Add limited engineering contracts for 11 huit-dimensions features with associated manifests, dependencies, unresolved reservations, traceability, validation criteria, and reports.
- Define a targeted prototype IR plan for prototype-ready huit-dimensions features, capturing expected opaque operations and parallelization groups without generating IR artifacts.

Enhancements:
- Reclassify global blockers TLC-GBLOCK-0035 through TLC-GBLOCK-0045 so they block canonical science and IR but permit limited engineering contracts and, for some features, prototype IR.
- Record a set of reversible provisional engineering assumptions for all huit-dimensions features, clarifying that only opaque parameterized representations are permitted at this stage.
- Add batch-level reporting and readiness metadata summarizing feature status, reservation preservation, and progress constraints for the huit-dimensions engineering batch.