### PR TITLE
[SUPERSEDED] Theorems semantic specialization

### DIFF
--- a/registry/ir-batches/theorems-prototype-ir-batch-001/manifest.yaml
+++ b/registry/ir-batches/theorems-prototype-ir-batch-001/manifest.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+ir_batch_id: TLC-IRB-THEOREMS-001
+domain: theorems
+source_contract_batch: TLC-LCEB-THEOREMS-001
+ir_kind: prototype_ir_with_reservations
+features: [TLC-FC-06-THEOREMS-001, TLC-FC-06-THEOREMS-002, TLC-FC-06-THEOREMS-003, TLC-FC-06-THEOREMS-004, TLC-FC-06-THEOREMS-005, TLC-FC-06-THEOREMS-006, TLC-FC-06-THEOREMS-007, TLC-FC-06-THEOREMS-008, TLC-FC-06-THEOREMS-009]
+prototype_irs_created: 9
+test_plans_created: 9
+canonical_irs_created: 0
+blocks_all_prototype_progress: false
+readiness: {ready_for_reference_python_count: 9, ready_for_cpp_prototype_count: 9, ready_for_canonical_ir_count: 0}

--- a/registry/ir/TLC-FC-06-THEOREMS-001/ir.yaml
+++ b/registry/ir/TLC-FC-06-THEOREMS-001/ir.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-001-001
+feature_id: TLC-FC-06-THEOREMS-001
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-001-001
+ir_kind: prototype_ir_with_reservations
+prototype_classification: substantive_and_implementable
+entrypoint:
+  callable: assemble_experiential_conservation_claim
+  implementation_form: pure_function_or_small_builder
+inputs:
+  - {name: axiom_reference, type: "OpaqueAxiomReference"}
+  - {name: experience_symbol, type: "OpaqueExperienceSymbol"}
+  - {name: claim_clauses, type: "ConservationClauseSet"}
+outputs:
+  - {name: conservation_claim, type: "UnevaluatedConservationClaim"}
+opaque_types: [OpaqueScientificValue, OpaqueScientificExpression]
+parameterized_types: [Mapping<K,V>, Sequence<T>]
+operations:
+  - operation_id: assemble_experiential_conservation_claim
+    responsibility: "Assemble an unevaluated conservation-claim descriptor from the cited experiential-energy statement and its external axiom reference."
+    observable_effect: "return a descriptor containing the bounded-energy, controlled-variation, and stationary-law clause identifiers without evaluating them"
+    scientific_evaluation: forbidden
+control_flow:
+  - Validate the feature-specific precondition.
+  - Construct the declared output from unchanged opaque inputs and source metadata.
+  - Validate the feature-specific postcondition before returning.
+preconditions:
+  - "The axiom reference and all three source clause identifiers are present."
+postconditions:
+  - "The result contains exactly the supplied axiom reference, experience symbol, and three unevaluated clause identifiers."
+invariants: []
+errors:
+  - MISSING_AXIOM_REFERENCE
+  - INCOMPLETE_CONSERVATION_CLAUSES
+unresolved_propagated: []
+provisional_assumptions_propagated: [TLC-EA-THEOREMS-001-001]
+opaque_value_policy: "an opaque experience symbol is preserved byte-for-byte"
+traceability:
+  contract: registry/math-contracts/TLC-FC-06-THEOREMS-001/contract.yaml
+  sources: [maths/06-theorems.md:141-144]
+  source_objects: [TLC-SO-THEOREMS-011]
+  source_relations: []
+determinism_status: deterministic_structural_construction_for_identical_inputs
+testability_status: feature_specific_operation_and_effect_testable
+implementation_constraints:
+  - Implement only validation, structural construction, lookup, and identity preservation described by the entrypoint.
+  - Do not evaluate formulas, proofs, scientific truth, convergence, stability, sufficiency, or operator behavior.
+readiness:
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/ir/TLC-FC-06-THEOREMS-002/ir.yaml
+++ b/registry/ir/TLC-FC-06-THEOREMS-002/ir.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-002-001
+feature_id: TLC-FC-06-THEOREMS-002
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-002-001
+ir_kind: prototype_ir_with_reservations
+prototype_classification: substantive_and_implementable
+entrypoint:
+  callable: register_theorem_dynamics_equations
+  implementation_form: pure_function_or_small_builder
+inputs:
+  - {name: equation_records, type: "Mapping<ScientificObjectId,OpaqueEquation>"}
+  - {name: declared_roles, type: "Mapping<ScientificObjectId,DynamicsRole>"}
+outputs:
+  - {name: dynamics_registry, type: "DynamicsEquationRegistry"}
+opaque_types: [OpaqueScientificValue, OpaqueScientificExpression]
+parameterized_types: [Mapping<K,V>, Sequence<T>]
+operations:
+  - operation_id: register_theorem_dynamics_equations
+    responsibility: "Register the three cited evolution equations as distinct unevaluated dynamics records with their prepared source roles."
+    observable_effect: "return a registry keyed by the three prepared object identifiers and preserving each equation's declared trajectory, identity-wave, or receptivity role"
+    scientific_evaluation: forbidden
+control_flow:
+  - Validate the feature-specific precondition.
+  - Construct the declared output from unchanged opaque inputs and source metadata.
+  - Validate the feature-specific postcondition before returning.
+preconditions:
+  - "Every covered object has one opaque equation and one prepared role."
+postconditions:
+  - "The registry has one entry for each covered object and never evaluates a derivative or evolution law."
+invariants: []
+errors:
+  - MISSING_DYNAMICS_EQUATION
+  - UNKNOWN_DYNAMICS_ROLE
+  - DUPLICATE_SCIENTIFIC_OBJECT
+unresolved_propagated: []
+provisional_assumptions_propagated: [TLC-EA-THEOREMS-002-001]
+opaque_value_policy: "opaque equation payloads with distinct roles remain distinct"
+traceability:
+  contract: registry/math-contracts/TLC-FC-06-THEOREMS-002/contract.yaml
+  sources: [maths/06-theorems.md:109-111, maths/06-theorems.md:118-120, maths/06-theorems.md:133-135]
+  source_objects: [TLC-SO-THEOREMS-027, TLC-SO-THEOREMS-028, TLC-SO-THEOREMS-030]
+  source_relations: []
+determinism_status: deterministic_structural_construction_for_identical_inputs
+testability_status: feature_specific_operation_and_effect_testable
+implementation_constraints:
+  - Implement only validation, structural construction, lookup, and identity preservation described by the entrypoint.
+  - Do not evaluate formulas, proofs, scientific truth, convergence, stability, sufficiency, or operator behavior.
+readiness:
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/ir/TLC-FC-06-THEOREMS-003/ir.yaml
+++ b/registry/ir/TLC-FC-06-THEOREMS-003/ir.yaml
@@ -1,0 +1,53 @@
+schema_version: 1
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-003-001
+feature_id: TLC-FC-06-THEOREMS-003
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-003-001
+ir_kind: prototype_ir_with_reservations
+prototype_classification: substantive_and_implementable
+entrypoint:
+  callable: catalogue_explicit_theorem_equations
+  implementation_form: pure_function_or_small_builder
+inputs:
+  - {name: equation_entries, type: "Sequence<TheoremEquationEntry>"}
+outputs:
+  - {name: equation_catalogue, type: "TheoremEquationCatalogue"}
+opaque_types: [OpaqueScientificValue, OpaqueScientificExpression]
+parameterized_types: [Mapping<K,V>, Sequence<T>]
+operations:
+  - operation_id: catalogue_explicit_theorem_equations
+    responsibility: "Build a source-addressable catalogue of the four explicit theorem equations without evaluating or normalizing their mathematical expressions."
+    observable_effect: "return entries addressable by source object and equation role for stability bound, emergence probability, trajectory convergence, and wave speed"
+    scientific_evaluation: forbidden
+control_flow:
+  - Validate the feature-specific precondition.
+  - Construct the declared output from unchanged opaque inputs and source metadata.
+  - Validate the feature-specific postcondition before returning.
+preconditions:
+  - "Each of the four covered objects occurs exactly once with a source reference and opaque expression."
+postconditions:
+  - "The catalogue exposes four distinct roles and preserves each expression unchanged."
+invariants: []
+errors:
+  - MISSING_EQUATION_ROLE
+  - DUPLICATE_EQUATION_ROLE
+  - MISSING_SOURCE_REFERENCE
+unresolved_propagated: []
+provisional_assumptions_propagated: [TLC-EA-THEOREMS-003-001]
+opaque_value_policy: "an unevaluated expression is stored without algebraic normalization"
+traceability:
+  contract: registry/math-contracts/TLC-FC-06-THEOREMS-003/contract.yaml
+  sources: [maths/06-theorems.md:24-26, maths/06-theorems.md:35-37, maths/06-theorems.md:102-104, maths/06-theorems.md:122-124]
+  source_objects: [TLC-SO-THEOREMS-016, TLC-SO-THEOREMS-017, TLC-SO-THEOREMS-026, TLC-SO-THEOREMS-029]
+  source_relations: []
+determinism_status: deterministic_structural_construction_for_identical_inputs
+testability_status: feature_specific_operation_and_effect_testable
+implementation_constraints:
+  - Implement only validation, structural construction, lookup, and identity preservation described by the entrypoint.
+  - Do not evaluate formulas, proofs, scientific truth, convergence, stability, sufficiency, or operator behavior.
+readiness:
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/ir/TLC-FC-06-THEOREMS-004/ir.yaml
+++ b/registry/ir/TLC-FC-06-THEOREMS-004/ir.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-004-001
+feature_id: TLC-FC-06-THEOREMS-004
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-004-001
+ir_kind: prototype_ir_with_reservations
+prototype_classification: substantive_and_implementable
+entrypoint:
+  callable: construct_transmission_ergodicity_hypothesis
+  implementation_form: pure_function_or_small_builder
+inputs:
+  - {name: transmission_operator, type: "OpaqueOperatorSymbol"}
+  - {name: ergodicity_condition, type: "OpaqueSpectralGapCondition"}
+outputs:
+  - {name: operator_hypothesis, type: "TransmissionErgodicityHypothesis"}
+opaque_types: [OpaqueScientificValue, OpaqueScientificExpression]
+parameterized_types: [Mapping<K,V>, Sequence<T>]
+operations:
+  - operation_id: construct_transmission_ergodicity_hypothesis
+    responsibility: "Construct the transmission-ergodicity hypothesis record cited by the community-stability theorem."
+    observable_effect: "bind the operator symbol and its cited uniform-ergodicity condition into one traceable, unevaluated hypothesis record"
+    scientific_evaluation: forbidden
+control_flow:
+  - Validate the feature-specific precondition.
+  - Construct the declared output from unchanged opaque inputs and source metadata.
+  - Validate the feature-specific postcondition before returning.
+preconditions:
+  - "Both the transmission operator and spectral-gap condition carry the line-20 source reference."
+postconditions:
+  - "The result preserves both opaque components and labels the record as a hypothesis rather than a verified property."
+invariants: []
+errors:
+  - MISSING_OPERATOR_SYMBOL
+  - MISSING_ERGODICITY_CONDITION
+  - SOURCE_REFERENCE_MISMATCH
+unresolved_propagated: []
+provisional_assumptions_propagated: [TLC-EA-THEOREMS-004-001]
+opaque_value_policy: "no spectral gap value or operator behavior is computed"
+traceability:
+  contract: registry/math-contracts/TLC-FC-06-THEOREMS-004/contract.yaml
+  sources: [maths/06-theorems.md:20]
+  source_objects: [TLC-SO-THEOREMS-014]
+  source_relations: []
+determinism_status: deterministic_structural_construction_for_identical_inputs
+testability_status: feature_specific_operation_and_effect_testable
+implementation_constraints:
+  - Implement only validation, structural construction, lookup, and identity preservation described by the entrypoint.
+  - Do not evaluate formulas, proofs, scientific truth, convergence, stability, sufficiency, or operator behavior.
+readiness:
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/ir/TLC-FC-06-THEOREMS-005/ir.yaml
+++ b/registry/ir/TLC-FC-06-THEOREMS-005/ir.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-005-001
+feature_id: TLC-FC-06-THEOREMS-005
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-005-001
+ir_kind: prototype_ir_with_reservations
+prototype_classification: substantive_and_implementable
+entrypoint:
+  callable: register_cns_operator_claims
+  implementation_form: pure_function_or_small_builder
+inputs:
+  - {name: transformation_claim, type: "OpaqueTransformationClaim"}
+  - {name: dimension_removal_claims, type: "Mapping<DimensionId,OpaqueRemovalEffectClaim>"}
+outputs:
+  - {name: cns_operator_claims, type: "CNSOperatorClaimSet"}
+opaque_types: [OpaqueScientificValue, OpaqueScientificExpression]
+parameterized_types: [Mapping<K,V>, Sequence<T>]
+operations:
+  - operation_id: register_cns_operator_claims
+    responsibility: "Register the two CNS operator claims: the source transformation signature and the per-dimension removal-effect claim."
+    observable_effect: "return a claim set separating the transformation signature from the dimension-removal effects while leaving completeness and necessity unevaluated"
+    scientific_evaluation: forbidden
+control_flow:
+  - Validate the feature-specific precondition.
+  - Construct the declared output from unchanged opaque inputs and source metadata.
+  - Validate the feature-specific postcondition before returning.
+preconditions:
+  - "The transformation claim cites lines 54-55 and every removal claim cites lines 66-67."
+postconditions:
+  - "The two claim families remain separately addressable and retain blocked-local scientific status."
+invariants: []
+errors:
+  - MISSING_TRANSFORMATION_CLAIM
+  - MISSING_REMOVAL_CLAIM_SOURCE
+  - CLAIM_FAMILY_COLLISION
+unresolved_propagated: []
+provisional_assumptions_propagated: [TLC-EA-THEOREMS-005-001]
+opaque_value_policy: "removal effects remain opaque and are not executed"
+traceability:
+  contract: registry/math-contracts/TLC-FC-06-THEOREMS-005/contract.yaml
+  sources: [maths/06-theorems.md:54-55, maths/06-theorems.md:66-67]
+  source_objects: [TLC-SO-THEOREMS-005, TLC-SO-THEOREMS-006]
+  source_relations: []
+determinism_status: deterministic_structural_construction_for_identical_inputs
+testability_status: feature_specific_operation_and_effect_testable
+implementation_constraints:
+  - Implement only validation, structural construction, lookup, and identity preservation described by the entrypoint.
+  - Do not evaluate formulas, proofs, scientific truth, convergence, stability, sufficiency, or operator behavior.
+readiness:
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/ir/TLC-FC-06-THEOREMS-006/ir.yaml
+++ b/registry/ir/TLC-FC-06-THEOREMS-006/ir.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-006-001
+feature_id: TLC-FC-06-THEOREMS-006
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-006-001
+ir_kind: prototype_ir_with_reservations
+prototype_classification: substantive_and_implementable
+entrypoint:
+  callable: index_theorem_declarations
+  implementation_form: pure_function_or_small_builder
+inputs:
+  - {name: declarations, type: "Sequence<OpaqueTheoremDeclaration>"}
+  - {name: proof_statuses, type: "Mapping<ScientificObjectId,ProofStatus>"}
+outputs:
+  - {name: theorem_index, type: "TheoremDeclarationIndex"}
+opaque_types: [OpaqueScientificValue, OpaqueScientificExpression]
+parameterized_types: [Mapping<K,V>, Sequence<T>]
+operations:
+  - operation_id: index_theorem_declarations
+    responsibility: "Index the six prepared theorem declarations for lookup by scientific object identifier, retaining statement, source, and proof-status metadata."
+    observable_effect: "return a six-entry index supporting identifier lookup and preserving each declaration's partial or absent proof status"
+    scientific_evaluation: forbidden
+control_flow:
+  - Validate the feature-specific precondition.
+  - Construct the declared output from unchanged opaque inputs and source metadata.
+  - Validate the feature-specific postcondition before returning.
+preconditions:
+  - "Each covered theorem object occurs exactly once and has a source reference plus proof status."
+postconditions:
+  - "Lookup returns the unchanged declaration metadata and never returns a theorem truth value."
+invariants: []
+errors:
+  - DUPLICATE_THEOREM_ID
+  - MISSING_PROOF_STATUS
+  - UNKNOWN_THEOREM_ID
+unresolved_propagated: []
+provisional_assumptions_propagated: [TLC-EA-THEOREMS-006-001]
+opaque_value_policy: "a declaration with absent proof remains queryable but unevaluated"
+traceability:
+  contract: registry/math-contracts/TLC-FC-06-THEOREMS-006/contract.yaml
+  sources: [maths/06-theorems.md:13-16, maths/06-theorems.md:31-38, maths/06-theorems.md:49-52, maths/06-theorems.md:92-95, maths/06-theorems.md:114-124, maths/06-theorems.md:129-136]
+  source_objects: [TLC-SO-THEOREMS-002, TLC-SO-THEOREMS-003, TLC-SO-THEOREMS-004, TLC-SO-THEOREMS-008, TLC-SO-THEOREMS-009, TLC-SO-THEOREMS-010]
+  source_relations: []
+determinism_status: deterministic_structural_construction_for_identical_inputs
+testability_status: feature_specific_operation_and_effect_testable
+implementation_constraints:
+  - Implement only validation, structural construction, lookup, and identity preservation described by the entrypoint.
+  - Do not evaluate formulas, proofs, scientific truth, convergence, stability, sufficiency, or operator behavior.
+readiness:
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/ir/TLC-FC-06-THEOREMS-007/ir.yaml
+++ b/registry/ir/TLC-FC-06-THEOREMS-007/ir.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-007-001
+feature_id: TLC-FC-06-THEOREMS-007
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-007-001
+ir_kind: prototype_ir_with_reservations
+prototype_classification: substantive_and_implementable
+entrypoint:
+  callable: construct_community_stability_state
+  implementation_form: pure_function_or_small_builder
+inputs:
+  - {name: community_sequence, type: "OpaqueCommunitySequence"}
+  - {name: limit_community, type: "OpaqueCommunityState"}
+  - {name: stability_context, type: "CommunityStabilityContextComponents"}
+outputs:
+  - {name: community_stability_state, type: "CommunityStabilityStateDescriptor"}
+opaque_types: [OpaqueScientificValue, OpaqueScientificExpression]
+parameterized_types: [Mapping<K,V>, Sequence<T>]
+operations:
+  - operation_id: construct_community_stability_state
+    responsibility: "Construct the source-traceable community-stability context used by theorem C5 from the prepared state objects and relations."
+    observable_effect: "return a descriptor linking sequence, limit, and cited relation components without asserting convergence or stability"
+    scientific_evaluation: forbidden
+control_flow:
+  - Validate the feature-specific precondition.
+  - Construct the declared output from unchanged opaque inputs and source metadata.
+  - Validate the feature-specific postcondition before returning.
+preconditions:
+  - "The sequence and limit identities exist and every covered relation references a covered state component."
+postconditions:
+  - "The descriptor preserves all four object IDs, three relation IDs, and three unresolved term IDs."
+invariants: []
+errors:
+  - MISSING_COMMUNITY_SEQUENCE
+  - MISSING_LIMIT_STATE
+  - DANGLING_STABILITY_RELATION
+unresolved_propagated: [TLC-UT-THEOREMS-002, TLC-UT-THEOREMS-003, TLC-UT-THEOREMS-004]
+provisional_assumptions_propagated: [TLC-EA-THEOREMS-007-001]
+opaque_value_policy: "unresolved community, convergence, and stability semantics remain attached"
+traceability:
+  contract: registry/math-contracts/TLC-FC-06-THEOREMS-007/contract.yaml
+  sources: [maths/06-theorems.md:1-5, maths/06-theorems.md:18-21]
+  source_objects: [TLC-SO-THEOREMS-001, TLC-SO-THEOREMS-012, TLC-SO-THEOREMS-013, TLC-SO-THEOREMS-015]
+  source_relations: [TLC-SR-THEOREMS-011, TLC-SR-THEOREMS-012, TLC-SR-THEOREMS-014]
+determinism_status: deterministic_structural_construction_for_identical_inputs
+testability_status: feature_specific_operation_and_effect_testable
+implementation_constraints:
+  - Implement only validation, structural construction, lookup, and identity preservation described by the entrypoint.
+  - Do not evaluate formulas, proofs, scientific truth, convergence, stability, sufficiency, or operator behavior.
+readiness:
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/ir/TLC-FC-06-THEOREMS-008/ir.yaml
+++ b/registry/ir/TLC-FC-06-THEOREMS-008/ir.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-008-001
+feature_id: TLC-FC-06-THEOREMS-008
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-008-001
+ir_kind: prototype_ir_with_reservations
+prototype_classification: substantive_and_implementable
+entrypoint:
+  callable: assemble_eight_dimension_sufficiency_roles
+  implementation_form: pure_function_or_small_builder
+inputs:
+  - {name: dimension_roles, type: "Mapping<SourceOrdinal,OpaqueDimensionRole>"}
+  - {name: cross_domain_mappings, type: "Mapping<OpaqueDimensionRole,UnresolvedMappingId>"}
+outputs:
+  - {name: sufficiency_role_bundle, type: "EightDimensionSufficiencyRoleBundle"}
+opaque_types: [OpaqueScientificValue, OpaqueScientificExpression]
+parameterized_types: [Mapping<K,V>, Sequence<T>]
+operations:
+  - operation_id: assemble_eight_dimension_sufficiency_roles
+    responsibility: "Assemble the eight source-enumerated sufficiency-role records into a dimension-role bundle while preserving unresolved cross-domain mappings."
+    observable_effect: "return an eight-entry bundle preserving source ordinals 1 through 8, role labels, and unresolved mapping identifiers without asserting sufficiency"
+    scientific_evaluation: forbidden
+control_flow:
+  - Validate the feature-specific precondition.
+  - Construct the declared output from unchanged opaque inputs and source metadata.
+  - Validate the feature-specific postcondition before returning.
+preconditions:
+  - "Exactly the eight source ordinals are present and every unresolved mapping remains attached to its role."
+postconditions:
+  - "The bundle contains Message, Principles, Values, Virtues, Capacities, Competencies, Practice, and Lived Experience once each in source order."
+invariants: []
+errors:
+  - MISSING_DIMENSION_ROLE
+  - DUPLICATE_SOURCE_ORDINAL
+  - DROPPED_CROSS_DOMAIN_UNRESOLVED
+unresolved_propagated: [TLC-UT-THEOREMS-001, TLC-UT-THEOREMS-005, TLC-UT-THEOREMS-007, TLC-UT-THEOREMS-008, TLC-UT-THEOREMS-009, TLC-UT-THEOREMS-010, TLC-UT-THEOREMS-011, TLC-UT-THEOREMS-012]
+provisional_assumptions_propagated: [TLC-EA-THEOREMS-008-001]
+opaque_value_policy: "each role payload remains opaque even though source order and labels are preserved"
+traceability:
+  contract: registry/math-contracts/TLC-FC-06-THEOREMS-008/contract.yaml
+  sources: [maths/06-theorems.md:78-88]
+  source_objects: [TLC-SO-THEOREMS-007, TLC-SO-THEOREMS-018, TLC-SO-THEOREMS-020, TLC-SO-THEOREMS-021, TLC-SO-THEOREMS-022, TLC-SO-THEOREMS-023, TLC-SO-THEOREMS-024, TLC-SO-THEOREMS-025]
+  source_relations: []
+determinism_status: deterministic_structural_construction_for_identical_inputs
+testability_status: feature_specific_operation_and_effect_testable
+implementation_constraints:
+  - Implement only validation, structural construction, lookup, and identity preservation described by the entrypoint.
+  - Do not evaluate formulas, proofs, scientific truth, convergence, stability, sufficiency, or operator behavior.
+readiness:
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/ir/TLC-FC-06-THEOREMS-009/ir.yaml
+++ b/registry/ir/TLC-FC-06-THEOREMS-009/ir.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-009-001
+feature_id: TLC-FC-06-THEOREMS-009
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-009-001
+ir_kind: prototype_ir_with_reservations
+prototype_classification: substantive_and_implementable
+entrypoint:
+  callable: construct_principles_role_descriptor
+  implementation_form: pure_function_or_small_builder
+inputs:
+  - {name: principles_role, type: "OpaqueDimensionRole"}
+  - {name: source_ordinal, type: "SourceOrdinal"}
+outputs:
+  - {name: principles_descriptor, type: "PrinciplesRoleDescriptor"}
+opaque_types: [OpaqueScientificValue, OpaqueScientificExpression]
+parameterized_types: [Mapping<K,V>, Sequence<T>]
+operations:
+  - operation_id: construct_principles_role_descriptor
+    responsibility: "Construct the isolated Principles role descriptor from the provisionally separated source statement at line 82."
+    observable_effect: "return a descriptor identifying Principles, source ordinal 2, and the cited rational-coherence label without defining coherence"
+    scientific_evaluation: forbidden
+control_flow:
+  - Validate the feature-specific precondition.
+  - Construct the declared output from unchanged opaque inputs and source metadata.
+  - Validate the feature-specific postcondition before returning.
+preconditions:
+  - "The supplied role cites line 82 and carries unresolved identifier TLC-UT-THEOREMS-006."
+postconditions:
+  - "The descriptor is labelled Principles and preserves ordinal 2, the opaque role payload, and its unresolved identifier."
+invariants: []
+errors:
+  - WRONG_DIMENSION_LABEL
+  - WRONG_SOURCE_ORDINAL
+  - MISSING_PRINCIPLES_UNRESOLVED
+unresolved_propagated: [TLC-UT-THEOREMS-006]
+provisional_assumptions_propagated: [TLC-EA-THEOREMS-009-001]
+opaque_value_policy: "rational coherence remains an opaque source label, not an implemented property"
+traceability:
+  contract: registry/math-contracts/TLC-FC-06-THEOREMS-009/contract.yaml
+  sources: [maths/06-theorems.md:82]
+  source_objects: [TLC-SO-THEOREMS-019]
+  source_relations: []
+determinism_status: deterministic_structural_construction_for_identical_inputs
+testability_status: feature_specific_operation_and_effect_testable
+implementation_constraints:
+  - Implement only validation, structural construction, lookup, and identity preservation described by the entrypoint.
+  - Do not evaluate formulas, proofs, scientific truth, convergence, stability, sufficiency, or operator behavior.
+readiness:
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contract-batches/theorems-engineering-batch-001/manifest.yaml
+++ b/registry/math-contract-batches/theorems-engineering-batch-001/manifest.yaml
@@ -1,0 +1,86 @@
+schema_version: 1
+batch_id: TLC-LCEB-THEOREMS-001
+domain: theorems
+domain_index: "06"
+status: domain_reached_prototype_ir_level
+authority: origin/main
+source_commit: f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa
+generated_on: "2026-07-24"
+summary:
+  total_features: 9
+  contracts_reused: 0
+  contracts_created: 9
+  contracts_revised: 0
+  ir_preserved: 0
+  ir_created: 9
+  ir_revised: 0
+  ir_not_produced: 0
+  unresolved_propagated_unique: 12
+  provisional_assumptions: 9
+  blockers_remaining: 0
+features:
+  - feature_id: TLC-FC-06-THEOREMS-001
+    contract_id: TLC-LEC-TLC-FC-06-THEOREMS-001-001
+    ir_id: TLC-PIR-TLC-FC-06-THEOREMS-001-001
+    test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-001-001
+    unresolved_propagated: []
+    readiness: {ready_for_limited_engineering_contract: true, ready_for_prototype_ir: true, ready_for_reference_python: true, ready_for_cpp_prototype: true, ready_for_canonical_ir: false, ready_for_production_implementation: false}
+  - feature_id: TLC-FC-06-THEOREMS-002
+    contract_id: TLC-LEC-TLC-FC-06-THEOREMS-002-001
+    ir_id: TLC-PIR-TLC-FC-06-THEOREMS-002-001
+    test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-002-001
+    unresolved_propagated: []
+    readiness: {ready_for_limited_engineering_contract: true, ready_for_prototype_ir: true, ready_for_reference_python: true, ready_for_cpp_prototype: true, ready_for_canonical_ir: false, ready_for_production_implementation: false}
+  - feature_id: TLC-FC-06-THEOREMS-003
+    contract_id: TLC-LEC-TLC-FC-06-THEOREMS-003-001
+    ir_id: TLC-PIR-TLC-FC-06-THEOREMS-003-001
+    test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-003-001
+    unresolved_propagated: []
+    readiness: {ready_for_limited_engineering_contract: true, ready_for_prototype_ir: true, ready_for_reference_python: true, ready_for_cpp_prototype: true, ready_for_canonical_ir: false, ready_for_production_implementation: false}
+  - feature_id: TLC-FC-06-THEOREMS-004
+    contract_id: TLC-LEC-TLC-FC-06-THEOREMS-004-001
+    ir_id: TLC-PIR-TLC-FC-06-THEOREMS-004-001
+    test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-004-001
+    unresolved_propagated: []
+    readiness: {ready_for_limited_engineering_contract: true, ready_for_prototype_ir: true, ready_for_reference_python: true, ready_for_cpp_prototype: true, ready_for_canonical_ir: false, ready_for_production_implementation: false}
+  - feature_id: TLC-FC-06-THEOREMS-005
+    contract_id: TLC-LEC-TLC-FC-06-THEOREMS-005-001
+    ir_id: TLC-PIR-TLC-FC-06-THEOREMS-005-001
+    test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-005-001
+    unresolved_propagated: []
+    readiness: {ready_for_limited_engineering_contract: true, ready_for_prototype_ir: true, ready_for_reference_python: true, ready_for_cpp_prototype: true, ready_for_canonical_ir: false, ready_for_production_implementation: false}
+  - feature_id: TLC-FC-06-THEOREMS-006
+    contract_id: TLC-LEC-TLC-FC-06-THEOREMS-006-001
+    ir_id: TLC-PIR-TLC-FC-06-THEOREMS-006-001
+    test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-006-001
+    unresolved_propagated: []
+    readiness: {ready_for_limited_engineering_contract: true, ready_for_prototype_ir: true, ready_for_reference_python: true, ready_for_cpp_prototype: true, ready_for_canonical_ir: false, ready_for_production_implementation: false}
+  - feature_id: TLC-FC-06-THEOREMS-007
+    contract_id: TLC-LEC-TLC-FC-06-THEOREMS-007-001
+    ir_id: TLC-PIR-TLC-FC-06-THEOREMS-007-001
+    test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-007-001
+    unresolved_propagated: [TLC-UT-THEOREMS-002, TLC-UT-THEOREMS-003, TLC-UT-THEOREMS-004]
+    readiness: {ready_for_limited_engineering_contract: true, ready_for_prototype_ir: true, ready_for_reference_python: true, ready_for_cpp_prototype: true, ready_for_canonical_ir: false, ready_for_production_implementation: false}
+  - feature_id: TLC-FC-06-THEOREMS-008
+    contract_id: TLC-LEC-TLC-FC-06-THEOREMS-008-001
+    ir_id: TLC-PIR-TLC-FC-06-THEOREMS-008-001
+    test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-008-001
+    unresolved_propagated: [TLC-UT-THEOREMS-001, TLC-UT-THEOREMS-005, TLC-UT-THEOREMS-007, TLC-UT-THEOREMS-008, TLC-UT-THEOREMS-009, TLC-UT-THEOREMS-010, TLC-UT-THEOREMS-011, TLC-UT-THEOREMS-012]
+    readiness: {ready_for_limited_engineering_contract: true, ready_for_prototype_ir: true, ready_for_reference_python: true, ready_for_cpp_prototype: true, ready_for_canonical_ir: false, ready_for_production_implementation: false}
+  - feature_id: TLC-FC-06-THEOREMS-009
+    contract_id: TLC-LEC-TLC-FC-06-THEOREMS-009-001
+    ir_id: TLC-PIR-TLC-FC-06-THEOREMS-009-001
+    test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-009-001
+    unresolved_propagated: [TLC-UT-THEOREMS-006]
+    readiness: {ready_for_limited_engineering_contract: true, ready_for_prototype_ir: true, ready_for_reference_python: true, ready_for_cpp_prototype: true, ready_for_canonical_ir: false, ready_for_production_implementation: false}
+readiness_final:
+  ready_for_limited_engineering_contract_count: 9
+  ready_for_prototype_ir_count: 9
+  ready_for_reference_python_count: 9
+  ready_for_cpp_prototype_count: 9
+  ready_for_canonical_ir_count: 0
+  ready_for_production_implementation_count: 0
+  features_blocked_from_all_prototype_ir: 0
+  scientific_reservations_preserved: true
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contract-batches/theorems-engineering-batch-001/provisional-assumptions.yaml
+++ b/registry/math-contract-batches/theorems-engineering-batch-001/provisional-assumptions.yaml
@@ -1,0 +1,84 @@
+schema_version: 1
+batch_id: TLC-LCEB-THEOREMS-001
+assumptions:
+  - assumption_id: TLC-EA-THEOREMS-001-001
+    feature_id: TLC-FC-06-THEOREMS-001
+    undefined_property: canonical software type and executable scientific semantics
+    technical_reason: A prototype interface requires a representable boundary.
+    minimal_choice: identity-preserving opaque parameterized payload and unevaluated result
+    alternatives_left_open: [symbolic_ast, domain_specific_type, numeric_representation, proof_object]
+    impact: Prototype validates identity and traceability only.
+    reversibility: fully_reversible
+    status: provisional_engineering_assumption
+  - assumption_id: TLC-EA-THEOREMS-002-001
+    feature_id: TLC-FC-06-THEOREMS-002
+    undefined_property: canonical software type and executable scientific semantics
+    technical_reason: A prototype interface requires a representable boundary.
+    minimal_choice: identity-preserving opaque parameterized payload and unevaluated result
+    alternatives_left_open: [symbolic_ast, domain_specific_type, numeric_representation, proof_object]
+    impact: Prototype validates identity and traceability only.
+    reversibility: fully_reversible
+    status: provisional_engineering_assumption
+  - assumption_id: TLC-EA-THEOREMS-003-001
+    feature_id: TLC-FC-06-THEOREMS-003
+    undefined_property: canonical software type and executable scientific semantics
+    technical_reason: A prototype interface requires a representable boundary.
+    minimal_choice: identity-preserving opaque parameterized payload and unevaluated result
+    alternatives_left_open: [symbolic_ast, domain_specific_type, numeric_representation, proof_object]
+    impact: Prototype validates identity and traceability only.
+    reversibility: fully_reversible
+    status: provisional_engineering_assumption
+  - assumption_id: TLC-EA-THEOREMS-004-001
+    feature_id: TLC-FC-06-THEOREMS-004
+    undefined_property: canonical software type and executable scientific semantics
+    technical_reason: A prototype interface requires a representable boundary.
+    minimal_choice: identity-preserving opaque parameterized payload and unevaluated result
+    alternatives_left_open: [symbolic_ast, domain_specific_type, numeric_representation, proof_object]
+    impact: Prototype validates identity and traceability only.
+    reversibility: fully_reversible
+    status: provisional_engineering_assumption
+  - assumption_id: TLC-EA-THEOREMS-005-001
+    feature_id: TLC-FC-06-THEOREMS-005
+    undefined_property: canonical software type and executable scientific semantics
+    technical_reason: A prototype interface requires a representable boundary.
+    minimal_choice: identity-preserving opaque parameterized payload and unevaluated result
+    alternatives_left_open: [symbolic_ast, domain_specific_type, numeric_representation, proof_object]
+    impact: Prototype validates identity and traceability only.
+    reversibility: fully_reversible
+    status: provisional_engineering_assumption
+  - assumption_id: TLC-EA-THEOREMS-006-001
+    feature_id: TLC-FC-06-THEOREMS-006
+    undefined_property: canonical software type and executable scientific semantics
+    technical_reason: A prototype interface requires a representable boundary.
+    minimal_choice: identity-preserving opaque parameterized payload and unevaluated result
+    alternatives_left_open: [symbolic_ast, domain_specific_type, numeric_representation, proof_object]
+    impact: Prototype validates identity and traceability only.
+    reversibility: fully_reversible
+    status: provisional_engineering_assumption
+  - assumption_id: TLC-EA-THEOREMS-007-001
+    feature_id: TLC-FC-06-THEOREMS-007
+    undefined_property: canonical software type and executable scientific semantics
+    technical_reason: A prototype interface requires a representable boundary.
+    minimal_choice: identity-preserving opaque parameterized payload and unevaluated result
+    alternatives_left_open: [symbolic_ast, domain_specific_type, numeric_representation, proof_object]
+    impact: Prototype validates identity and traceability only.
+    reversibility: fully_reversible
+    status: provisional_engineering_assumption
+  - assumption_id: TLC-EA-THEOREMS-008-001
+    feature_id: TLC-FC-06-THEOREMS-008
+    undefined_property: canonical software type and executable scientific semantics
+    technical_reason: A prototype interface requires a representable boundary.
+    minimal_choice: identity-preserving opaque parameterized payload and unevaluated result
+    alternatives_left_open: [symbolic_ast, domain_specific_type, numeric_representation, proof_object]
+    impact: Prototype validates identity and traceability only.
+    reversibility: fully_reversible
+    status: provisional_engineering_assumption
+  - assumption_id: TLC-EA-THEOREMS-009-001
+    feature_id: TLC-FC-06-THEOREMS-009
+    undefined_property: canonical software type and executable scientific semantics
+    technical_reason: A prototype interface requires a representable boundary.
+    minimal_choice: identity-preserving opaque parameterized payload and unevaluated result
+    alternatives_left_open: [symbolic_ast, domain_specific_type, numeric_representation, proof_object]
+    impact: Prototype validates identity and traceability only.
+    reversibility: fully_reversible
+    status: provisional_engineering_assumption

--- a/registry/math-contracts/TLC-FC-06-THEOREMS-001/contract.yaml
+++ b/registry/math-contracts/TLC-FC-06-THEOREMS-001/contract.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-001-001
+feature_id: TLC-FC-06-THEOREMS-001
+contract_kind: limited_engineering_contract_with_reservations
+scientific_authority: origin/main@f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa
+status: limited_engineering_contract_with_reservations
+functional_purpose: "Assemble an unevaluated conservation-claim descriptor from the cited experiential-energy statement and its external axiom reference."
+software_responsibility:
+  operation: assemble_experiential_conservation_claim
+  observable_effect: "return a descriptor containing the bounded-energy, controlled-variation, and stationary-law clause identifiers without evaluating them"
+source_references: [maths/06-theorems.md:141-144]
+objects_covered: [TLC-SO-THEOREMS-011]
+relations_covered: []
+relations_contextual_only: []
+inputs:
+  - {name: axiom_reference, type: "OpaqueAxiomReference"}
+  - {name: experience_symbol, type: "OpaqueExperienceSymbol"}
+  - {name: claim_clauses, type: "ConservationClauseSet"}
+outputs:
+  - {name: conservation_claim, type: "UnevaluatedConservationClaim"}
+types:
+  opaque: [OpaqueScientificValue, OpaqueScientificExpression]
+  parameterized: [Mapping<K,V>, Sequence<T>]
+preconditions:
+  - "The axiom reference and all three source clause identifiers are present."
+postconditions:
+  - "The result contains exactly the supplied axiom reference, experience symbol, and three unevaluated clause identifiers."
+invariants_explicitly_sourced: []
+errors_or_undefined_behavior:
+  - MISSING_AXIOM_REFERENCE
+  - INCOMPLETE_CONSERVATION_CLAUSES
+  - Scientific evaluation and unstated numeric semantics are undefined.
+unresolved_propagated: []
+provisional_assumptions: [TLC-EA-THEOREMS-001-001]
+scientific_reservations:
+  - The operation organizes source evidence but does not establish theorem truth.
+  - Missing types, units, dimensions, cardinalities, ordering, precision, probability laws, and algorithms remain unspecified.
+strong_dependencies_explicitly_confirmed: []
+documentary_references:
+  - registry/domain-progress/theorems/feature-inventory.yaml
+  - registry/domain-progress/theorems/feature-status.yaml
+  - registry/domain-progress/theorems/result-semantics.yaml
+traceability:
+  feature_kind: constraint_evaluation
+  source_objects: [TLC-SO-THEOREMS-011]
+  source_relations: []
+validation_criteria:
+  - The named operation produces the declared structural result.
+  - The feature-specific precondition, postcondition, and errors are testable.
+  - Every attached unresolved and provisional assumption is propagated unchanged.
+readiness:
+  ready_for_limited_engineering_contract: true
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-06-THEOREMS-002/contract.yaml
+++ b/registry/math-contracts/TLC-FC-06-THEOREMS-002/contract.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-002-001
+feature_id: TLC-FC-06-THEOREMS-002
+contract_kind: limited_engineering_contract_with_reservations
+scientific_authority: origin/main@f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa
+status: limited_engineering_contract_with_reservations
+functional_purpose: "Register the three cited evolution equations as distinct unevaluated dynamics records with their prepared source roles."
+software_responsibility:
+  operation: register_theorem_dynamics_equations
+  observable_effect: "return a registry keyed by the three prepared object identifiers and preserving each equation's declared trajectory, identity-wave, or receptivity role"
+source_references: [maths/06-theorems.md:109-111, maths/06-theorems.md:118-120, maths/06-theorems.md:133-135]
+objects_covered: [TLC-SO-THEOREMS-027, TLC-SO-THEOREMS-028, TLC-SO-THEOREMS-030]
+relations_covered: []
+relations_contextual_only: []
+inputs:
+  - {name: equation_records, type: "Mapping<ScientificObjectId,OpaqueEquation>"}
+  - {name: declared_roles, type: "Mapping<ScientificObjectId,DynamicsRole>"}
+outputs:
+  - {name: dynamics_registry, type: "DynamicsEquationRegistry"}
+types:
+  opaque: [OpaqueScientificValue, OpaqueScientificExpression]
+  parameterized: [Mapping<K,V>, Sequence<T>]
+preconditions:
+  - "Every covered object has one opaque equation and one prepared role."
+postconditions:
+  - "The registry has one entry for each covered object and never evaluates a derivative or evolution law."
+invariants_explicitly_sourced: []
+errors_or_undefined_behavior:
+  - MISSING_DYNAMICS_EQUATION
+  - UNKNOWN_DYNAMICS_ROLE
+  - DUPLICATE_SCIENTIFIC_OBJECT
+  - Scientific evaluation and unstated numeric semantics are undefined.
+unresolved_propagated: []
+provisional_assumptions: [TLC-EA-THEOREMS-002-001]
+scientific_reservations:
+  - The operation organizes source evidence but does not establish theorem truth.
+  - Missing types, units, dimensions, cardinalities, ordering, precision, probability laws, and algorithms remain unspecified.
+strong_dependencies_explicitly_confirmed: []
+documentary_references:
+  - registry/domain-progress/theorems/feature-inventory.yaml
+  - registry/domain-progress/theorems/feature-status.yaml
+  - registry/domain-progress/theorems/result-semantics.yaml
+traceability:
+  feature_kind: evolution_dynamics
+  source_objects: [TLC-SO-THEOREMS-027, TLC-SO-THEOREMS-028, TLC-SO-THEOREMS-030]
+  source_relations: []
+validation_criteria:
+  - The named operation produces the declared structural result.
+  - The feature-specific precondition, postcondition, and errors are testable.
+  - Every attached unresolved and provisional assumption is propagated unchanged.
+readiness:
+  ready_for_limited_engineering_contract: true
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-06-THEOREMS-003/contract.yaml
+++ b/registry/math-contracts/TLC-FC-06-THEOREMS-003/contract.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-003-001
+feature_id: TLC-FC-06-THEOREMS-003
+contract_kind: limited_engineering_contract_with_reservations
+scientific_authority: origin/main@f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa
+status: limited_engineering_contract_with_reservations
+functional_purpose: "Build a source-addressable catalogue of the four explicit theorem equations without evaluating or normalizing their mathematical expressions."
+software_responsibility:
+  operation: catalogue_explicit_theorem_equations
+  observable_effect: "return entries addressable by source object and equation role for stability bound, emergence probability, trajectory convergence, and wave speed"
+source_references: [maths/06-theorems.md:24-26, maths/06-theorems.md:35-37, maths/06-theorems.md:102-104, maths/06-theorems.md:122-124]
+objects_covered: [TLC-SO-THEOREMS-016, TLC-SO-THEOREMS-017, TLC-SO-THEOREMS-026, TLC-SO-THEOREMS-029]
+relations_covered: []
+relations_contextual_only: []
+inputs:
+  - {name: equation_entries, type: "Sequence<TheoremEquationEntry>"}
+outputs:
+  - {name: equation_catalogue, type: "TheoremEquationCatalogue"}
+types:
+  opaque: [OpaqueScientificValue, OpaqueScientificExpression]
+  parameterized: [Mapping<K,V>, Sequence<T>]
+preconditions:
+  - "Each of the four covered objects occurs exactly once with a source reference and opaque expression."
+postconditions:
+  - "The catalogue exposes four distinct roles and preserves each expression unchanged."
+invariants_explicitly_sourced: []
+errors_or_undefined_behavior:
+  - MISSING_EQUATION_ROLE
+  - DUPLICATE_EQUATION_ROLE
+  - MISSING_SOURCE_REFERENCE
+  - Scientific evaluation and unstated numeric semantics are undefined.
+unresolved_propagated: []
+provisional_assumptions: [TLC-EA-THEOREMS-003-001]
+scientific_reservations:
+  - The operation organizes source evidence but does not establish theorem truth.
+  - Missing types, units, dimensions, cardinalities, ordering, precision, probability laws, and algorithms remain unspecified.
+strong_dependencies_explicitly_confirmed: []
+documentary_references:
+  - registry/domain-progress/theorems/feature-inventory.yaml
+  - registry/domain-progress/theorems/feature-status.yaml
+  - registry/domain-progress/theorems/result-semantics.yaml
+traceability:
+  feature_kind: transformation
+  source_objects: [TLC-SO-THEOREMS-016, TLC-SO-THEOREMS-017, TLC-SO-THEOREMS-026, TLC-SO-THEOREMS-029]
+  source_relations: []
+validation_criteria:
+  - The named operation produces the declared structural result.
+  - The feature-specific precondition, postcondition, and errors are testable.
+  - Every attached unresolved and provisional assumption is propagated unchanged.
+readiness:
+  ready_for_limited_engineering_contract: true
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-06-THEOREMS-004/contract.yaml
+++ b/registry/math-contracts/TLC-FC-06-THEOREMS-004/contract.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-004-001
+feature_id: TLC-FC-06-THEOREMS-004
+contract_kind: limited_engineering_contract_with_reservations
+scientific_authority: origin/main@f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa
+status: limited_engineering_contract_with_reservations
+functional_purpose: "Construct the transmission-ergodicity hypothesis record cited by the community-stability theorem."
+software_responsibility:
+  operation: construct_transmission_ergodicity_hypothesis
+  observable_effect: "bind the operator symbol and its cited uniform-ergodicity condition into one traceable, unevaluated hypothesis record"
+source_references: [maths/06-theorems.md:20]
+objects_covered: [TLC-SO-THEOREMS-014]
+relations_covered: []
+relations_contextual_only: []
+inputs:
+  - {name: transmission_operator, type: "OpaqueOperatorSymbol"}
+  - {name: ergodicity_condition, type: "OpaqueSpectralGapCondition"}
+outputs:
+  - {name: operator_hypothesis, type: "TransmissionErgodicityHypothesis"}
+types:
+  opaque: [OpaqueScientificValue, OpaqueScientificExpression]
+  parameterized: [Mapping<K,V>, Sequence<T>]
+preconditions:
+  - "Both the transmission operator and spectral-gap condition carry the line-20 source reference."
+postconditions:
+  - "The result preserves both opaque components and labels the record as a hypothesis rather than a verified property."
+invariants_explicitly_sourced: []
+errors_or_undefined_behavior:
+  - MISSING_OPERATOR_SYMBOL
+  - MISSING_ERGODICITY_CONDITION
+  - SOURCE_REFERENCE_MISMATCH
+  - Scientific evaluation and unstated numeric semantics are undefined.
+unresolved_propagated: []
+provisional_assumptions: [TLC-EA-THEOREMS-004-001]
+scientific_reservations:
+  - The operation organizes source evidence but does not establish theorem truth.
+  - Missing types, units, dimensions, cardinalities, ordering, precision, probability laws, and algorithms remain unspecified.
+strong_dependencies_explicitly_confirmed: []
+documentary_references:
+  - registry/domain-progress/theorems/feature-inventory.yaml
+  - registry/domain-progress/theorems/feature-status.yaml
+  - registry/domain-progress/theorems/result-semantics.yaml
+traceability:
+  feature_kind: scientific_operator
+  source_objects: [TLC-SO-THEOREMS-014]
+  source_relations: []
+validation_criteria:
+  - The named operation produces the declared structural result.
+  - The feature-specific precondition, postcondition, and errors are testable.
+  - Every attached unresolved and provisional assumption is propagated unchanged.
+readiness:
+  ready_for_limited_engineering_contract: true
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-06-THEOREMS-005/contract.yaml
+++ b/registry/math-contracts/TLC-FC-06-THEOREMS-005/contract.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-005-001
+feature_id: TLC-FC-06-THEOREMS-005
+contract_kind: limited_engineering_contract_with_reservations
+scientific_authority: origin/main@f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa
+status: limited_engineering_contract_with_reservations
+functional_purpose: "Register the two CNS operator claims: the source transformation signature and the per-dimension removal-effect claim."
+software_responsibility:
+  operation: register_cns_operator_claims
+  observable_effect: "return a claim set separating the transformation signature from the dimension-removal effects while leaving completeness and necessity unevaluated"
+source_references: [maths/06-theorems.md:54-55, maths/06-theorems.md:66-67]
+objects_covered: [TLC-SO-THEOREMS-005, TLC-SO-THEOREMS-006]
+relations_covered: []
+relations_contextual_only: []
+inputs:
+  - {name: transformation_claim, type: "OpaqueTransformationClaim"}
+  - {name: dimension_removal_claims, type: "Mapping<DimensionId,OpaqueRemovalEffectClaim>"}
+outputs:
+  - {name: cns_operator_claims, type: "CNSOperatorClaimSet"}
+types:
+  opaque: [OpaqueScientificValue, OpaqueScientificExpression]
+  parameterized: [Mapping<K,V>, Sequence<T>]
+preconditions:
+  - "The transformation claim cites lines 54-55 and every removal claim cites lines 66-67."
+postconditions:
+  - "The two claim families remain separately addressable and retain blocked-local scientific status."
+invariants_explicitly_sourced: []
+errors_or_undefined_behavior:
+  - MISSING_TRANSFORMATION_CLAIM
+  - MISSING_REMOVAL_CLAIM_SOURCE
+  - CLAIM_FAMILY_COLLISION
+  - Scientific evaluation and unstated numeric semantics are undefined.
+unresolved_propagated: []
+provisional_assumptions: [TLC-EA-THEOREMS-005-001]
+scientific_reservations:
+  - The operation organizes source evidence but does not establish theorem truth.
+  - Missing types, units, dimensions, cardinalities, ordering, precision, probability laws, and algorithms remain unspecified.
+strong_dependencies_explicitly_confirmed: []
+documentary_references:
+  - registry/domain-progress/theorems/feature-inventory.yaml
+  - registry/domain-progress/theorems/feature-status.yaml
+  - registry/domain-progress/theorems/result-semantics.yaml
+traceability:
+  feature_kind: scientific_operator
+  source_objects: [TLC-SO-THEOREMS-005, TLC-SO-THEOREMS-006]
+  source_relations: []
+validation_criteria:
+  - The named operation produces the declared structural result.
+  - The feature-specific precondition, postcondition, and errors are testable.
+  - Every attached unresolved and provisional assumption is propagated unchanged.
+readiness:
+  ready_for_limited_engineering_contract: true
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-06-THEOREMS-006/contract.yaml
+++ b/registry/math-contracts/TLC-FC-06-THEOREMS-006/contract.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-006-001
+feature_id: TLC-FC-06-THEOREMS-006
+contract_kind: limited_engineering_contract_with_reservations
+scientific_authority: origin/main@f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa
+status: limited_engineering_contract_with_reservations
+functional_purpose: "Index the six prepared theorem declarations for lookup by scientific object identifier, retaining statement, source, and proof-status metadata."
+software_responsibility:
+  operation: index_theorem_declarations
+  observable_effect: "return a six-entry index supporting identifier lookup and preserving each declaration's partial or absent proof status"
+source_references: [maths/06-theorems.md:13-16, maths/06-theorems.md:31-38, maths/06-theorems.md:49-52, maths/06-theorems.md:92-95, maths/06-theorems.md:114-124, maths/06-theorems.md:129-136]
+objects_covered: [TLC-SO-THEOREMS-002, TLC-SO-THEOREMS-003, TLC-SO-THEOREMS-004, TLC-SO-THEOREMS-008, TLC-SO-THEOREMS-009, TLC-SO-THEOREMS-010]
+relations_covered: []
+relations_contextual_only: []
+inputs:
+  - {name: declarations, type: "Sequence<OpaqueTheoremDeclaration>"}
+  - {name: proof_statuses, type: "Mapping<ScientificObjectId,ProofStatus>"}
+outputs:
+  - {name: theorem_index, type: "TheoremDeclarationIndex"}
+types:
+  opaque: [OpaqueScientificValue, OpaqueScientificExpression]
+  parameterized: [Mapping<K,V>, Sequence<T>]
+preconditions:
+  - "Each covered theorem object occurs exactly once and has a source reference plus proof status."
+postconditions:
+  - "Lookup returns the unchanged declaration metadata and never returns a theorem truth value."
+invariants_explicitly_sourced: []
+errors_or_undefined_behavior:
+  - DUPLICATE_THEOREM_ID
+  - MISSING_PROOF_STATUS
+  - UNKNOWN_THEOREM_ID
+  - Scientific evaluation and unstated numeric semantics are undefined.
+unresolved_propagated: []
+provisional_assumptions: [TLC-EA-THEOREMS-006-001]
+scientific_reservations:
+  - The operation organizes source evidence but does not establish theorem truth.
+  - Missing types, units, dimensions, cardinalities, ordering, precision, probability laws, and algorithms remain unspecified.
+strong_dependencies_explicitly_confirmed: []
+documentary_references:
+  - registry/domain-progress/theorems/feature-inventory.yaml
+  - registry/domain-progress/theorems/feature-status.yaml
+  - registry/domain-progress/theorems/result-semantics.yaml
+traceability:
+  feature_kind: theorem_collection
+  source_objects: [TLC-SO-THEOREMS-002, TLC-SO-THEOREMS-003, TLC-SO-THEOREMS-004, TLC-SO-THEOREMS-008, TLC-SO-THEOREMS-009, TLC-SO-THEOREMS-010]
+  source_relations: []
+validation_criteria:
+  - The named operation produces the declared structural result.
+  - The feature-specific precondition, postcondition, and errors are testable.
+  - Every attached unresolved and provisional assumption is propagated unchanged.
+readiness:
+  ready_for_limited_engineering_contract: true
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-06-THEOREMS-007/contract.yaml
+++ b/registry/math-contracts/TLC-FC-06-THEOREMS-007/contract.yaml
@@ -1,0 +1,60 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-007-001
+feature_id: TLC-FC-06-THEOREMS-007
+contract_kind: limited_engineering_contract_with_reservations
+scientific_authority: origin/main@f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa
+status: limited_engineering_contract_with_reservations
+functional_purpose: "Construct the source-traceable community-stability context used by theorem C5 from the prepared state objects and relations."
+software_responsibility:
+  operation: construct_community_stability_state
+  observable_effect: "return a descriptor linking sequence, limit, and cited relation components without asserting convergence or stability"
+source_references: [maths/06-theorems.md:1-5, maths/06-theorems.md:18-21]
+objects_covered: [TLC-SO-THEOREMS-001, TLC-SO-THEOREMS-012, TLC-SO-THEOREMS-013, TLC-SO-THEOREMS-015]
+relations_covered: [TLC-SR-THEOREMS-011, TLC-SR-THEOREMS-012, TLC-SR-THEOREMS-014]
+relations_contextual_only: []
+inputs:
+  - {name: community_sequence, type: "OpaqueCommunitySequence"}
+  - {name: limit_community, type: "OpaqueCommunityState"}
+  - {name: stability_context, type: "CommunityStabilityContextComponents"}
+outputs:
+  - {name: community_stability_state, type: "CommunityStabilityStateDescriptor"}
+types:
+  opaque: [OpaqueScientificValue, OpaqueScientificExpression]
+  parameterized: [Mapping<K,V>, Sequence<T>]
+preconditions:
+  - "The sequence and limit identities exist and every covered relation references a covered state component."
+postconditions:
+  - "The descriptor preserves all four object IDs, three relation IDs, and three unresolved term IDs."
+invariants_explicitly_sourced: []
+errors_or_undefined_behavior:
+  - MISSING_COMMUNITY_SEQUENCE
+  - MISSING_LIMIT_STATE
+  - DANGLING_STABILITY_RELATION
+  - Scientific evaluation and unstated numeric semantics are undefined.
+unresolved_propagated: [TLC-UT-THEOREMS-002, TLC-UT-THEOREMS-003, TLC-UT-THEOREMS-004]
+provisional_assumptions: [TLC-EA-THEOREMS-007-001]
+scientific_reservations:
+  - The operation organizes source evidence but does not establish theorem truth.
+  - Missing types, units, dimensions, cardinalities, ordering, precision, probability laws, and algorithms remain unspecified.
+strong_dependencies_explicitly_confirmed: []
+documentary_references:
+  - registry/domain-progress/theorems/feature-inventory.yaml
+  - registry/domain-progress/theorems/feature-status.yaml
+  - registry/domain-progress/theorems/result-semantics.yaml
+traceability:
+  feature_kind: state_representation
+  source_objects: [TLC-SO-THEOREMS-001, TLC-SO-THEOREMS-012, TLC-SO-THEOREMS-013, TLC-SO-THEOREMS-015]
+  source_relations: [TLC-SR-THEOREMS-011, TLC-SR-THEOREMS-012, TLC-SR-THEOREMS-014]
+validation_criteria:
+  - The named operation produces the declared structural result.
+  - The feature-specific precondition, postcondition, and errors are testable.
+  - Every attached unresolved and provisional assumption is propagated unchanged.
+readiness:
+  ready_for_limited_engineering_contract: true
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-06-THEOREMS-008/contract.yaml
+++ b/registry/math-contracts/TLC-FC-06-THEOREMS-008/contract.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-008-001
+feature_id: TLC-FC-06-THEOREMS-008
+contract_kind: limited_engineering_contract_with_reservations
+scientific_authority: origin/main@f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa
+status: limited_engineering_contract_with_reservations
+functional_purpose: "Assemble the eight source-enumerated sufficiency-role records into a dimension-role bundle while preserving unresolved cross-domain mappings."
+software_responsibility:
+  operation: assemble_eight_dimension_sufficiency_roles
+  observable_effect: "return an eight-entry bundle preserving source ordinals 1 through 8, role labels, and unresolved mapping identifiers without asserting sufficiency"
+source_references: [maths/06-theorems.md:78-88]
+objects_covered: [TLC-SO-THEOREMS-007, TLC-SO-THEOREMS-018, TLC-SO-THEOREMS-020, TLC-SO-THEOREMS-021, TLC-SO-THEOREMS-022, TLC-SO-THEOREMS-023, TLC-SO-THEOREMS-024, TLC-SO-THEOREMS-025]
+relations_covered: []
+relations_contextual_only: []
+inputs:
+  - {name: dimension_roles, type: "Mapping<SourceOrdinal,OpaqueDimensionRole>"}
+  - {name: cross_domain_mappings, type: "Mapping<OpaqueDimensionRole,UnresolvedMappingId>"}
+outputs:
+  - {name: sufficiency_role_bundle, type: "EightDimensionSufficiencyRoleBundle"}
+types:
+  opaque: [OpaqueScientificValue, OpaqueScientificExpression]
+  parameterized: [Mapping<K,V>, Sequence<T>]
+preconditions:
+  - "Exactly the eight source ordinals are present and every unresolved mapping remains attached to its role."
+postconditions:
+  - "The bundle contains Message, Principles, Values, Virtues, Capacities, Competencies, Practice, and Lived Experience once each in source order."
+invariants_explicitly_sourced: []
+errors_or_undefined_behavior:
+  - MISSING_DIMENSION_ROLE
+  - DUPLICATE_SOURCE_ORDINAL
+  - DROPPED_CROSS_DOMAIN_UNRESOLVED
+  - Scientific evaluation and unstated numeric semantics are undefined.
+unresolved_propagated: [TLC-UT-THEOREMS-001, TLC-UT-THEOREMS-005, TLC-UT-THEOREMS-007, TLC-UT-THEOREMS-008, TLC-UT-THEOREMS-009, TLC-UT-THEOREMS-010, TLC-UT-THEOREMS-011, TLC-UT-THEOREMS-012]
+provisional_assumptions: [TLC-EA-THEOREMS-008-001]
+scientific_reservations:
+  - The operation organizes source evidence but does not establish theorem truth.
+  - Missing types, units, dimensions, cardinalities, ordering, precision, probability laws, and algorithms remain unspecified.
+strong_dependencies_explicitly_confirmed: []
+documentary_references:
+  - registry/domain-progress/theorems/feature-inventory.yaml
+  - registry/domain-progress/theorems/feature-status.yaml
+  - registry/domain-progress/theorems/result-semantics.yaml
+traceability:
+  feature_kind: state_representation
+  source_objects: [TLC-SO-THEOREMS-007, TLC-SO-THEOREMS-018, TLC-SO-THEOREMS-020, TLC-SO-THEOREMS-021, TLC-SO-THEOREMS-022, TLC-SO-THEOREMS-023, TLC-SO-THEOREMS-024, TLC-SO-THEOREMS-025]
+  source_relations: []
+validation_criteria:
+  - The named operation produces the declared structural result.
+  - The feature-specific precondition, postcondition, and errors are testable.
+  - Every attached unresolved and provisional assumption is propagated unchanged.
+readiness:
+  ready_for_limited_engineering_contract: true
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/math-contracts/TLC-FC-06-THEOREMS-009/contract.yaml
+++ b/registry/math-contracts/TLC-FC-06-THEOREMS-009/contract.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-009-001
+feature_id: TLC-FC-06-THEOREMS-009
+contract_kind: limited_engineering_contract_with_reservations
+scientific_authority: origin/main@f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa
+status: limited_engineering_contract_with_reservations
+functional_purpose: "Construct the isolated Principles role descriptor from the provisionally separated source statement at line 82."
+software_responsibility:
+  operation: construct_principles_role_descriptor
+  observable_effect: "return a descriptor identifying Principles, source ordinal 2, and the cited rational-coherence label without defining coherence"
+source_references: [maths/06-theorems.md:82]
+objects_covered: [TLC-SO-THEOREMS-019]
+relations_covered: []
+relations_contextual_only: []
+inputs:
+  - {name: principles_role, type: "OpaqueDimensionRole"}
+  - {name: source_ordinal, type: "SourceOrdinal"}
+outputs:
+  - {name: principles_descriptor, type: "PrinciplesRoleDescriptor"}
+types:
+  opaque: [OpaqueScientificValue, OpaqueScientificExpression]
+  parameterized: [Mapping<K,V>, Sequence<T>]
+preconditions:
+  - "The supplied role cites line 82 and carries unresolved identifier TLC-UT-THEOREMS-006."
+postconditions:
+  - "The descriptor is labelled Principles and preserves ordinal 2, the opaque role payload, and its unresolved identifier."
+invariants_explicitly_sourced: []
+errors_or_undefined_behavior:
+  - WRONG_DIMENSION_LABEL
+  - WRONG_SOURCE_ORDINAL
+  - MISSING_PRINCIPLES_UNRESOLVED
+  - Scientific evaluation and unstated numeric semantics are undefined.
+unresolved_propagated: [TLC-UT-THEOREMS-006]
+provisional_assumptions: [TLC-EA-THEOREMS-009-001]
+scientific_reservations:
+  - The operation organizes source evidence but does not establish theorem truth.
+  - Missing types, units, dimensions, cardinalities, ordering, precision, probability laws, and algorithms remain unspecified.
+strong_dependencies_explicitly_confirmed: []
+documentary_references:
+  - registry/domain-progress/theorems/feature-inventory.yaml
+  - registry/domain-progress/theorems/feature-status.yaml
+  - registry/domain-progress/theorems/result-semantics.yaml
+traceability:
+  feature_kind: state_representation
+  source_objects: [TLC-SO-THEOREMS-019]
+  source_relations: []
+validation_criteria:
+  - The named operation produces the declared structural result.
+  - The feature-specific precondition, postcondition, and errors are testable.
+  - Every attached unresolved and provisional assumption is propagated unchanged.
+readiness:
+  ready_for_limited_engineering_contract: true
+  ready_for_prototype_ir: true
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_canonical_ir: false
+  ready_for_production_implementation: false
+  human_validation_required_before_prototype_work: false
+  human_validation_required_before_canonical_release: true

--- a/registry/test-plans/TLC-FC-06-THEOREMS-001/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-06-THEOREMS-001/test-plan.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-001-001
+feature_id: TLC-FC-06-THEOREMS-001
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-001-001
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-001-001
+operation_under_test: assemble_experiential_conservation_claim
+status: planned
+tests:
+  - {id: TEST-001-NOMINAL, kind: nominal, assertion: "invoke assemble_experiential_conservation_claim with complete feature evidence and obtain conservation_claim"}
+  - {id: TEST-001-EFFECT, kind: observable_effect, assertion: "return a descriptor containing the bounded-energy, controlled-variation, and stationary-law clause identifiers without evaluating them"}
+  - {id: TEST-001-BOUNDARY, kind: opaque_boundary, assertion: "an opaque experience symbol is preserved byte-for-byte"}
+  - {id: TEST-001-PRECONDITION, kind: precondition, assertion: "reject input when: The axiom reference and all three source clause identifiers are present."}
+  - {id: TEST-001-ERROR, kind: failure, assertion: "the first violated precondition returns one of: MISSING_AXIOM_REFERENCE, INCOMPLETE_CONSERVATION_CLAUSES"}
+  - {id: TEST-001-POSTCONDITION, kind: postcondition, assertion: "The result contains exactly the supplied axiom reference, experience symbol, and three unevaluated clause identifiers."}
+  - {id: TEST-001-DETERMINISM, kind: determinism, assertion: identical structural inputs produce an identical structural result}
+  - {id: TEST-001-RESERVATIONS, kind: reservation_propagation, assertion: "preserve unresolved set (empty) and assumption TLC-EA-THEOREMS-001-001"}
+  - {id: TEST-001-TRACE, kind: traceability, assertion: preserve every feature-specific source object relation and line reference}
+  - {id: TEST-001-CONFORMANCE, kind: contract_ir_conformance, assertion: entrypoint inputs output errors and readiness match contract and IR}
+numeric_expected_results: forbidden
+implementation_status: no_test_code_created

--- a/registry/test-plans/TLC-FC-06-THEOREMS-002/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-06-THEOREMS-002/test-plan.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-002-001
+feature_id: TLC-FC-06-THEOREMS-002
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-002-001
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-002-001
+operation_under_test: register_theorem_dynamics_equations
+status: planned
+tests:
+  - {id: TEST-002-NOMINAL, kind: nominal, assertion: "invoke register_theorem_dynamics_equations with complete feature evidence and obtain dynamics_registry"}
+  - {id: TEST-002-EFFECT, kind: observable_effect, assertion: "return a registry keyed by the three prepared object identifiers and preserving each equation's declared trajectory, identity-wave, or receptivity role"}
+  - {id: TEST-002-BOUNDARY, kind: opaque_boundary, assertion: "opaque equation payloads with distinct roles remain distinct"}
+  - {id: TEST-002-PRECONDITION, kind: precondition, assertion: "reject input when: Every covered object has one opaque equation and one prepared role."}
+  - {id: TEST-002-ERROR, kind: failure, assertion: "the first violated precondition returns one of: MISSING_DYNAMICS_EQUATION, UNKNOWN_DYNAMICS_ROLE, DUPLICATE_SCIENTIFIC_OBJECT"}
+  - {id: TEST-002-POSTCONDITION, kind: postcondition, assertion: "The registry has one entry for each covered object and never evaluates a derivative or evolution law."}
+  - {id: TEST-002-DETERMINISM, kind: determinism, assertion: identical structural inputs produce an identical structural result}
+  - {id: TEST-002-RESERVATIONS, kind: reservation_propagation, assertion: "preserve unresolved set (empty) and assumption TLC-EA-THEOREMS-002-001"}
+  - {id: TEST-002-TRACE, kind: traceability, assertion: preserve every feature-specific source object relation and line reference}
+  - {id: TEST-002-CONFORMANCE, kind: contract_ir_conformance, assertion: entrypoint inputs output errors and readiness match contract and IR}
+numeric_expected_results: forbidden
+implementation_status: no_test_code_created

--- a/registry/test-plans/TLC-FC-06-THEOREMS-003/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-06-THEOREMS-003/test-plan.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-003-001
+feature_id: TLC-FC-06-THEOREMS-003
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-003-001
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-003-001
+operation_under_test: catalogue_explicit_theorem_equations
+status: planned
+tests:
+  - {id: TEST-003-NOMINAL, kind: nominal, assertion: "invoke catalogue_explicit_theorem_equations with complete feature evidence and obtain equation_catalogue"}
+  - {id: TEST-003-EFFECT, kind: observable_effect, assertion: "return entries addressable by source object and equation role for stability bound, emergence probability, trajectory convergence, and wave speed"}
+  - {id: TEST-003-BOUNDARY, kind: opaque_boundary, assertion: "an unevaluated expression is stored without algebraic normalization"}
+  - {id: TEST-003-PRECONDITION, kind: precondition, assertion: "reject input when: Each of the four covered objects occurs exactly once with a source reference and opaque expression."}
+  - {id: TEST-003-ERROR, kind: failure, assertion: "the first violated precondition returns one of: MISSING_EQUATION_ROLE, DUPLICATE_EQUATION_ROLE, MISSING_SOURCE_REFERENCE"}
+  - {id: TEST-003-POSTCONDITION, kind: postcondition, assertion: "The catalogue exposes four distinct roles and preserves each expression unchanged."}
+  - {id: TEST-003-DETERMINISM, kind: determinism, assertion: identical structural inputs produce an identical structural result}
+  - {id: TEST-003-RESERVATIONS, kind: reservation_propagation, assertion: "preserve unresolved set (empty) and assumption TLC-EA-THEOREMS-003-001"}
+  - {id: TEST-003-TRACE, kind: traceability, assertion: preserve every feature-specific source object relation and line reference}
+  - {id: TEST-003-CONFORMANCE, kind: contract_ir_conformance, assertion: entrypoint inputs output errors and readiness match contract and IR}
+numeric_expected_results: forbidden
+implementation_status: no_test_code_created

--- a/registry/test-plans/TLC-FC-06-THEOREMS-004/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-06-THEOREMS-004/test-plan.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-004-001
+feature_id: TLC-FC-06-THEOREMS-004
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-004-001
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-004-001
+operation_under_test: construct_transmission_ergodicity_hypothesis
+status: planned
+tests:
+  - {id: TEST-004-NOMINAL, kind: nominal, assertion: "invoke construct_transmission_ergodicity_hypothesis with complete feature evidence and obtain operator_hypothesis"}
+  - {id: TEST-004-EFFECT, kind: observable_effect, assertion: "bind the operator symbol and its cited uniform-ergodicity condition into one traceable, unevaluated hypothesis record"}
+  - {id: TEST-004-BOUNDARY, kind: opaque_boundary, assertion: "no spectral gap value or operator behavior is computed"}
+  - {id: TEST-004-PRECONDITION, kind: precondition, assertion: "reject input when: Both the transmission operator and spectral-gap condition carry the line-20 source reference."}
+  - {id: TEST-004-ERROR, kind: failure, assertion: "the first violated precondition returns one of: MISSING_OPERATOR_SYMBOL, MISSING_ERGODICITY_CONDITION, SOURCE_REFERENCE_MISMATCH"}
+  - {id: TEST-004-POSTCONDITION, kind: postcondition, assertion: "The result preserves both opaque components and labels the record as a hypothesis rather than a verified property."}
+  - {id: TEST-004-DETERMINISM, kind: determinism, assertion: identical structural inputs produce an identical structural result}
+  - {id: TEST-004-RESERVATIONS, kind: reservation_propagation, assertion: "preserve unresolved set (empty) and assumption TLC-EA-THEOREMS-004-001"}
+  - {id: TEST-004-TRACE, kind: traceability, assertion: preserve every feature-specific source object relation and line reference}
+  - {id: TEST-004-CONFORMANCE, kind: contract_ir_conformance, assertion: entrypoint inputs output errors and readiness match contract and IR}
+numeric_expected_results: forbidden
+implementation_status: no_test_code_created

--- a/registry/test-plans/TLC-FC-06-THEOREMS-005/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-06-THEOREMS-005/test-plan.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-005-001
+feature_id: TLC-FC-06-THEOREMS-005
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-005-001
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-005-001
+operation_under_test: register_cns_operator_claims
+status: planned
+tests:
+  - {id: TEST-005-NOMINAL, kind: nominal, assertion: "invoke register_cns_operator_claims with complete feature evidence and obtain cns_operator_claims"}
+  - {id: TEST-005-EFFECT, kind: observable_effect, assertion: "return a claim set separating the transformation signature from the dimension-removal effects while leaving completeness and necessity unevaluated"}
+  - {id: TEST-005-BOUNDARY, kind: opaque_boundary, assertion: "removal effects remain opaque and are not executed"}
+  - {id: TEST-005-PRECONDITION, kind: precondition, assertion: "reject input when: The transformation claim cites lines 54-55 and every removal claim cites lines 66-67."}
+  - {id: TEST-005-ERROR, kind: failure, assertion: "the first violated precondition returns one of: MISSING_TRANSFORMATION_CLAIM, MISSING_REMOVAL_CLAIM_SOURCE, CLAIM_FAMILY_COLLISION"}
+  - {id: TEST-005-POSTCONDITION, kind: postcondition, assertion: "The two claim families remain separately addressable and retain blocked-local scientific status."}
+  - {id: TEST-005-DETERMINISM, kind: determinism, assertion: identical structural inputs produce an identical structural result}
+  - {id: TEST-005-RESERVATIONS, kind: reservation_propagation, assertion: "preserve unresolved set (empty) and assumption TLC-EA-THEOREMS-005-001"}
+  - {id: TEST-005-TRACE, kind: traceability, assertion: preserve every feature-specific source object relation and line reference}
+  - {id: TEST-005-CONFORMANCE, kind: contract_ir_conformance, assertion: entrypoint inputs output errors and readiness match contract and IR}
+numeric_expected_results: forbidden
+implementation_status: no_test_code_created

--- a/registry/test-plans/TLC-FC-06-THEOREMS-006/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-06-THEOREMS-006/test-plan.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-006-001
+feature_id: TLC-FC-06-THEOREMS-006
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-006-001
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-006-001
+operation_under_test: index_theorem_declarations
+status: planned
+tests:
+  - {id: TEST-006-NOMINAL, kind: nominal, assertion: "invoke index_theorem_declarations with complete feature evidence and obtain theorem_index"}
+  - {id: TEST-006-EFFECT, kind: observable_effect, assertion: "return a six-entry index supporting identifier lookup and preserving each declaration's partial or absent proof status"}
+  - {id: TEST-006-BOUNDARY, kind: opaque_boundary, assertion: "a declaration with absent proof remains queryable but unevaluated"}
+  - {id: TEST-006-PRECONDITION, kind: precondition, assertion: "reject input when: Each covered theorem object occurs exactly once and has a source reference plus proof status."}
+  - {id: TEST-006-ERROR, kind: failure, assertion: "the first violated precondition returns one of: DUPLICATE_THEOREM_ID, MISSING_PROOF_STATUS, UNKNOWN_THEOREM_ID"}
+  - {id: TEST-006-POSTCONDITION, kind: postcondition, assertion: "Lookup returns the unchanged declaration metadata and never returns a theorem truth value."}
+  - {id: TEST-006-DETERMINISM, kind: determinism, assertion: identical structural inputs produce an identical structural result}
+  - {id: TEST-006-RESERVATIONS, kind: reservation_propagation, assertion: "preserve unresolved set (empty) and assumption TLC-EA-THEOREMS-006-001"}
+  - {id: TEST-006-TRACE, kind: traceability, assertion: preserve every feature-specific source object relation and line reference}
+  - {id: TEST-006-CONFORMANCE, kind: contract_ir_conformance, assertion: entrypoint inputs output errors and readiness match contract and IR}
+numeric_expected_results: forbidden
+implementation_status: no_test_code_created

--- a/registry/test-plans/TLC-FC-06-THEOREMS-007/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-06-THEOREMS-007/test-plan.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-007-001
+feature_id: TLC-FC-06-THEOREMS-007
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-007-001
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-007-001
+operation_under_test: construct_community_stability_state
+status: planned
+tests:
+  - {id: TEST-007-NOMINAL, kind: nominal, assertion: "invoke construct_community_stability_state with complete feature evidence and obtain community_stability_state"}
+  - {id: TEST-007-EFFECT, kind: observable_effect, assertion: "return a descriptor linking sequence, limit, and cited relation components without asserting convergence or stability"}
+  - {id: TEST-007-BOUNDARY, kind: opaque_boundary, assertion: "unresolved community, convergence, and stability semantics remain attached"}
+  - {id: TEST-007-PRECONDITION, kind: precondition, assertion: "reject input when: The sequence and limit identities exist and every covered relation references a covered state component."}
+  - {id: TEST-007-ERROR, kind: failure, assertion: "the first violated precondition returns one of: MISSING_COMMUNITY_SEQUENCE, MISSING_LIMIT_STATE, DANGLING_STABILITY_RELATION"}
+  - {id: TEST-007-POSTCONDITION, kind: postcondition, assertion: "The descriptor preserves all four object IDs, three relation IDs, and three unresolved term IDs."}
+  - {id: TEST-007-DETERMINISM, kind: determinism, assertion: identical structural inputs produce an identical structural result}
+  - {id: TEST-007-RESERVATIONS, kind: reservation_propagation, assertion: "preserve unresolved TLC-UT-THEOREMS-002, TLC-UT-THEOREMS-003, TLC-UT-THEOREMS-004 and assumption TLC-EA-THEOREMS-007-001"}
+  - {id: TEST-007-TRACE, kind: traceability, assertion: preserve every feature-specific source object relation and line reference}
+  - {id: TEST-007-CONFORMANCE, kind: contract_ir_conformance, assertion: entrypoint inputs output errors and readiness match contract and IR}
+numeric_expected_results: forbidden
+implementation_status: no_test_code_created

--- a/registry/test-plans/TLC-FC-06-THEOREMS-008/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-06-THEOREMS-008/test-plan.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-008-001
+feature_id: TLC-FC-06-THEOREMS-008
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-008-001
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-008-001
+operation_under_test: assemble_eight_dimension_sufficiency_roles
+status: planned
+tests:
+  - {id: TEST-008-NOMINAL, kind: nominal, assertion: "invoke assemble_eight_dimension_sufficiency_roles with complete feature evidence and obtain sufficiency_role_bundle"}
+  - {id: TEST-008-EFFECT, kind: observable_effect, assertion: "return an eight-entry bundle preserving source ordinals 1 through 8, role labels, and unresolved mapping identifiers without asserting sufficiency"}
+  - {id: TEST-008-BOUNDARY, kind: opaque_boundary, assertion: "each role payload remains opaque even though source order and labels are preserved"}
+  - {id: TEST-008-PRECONDITION, kind: precondition, assertion: "reject input when: Exactly the eight source ordinals are present and every unresolved mapping remains attached to its role."}
+  - {id: TEST-008-ERROR, kind: failure, assertion: "the first violated precondition returns one of: MISSING_DIMENSION_ROLE, DUPLICATE_SOURCE_ORDINAL, DROPPED_CROSS_DOMAIN_UNRESOLVED"}
+  - {id: TEST-008-POSTCONDITION, kind: postcondition, assertion: "The bundle contains Message, Principles, Values, Virtues, Capacities, Competencies, Practice, and Lived Experience once each in source order."}
+  - {id: TEST-008-DETERMINISM, kind: determinism, assertion: identical structural inputs produce an identical structural result}
+  - {id: TEST-008-RESERVATIONS, kind: reservation_propagation, assertion: "preserve unresolved TLC-UT-THEOREMS-001, TLC-UT-THEOREMS-005, TLC-UT-THEOREMS-007, TLC-UT-THEOREMS-008, TLC-UT-THEOREMS-009, TLC-UT-THEOREMS-010, TLC-UT-THEOREMS-011, TLC-UT-THEOREMS-012 and assumption TLC-EA-THEOREMS-008-001"}
+  - {id: TEST-008-TRACE, kind: traceability, assertion: preserve every feature-specific source object relation and line reference}
+  - {id: TEST-008-CONFORMANCE, kind: contract_ir_conformance, assertion: entrypoint inputs output errors and readiness match contract and IR}
+numeric_expected_results: forbidden
+implementation_status: no_test_code_created

--- a/registry/test-plans/TLC-FC-06-THEOREMS-009/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-06-THEOREMS-009/test-plan.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+test_plan_id: TLC-TP-TLC-FC-06-THEOREMS-009-001
+feature_id: TLC-FC-06-THEOREMS-009
+contract_id: TLC-LEC-TLC-FC-06-THEOREMS-009-001
+ir_id: TLC-PIR-TLC-FC-06-THEOREMS-009-001
+operation_under_test: construct_principles_role_descriptor
+status: planned
+tests:
+  - {id: TEST-009-NOMINAL, kind: nominal, assertion: "invoke construct_principles_role_descriptor with complete feature evidence and obtain principles_descriptor"}
+  - {id: TEST-009-EFFECT, kind: observable_effect, assertion: "return a descriptor identifying Principles, source ordinal 2, and the cited rational-coherence label without defining coherence"}
+  - {id: TEST-009-BOUNDARY, kind: opaque_boundary, assertion: "rational coherence remains an opaque source label, not an implemented property"}
+  - {id: TEST-009-PRECONDITION, kind: precondition, assertion: "reject input when: The supplied role cites line 82 and carries unresolved identifier TLC-UT-THEOREMS-006."}
+  - {id: TEST-009-ERROR, kind: failure, assertion: "the first violated precondition returns one of: WRONG_DIMENSION_LABEL, WRONG_SOURCE_ORDINAL, MISSING_PRINCIPLES_UNRESOLVED"}
+  - {id: TEST-009-POSTCONDITION, kind: postcondition, assertion: "The descriptor is labelled Principles and preserves ordinal 2, the opaque role payload, and its unresolved identifier."}
+  - {id: TEST-009-DETERMINISM, kind: determinism, assertion: identical structural inputs produce an identical structural result}
+  - {id: TEST-009-RESERVATIONS, kind: reservation_propagation, assertion: "preserve unresolved TLC-UT-THEOREMS-006 and assumption TLC-EA-THEOREMS-009-001"}
+  - {id: TEST-009-TRACE, kind: traceability, assertion: preserve every feature-specific source object relation and line reference}
+  - {id: TEST-009-CONFORMANCE, kind: contract_ir_conformance, assertion: entrypoint inputs output errors and readiness match contract and IR}
+numeric_expected_results: forbidden
+implementation_status: no_test_code_created

--- a/reports/ir-batches/theorems-prototype-ir-batch-001/batch-report.md
+++ b/reports/ir-batches/theorems-prototype-ir-batch-001/batch-report.md
@@ -1,0 +1,14 @@
+# Theorems prototype IR semantic rebuild
+
+The nine prototype IRs expose nine distinct entrypoints and observable structural
+effects. Every entrypoint can be implemented as a pure function or small builder
+using validation, lookup, source-addressable construction, and opaque-value
+preservation.
+
+Each associated plan names its entrypoint and includes a feature-specific nominal
+case, observable-effect check, opaque boundary, failing precondition, named error,
+postcondition, determinism check, reservation propagation, traceability, and
+contract–IR conformance.
+
+No IR evaluates scientific expressions or claims. All canonical and production
+readiness values remain false.

--- a/reports/math-contract-batches/theorems-engineering-batch-001/batch-report.md
+++ b/reports/math-contract-batches/theorems-engineering-batch-001/batch-report.md
@@ -1,0 +1,18 @@
+# Theorems semantic rebuild
+
+Source authority: `origin/main@f2b4dc5b04d88f9fc39b455aa8a8b463691ae4aa`.
+
+The nine limited engineering contracts now define distinct structural responsibilities:
+conservation-claim assembly, dynamics-equation registration, explicit-equation
+cataloguing, transmission-ergodicity hypothesis construction, CNS operator-claim
+registration, theorem-declaration indexing, community-stability state construction,
+eight-dimension role assembly, and Principles-role construction.
+
+Each responsibility has feature-specific inputs, output, precondition, observable
+postcondition, and error policy. Operations organize and validate opaque source
+evidence only; they never evaluate theorem truth, proofs, formulas, convergence,
+stability, sufficiency, or operator behavior.
+
+All twelve feature-linked unresolved identifiers and all nine reversible assumptions
+remain propagated. Readiness is 9/9 for reference Python and C++ prototypes, and 0/9
+for canonical IR or production implementation.


### PR DESCRIPTION
Superseded by the final consolidated Theorems pull request #65, which incorporated the corrective specialization, passed combined Wave 1 recheck, and was merged into `main`. Closed without merge for historical traceability.