### PR TITLE
ir(values): record active VALUES-018 registry IR and preserve historical variants

### DIFF
--- a/registry/domain-progress/values/historical-artifact-assessment.yaml
+++ b/registry/domain-progress/values/historical-artifact-assessment.yaml
@@ -1,3 +1,4 @@
+---
 domain_id: values
 baseline_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
 artifacts:
@@ -83,4 +84,31 @@ summary:
   artifacts_found: 6
   modified: 0
   promoted: 0
-status: complete_with_reservations
+  active_replacement_irs: 1
+  historical_variants_preserved: 2
+status: complete_with_single_active_values_018_ir
+values_018_resolution:
+  feature_id: TLC-FC-09-VALUES-018
+  previous_pilot_classification: comparison_only
+  active_replacement_ir: registry/ir/TLC-FC-09-VALUES-018/ir.yaml
+  active_replacement_status: active_prototype
+  replacement_reason: The registry IR provides a single limited engineering prototype
+    for structural matrix validation and provenance preservation while avoiding unsourced
+    ordering, scoring, ranking, or scientific evaluation.
+  historical_variants:
+  - path: ir/TLC-FC-09-VALUES-018/ir-functional.candidate.json
+    previous_status: engineering_candidate
+    final_status: historical_comparison_only
+    active_replacement: registry/ir/TLC-FC-09-VALUES-018/ir.yaml
+  - path: ir/TLC-FC-09-VALUES-018/ir-semantic.candidate.json
+    previous_status: engineering_candidate
+    final_status: historical_comparison_only
+    active_replacement: registry/ir/TLC-FC-09-VALUES-018/ir.yaml
+  active_ir_count: 1
+  historical_ir_count: 2
+  non_invention_guards:
+  - no ordered comparison
+  - no ranking
+  - no score
+  - no metric
+  - no category threshold inference


### PR DESCRIPTION
### Motivation
- Designate a single active prototype IR for feature VALUES-018 while preserving the two candidate variants as historical artifacts and explicitly document non-invention guards to avoid introducing unsourced ordering, ranking, scoring, or threshold semantics.

### Description
- Update `registry/domain-progress/values/historical-artifact-assessment.yaml` to add `values_018_resolution` and summary fields (`active_replacement_irs`, `historical_variants_preserved`, `active_ir_count`, `historical_ir_count`, and `non_invention_guards`) that point to `registry/ir/TLC-FC-09-VALUES-018/ir.yaml` as the single active prototype and mark the two prior candidate IRs as historical comparison-only.

### Testing
- Ran a targeted YAML validation implemented as `validate_values.rb` that loads the 14 contracts, IRs and test-plans, checks required fields and uniqueness of IDs, verifies every feature → contract → IR → test-plan chain, and checks there is exactly one active VALUES-018 IR and two preserved historical variants, and the final run passed after a one-time fix to the validator script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a638a08324c83278f1551bbb106ff69)

## Summary by Sourcery

Record a single active prototype IR for VALUES-018 in the domain progress registry while preserving prior candidate IRs as historical artifacts and documenting non-invention guard constraints.

Enhancements:
- Extend the VALUES domain historical artifact assessment summary with counts and metadata for active replacement IRs and preserved historical variants.
- Add a VALUES-018 resolution section that links the active registry IR, enumerates historical IR variants, and captures non-invention guard semantics.