### PR TITLE
Add 'virtues' domain: IRs, math-contracts, test-plans, and domain completion report

### DIFF
--- a/registry/domain-progress/virtues/domain-completion-report.yaml
+++ b/registry/domain-progress/virtues/domain-completion-report.yaml
@@ -1,0 +1,20 @@
+---
+domain: virtues
+domain_completion_attempted: true
+total_features: 10
+contracts: 10
+ir_classification_counts:
+  A: 7
+  B: 3
+  C: 0
+  D: 0
+  E: 0
+specific_test_plans: 10
+readiness:
+  python_prototype: 7
+  cpp_prototype: 7
+  canonical_ir: 0
+  production: 0
+scientific_reservations_preserved: true
+foreign_domain_file_count: 0
+maths_file_modified_count: 0

--- a/registry/ir/TLC-FC-10-VIRTUES-001/artifact.yaml
+++ b/registry/ir/TLC-FC-10-VIRTUES-001/artifact.yaml
@@ -1,0 +1,40 @@
+---
+feature_id: TLC-FC-10-VIRTUES-001
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-100
+status: limited_engineering_contract_with_reservations
+ir_id: TLC-FC-10-VIRTUES-001-IR
+entrypoint: check_apprenticeship_responsibility
+operation: Verify that an apprenticeship responsibility handoff record contains bounded
+  roles, guided responsibility, source provenance, and explicit reservations without
+  grading virtue.
+inputs:
+- artifact
+- provenance
+- reservations
+observable_output: structured result recording accepted source-bound operation or
+  named error
+testable_postcondition: result echoes feature id, entrypoint, source objects, unresolved
+  items, assumptions, and reservations without adding scientific computation
+error_policy:
+  missing_provenance: return error and do not emit accepted result
+  unsupported_scientific_completion_request: return error when caller asks for score,
+    hierarchy, metric selection, threshold, weight, formula completion, or moral decision
+  invalid_feature_id: return error when feature id differs
+opaque_or_parametric_types:
+- OpaqueVirtue
+- OpaqueEvidence
+- OpaqueContext
+- OpaqueRelationEndpoint
+- OpaqueMetricDescriptor
+unresolved_propagated: []
+assumptions_propagated:
+- source fragments are metadata, not executable science
+classification: substantive_and_implementable
+classification_code: A
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/ir/TLC-FC-10-VIRTUES-002/artifact.yaml
+++ b/registry/ir/TLC-FC-10-VIRTUES-002/artifact.yaml
@@ -1,0 +1,40 @@
+---
+feature_id: TLC-FC-10-VIRTUES-002
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-016
+status: limited_engineering_contract_with_reservations
+ir_id: TLC-FC-10-VIRTUES-002-IR
+entrypoint: register_observational_learning_assumption
+operation: Register observational-learning assumption evidence as opaque modelage/shadowing/apprenticeship/community
+  exposure claims without deriving a learning algorithm.
+inputs:
+- artifact
+- provenance
+- reservations
+observable_output: structured result recording accepted source-bound operation or
+  named error
+testable_postcondition: result echoes feature id, entrypoint, source objects, unresolved
+  items, assumptions, and reservations without adding scientific computation
+error_policy:
+  missing_provenance: return error and do not emit accepted result
+  unsupported_scientific_completion_request: return error when caller asks for score,
+    hierarchy, metric selection, threshold, weight, formula completion, or moral decision
+  invalid_feature_id: return error when feature id differs
+opaque_or_parametric_types:
+- OpaqueVirtue
+- OpaqueEvidence
+- OpaqueContext
+- OpaqueRelationEndpoint
+- OpaqueMetricDescriptor
+unresolved_propagated:
+- scientific ambiguity
+assumptions_propagated:
+- source fragments are metadata, not executable science
+classification: structurally_complete_but_semantically_thin
+classification_code: B
+readiness:
+  python_prototype: false
+  cpp_prototype: false
+  canonical_ir: false
+  production: false

--- a/registry/ir/TLC-FC-10-VIRTUES-005/artifact.yaml
+++ b/registry/ir/TLC-FC-10-VIRTUES-005/artifact.yaml
@@ -1,0 +1,40 @@
+---
+feature_id: TLC-FC-10-VIRTUES-005
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-196
+- TLC-SO-VIRTUES-199
+status: limited_engineering_contract_with_reservations
+ir_id: TLC-FC-10-VIRTUES-005-IR
+entrypoint: package_developmental_dynamics_rhs
+operation: Package supplied symbolic right-hand-side terms for developmental and vice-virtue
+  dynamics and reject numeric integration requests.
+inputs:
+- artifact
+- provenance
+- reservations
+observable_output: structured result recording accepted source-bound operation or
+  named error
+testable_postcondition: result echoes feature id, entrypoint, source objects, unresolved
+  items, assumptions, and reservations without adding scientific computation
+error_policy:
+  missing_provenance: return error and do not emit accepted result
+  unsupported_scientific_completion_request: return error when caller asks for score,
+    hierarchy, metric selection, threshold, weight, formula completion, or moral decision
+  invalid_feature_id: return error when feature id differs
+opaque_or_parametric_types:
+- OpaqueVirtue
+- OpaqueEvidence
+- OpaqueContext
+- OpaqueRelationEndpoint
+- OpaqueMetricDescriptor
+unresolved_propagated: []
+assumptions_propagated:
+- source fragments are metadata, not executable science
+classification: substantive_and_implementable
+classification_code: A
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/ir/TLC-FC-10-VIRTUES-006/artifact.yaml
+++ b/registry/ir/TLC-FC-10-VIRTUES-006/artifact.yaml
@@ -1,0 +1,43 @@
+---
+feature_id: TLC-FC-10-VIRTUES-006
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-070
+- TLC-SO-VIRTUES-194
+- TLC-SO-VIRTUES-195
+- TLC-SO-VIRTUES-197
+- TLC-SO-VIRTUES-198
+status: limited_engineering_contract_with_reservations
+ir_id: TLC-FC-10-VIRTUES-006-IR
+entrypoint: register_virtue_equation_forms
+operation: Register source equation forms, free symbols, duplicate-candidate links,
+  and required opaque operators without solving or ranking them.
+inputs:
+- artifact
+- provenance
+- reservations
+observable_output: structured result recording accepted source-bound operation or
+  named error
+testable_postcondition: result echoes feature id, entrypoint, source objects, unresolved
+  items, assumptions, and reservations without adding scientific computation
+error_policy:
+  missing_provenance: return error and do not emit accepted result
+  unsupported_scientific_completion_request: return error when caller asks for score,
+    hierarchy, metric selection, threshold, weight, formula completion, or moral decision
+  invalid_feature_id: return error when feature id differs
+opaque_or_parametric_types:
+- OpaqueVirtue
+- OpaqueEvidence
+- OpaqueContext
+- OpaqueRelationEndpoint
+- OpaqueMetricDescriptor
+unresolved_propagated: []
+assumptions_propagated:
+- source fragments are metadata, not executable science
+classification: substantive_and_implementable
+classification_code: A
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/ir/TLC-FC-10-VIRTUES-007/artifact.yaml
+++ b/registry/ir/TLC-FC-10-VIRTUES-007/artifact.yaml
@@ -1,0 +1,39 @@
+---
+feature_id: TLC-FC-10-VIRTUES-007
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-060
+status: limited_engineering_contract_with_reservations
+ir_id: TLC-FC-10-VIRTUES-007-IR
+entrypoint: check_virtue_function_invariant
+operation: Check that an artifact preserves the source-declared invariant role labels
+  ancrage, guidage, unification, and contrainte as labels only.
+inputs:
+- artifact
+- provenance
+- reservations
+observable_output: structured result recording accepted source-bound operation or
+  named error
+testable_postcondition: result echoes feature id, entrypoint, source objects, unresolved
+  items, assumptions, and reservations without adding scientific computation
+error_policy:
+  missing_provenance: return error and do not emit accepted result
+  unsupported_scientific_completion_request: return error when caller asks for score,
+    hierarchy, metric selection, threshold, weight, formula completion, or moral decision
+  invalid_feature_id: return error when feature id differs
+opaque_or_parametric_types:
+- OpaqueVirtue
+- OpaqueEvidence
+- OpaqueContext
+- OpaqueRelationEndpoint
+- OpaqueMetricDescriptor
+unresolved_propagated: []
+assumptions_propagated:
+- source fragments are metadata, not executable science
+classification: substantive_and_implementable
+classification_code: A
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/ir/TLC-FC-10-VIRTUES-008/artifact.yaml
+++ b/registry/ir/TLC-FC-10-VIRTUES-008/artifact.yaml
@@ -1,0 +1,45 @@
+---
+feature_id: TLC-FC-10-VIRTUES-008
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-007
+- TLC-SO-VIRTUES-019
+- TLC-SO-VIRTUES-021
+- TLC-SO-VIRTUES-025
+- TLC-SO-VIRTUES-026
+- TLC-SO-VIRTUES-112
+- TLC-SO-VIRTUES-136
+status: limited_engineering_contract_with_reservations
+ir_id: TLC-FC-10-VIRTUES-008-IR
+entrypoint: build_measure_observation_ledger
+operation: Build an observation-ledger schema for cited measurement families and reject
+  requests for weights, thresholds, or virtue scores.
+inputs:
+- artifact
+- provenance
+- reservations
+observable_output: structured result recording accepted source-bound operation or
+  named error
+testable_postcondition: result echoes feature id, entrypoint, source objects, unresolved
+  items, assumptions, and reservations without adding scientific computation
+error_policy:
+  missing_provenance: return error and do not emit accepted result
+  unsupported_scientific_completion_request: return error when caller asks for score,
+    hierarchy, metric selection, threshold, weight, formula completion, or moral decision
+  invalid_feature_id: return error when feature id differs
+opaque_or_parametric_types:
+- OpaqueVirtue
+- OpaqueEvidence
+- OpaqueContext
+- OpaqueRelationEndpoint
+- OpaqueMetricDescriptor
+unresolved_propagated: []
+assumptions_propagated:
+- source fragments are metadata, not executable science
+classification: substantive_and_implementable
+classification_code: A
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/ir/TLC-FC-10-VIRTUES-009/artifact.yaml
+++ b/registry/ir/TLC-FC-10-VIRTUES-009/artifact.yaml
@@ -1,0 +1,40 @@
+---
+feature_id: TLC-FC-10-VIRTUES-009
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-022
+status: limited_engineering_contract_with_reservations
+ir_id: TLC-FC-10-VIRTUES-009-IR
+entrypoint: register_quantitative_measure_reservations
+operation: Record the named quantitative measurement dimensions as unresolved semantic
+  commitments because scales and thresholds are absent.
+inputs:
+- artifact
+- provenance
+- reservations
+observable_output: structured result recording accepted source-bound operation or
+  named error
+testable_postcondition: result echoes feature id, entrypoint, source objects, unresolved
+  items, assumptions, and reservations without adding scientific computation
+error_policy:
+  missing_provenance: return error and do not emit accepted result
+  unsupported_scientific_completion_request: return error when caller asks for score,
+    hierarchy, metric selection, threshold, weight, formula completion, or moral decision
+  invalid_feature_id: return error when feature id differs
+opaque_or_parametric_types:
+- OpaqueVirtue
+- OpaqueEvidence
+- OpaqueContext
+- OpaqueRelationEndpoint
+- OpaqueMetricDescriptor
+unresolved_propagated:
+- scientific ambiguity
+assumptions_propagated:
+- source fragments are metadata, not executable science
+classification: structurally_complete_but_semantically_thin
+classification_code: B
+readiness:
+  python_prototype: false
+  cpp_prototype: false
+  canonical_ir: false
+  production: false

--- a/registry/ir/TLC-FC-10-VIRTUES-010/artifact.yaml
+++ b/registry/ir/TLC-FC-10-VIRTUES-010/artifact.yaml
@@ -1,0 +1,41 @@
+---
+feature_id: TLC-FC-10-VIRTUES-010
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-003
+- TLC-SO-VIRTUES-067
+status: limited_engineering_contract_with_reservations
+ir_id: TLC-FC-10-VIRTUES-010-IR
+entrypoint: register_essential_property_indicators
+operation: Register essential-property indicator categories while preserving opacity
+  of indicators, metrics, and progression semantics.
+inputs:
+- artifact
+- provenance
+- reservations
+observable_output: structured result recording accepted source-bound operation or
+  named error
+testable_postcondition: result echoes feature id, entrypoint, source objects, unresolved
+  items, assumptions, and reservations without adding scientific computation
+error_policy:
+  missing_provenance: return error and do not emit accepted result
+  unsupported_scientific_completion_request: return error when caller asks for score,
+    hierarchy, metric selection, threshold, weight, formula completion, or moral decision
+  invalid_feature_id: return error when feature id differs
+opaque_or_parametric_types:
+- OpaqueVirtue
+- OpaqueEvidence
+- OpaqueContext
+- OpaqueRelationEndpoint
+- OpaqueMetricDescriptor
+unresolved_propagated:
+- scientific ambiguity
+assumptions_propagated:
+- source fragments are metadata, not executable science
+classification: structurally_complete_but_semantically_thin
+classification_code: B
+readiness:
+  python_prototype: false
+  cpp_prototype: false
+  canonical_ir: false
+  production: false

--- a/registry/ir/TLC-FC-10-VIRTUES-011/artifact.yaml
+++ b/registry/ir/TLC-FC-10-VIRTUES-011/artifact.yaml
@@ -1,0 +1,40 @@
+---
+feature_id: TLC-FC-10-VIRTUES-011
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-055
+- TLC-SO-VIRTUES-212
+status: limited_engineering_contract_with_reservations
+ir_id: TLC-FC-10-VIRTUES-011-IR
+entrypoint: package_vice_diagnostic_function
+operation: Package diagnostic observations that map vice evidence to development-domain
+  labels supplied by humans without prescribing correction.
+inputs:
+- artifact
+- provenance
+- reservations
+observable_output: structured result recording accepted source-bound operation or
+  named error
+testable_postcondition: result echoes feature id, entrypoint, source objects, unresolved
+  items, assumptions, and reservations without adding scientific computation
+error_policy:
+  missing_provenance: return error and do not emit accepted result
+  unsupported_scientific_completion_request: return error when caller asks for score,
+    hierarchy, metric selection, threshold, weight, formula completion, or moral decision
+  invalid_feature_id: return error when feature id differs
+opaque_or_parametric_types:
+- OpaqueVirtue
+- OpaqueEvidence
+- OpaqueContext
+- OpaqueRelationEndpoint
+- OpaqueMetricDescriptor
+unresolved_propagated: []
+assumptions_propagated:
+- source fragments are metadata, not executable science
+classification: substantive_and_implementable
+classification_code: A
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/ir/TLC-FC-10-VIRTUES-014/artifact.yaml
+++ b/registry/ir/TLC-FC-10-VIRTUES-014/artifact.yaml
@@ -1,0 +1,43 @@
+---
+feature_id: TLC-FC-10-VIRTUES-014
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-013
+- TLC-SO-VIRTUES-020
+- TLC-SO-VIRTUES-054
+- TLC-SO-VIRTUES-093
+- TLC-SO-VIRTUES-116
+status: limited_engineering_contract_with_reservations
+ir_id: TLC-FC-10-VIRTUES-014-IR
+entrypoint: map_contextual_virtue_relations
+operation: Map contextual virtue relation claims among supplied entities with provenance
+  and reservations, without inferring endpoint identity.
+inputs:
+- artifact
+- provenance
+- reservations
+observable_output: structured result recording accepted source-bound operation or
+  named error
+testable_postcondition: result echoes feature id, entrypoint, source objects, unresolved
+  items, assumptions, and reservations without adding scientific computation
+error_policy:
+  missing_provenance: return error and do not emit accepted result
+  unsupported_scientific_completion_request: return error when caller asks for score,
+    hierarchy, metric selection, threshold, weight, formula completion, or moral decision
+  invalid_feature_id: return error when feature id differs
+opaque_or_parametric_types:
+- OpaqueVirtue
+- OpaqueEvidence
+- OpaqueContext
+- OpaqueRelationEndpoint
+- OpaqueMetricDescriptor
+unresolved_propagated: []
+assumptions_propagated:
+- source fragments are metadata, not executable science
+classification: substantive_and_implementable
+classification_code: A
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/math-contracts/TLC-FC-10-VIRTUES-001/artifact.yaml
+++ b/registry/math-contracts/TLC-FC-10-VIRTUES-001/artifact.yaml
@@ -1,0 +1,52 @@
+---
+feature_id: TLC-FC-10-VIRTUES-001
+domain: virtues
+source_objects: &1
+- TLC-SO-VIRTUES-100
+status: limited_engineering_contract_with_reservations
+contract_id: TLC-FC-10-VIRTUES-001-CONTRACT
+title: Apprentissage par compagnonnage
+responsibility: Verify that an apprenticeship responsibility handoff record contains
+  bounded roles, guided responsibility, source provenance, and explicit reservations
+  without grading virtue.
+inputs:
+  artifact: opaque Virtues artifact or evidence bundle
+  provenance: source object ids and source lines
+  reservations: caller-supplied unresolved and assumptions
+outputs:
+  contract_result: accepted/rejected engineering envelope with no moral score
+types:
+  OpaqueVirtue: uninterpreted label
+  OpaqueEvidence: uninterpreted evidence payload
+  ProvenanceRef: source object id plus source span
+operation_main: Verify that an apprenticeship responsibility handoff record contains
+  bounded roles, guided responsibility, source provenance, and explicit reservations
+  without grading virtue.
+preconditions:
+- feature id matches TLC-FC-10-VIRTUES-001
+- all source object ids are present in provenance
+- caller does not request moral ranking, scoring, weighting, thresholds, or formula
+  completion
+postconditions:
+- output preserves source object provenance
+- output states reservations and unresolved items
+- output contains no computed virtue score or moral decision
+errors:
+- missing_provenance
+- unsupported_scientific_completion_request
+- invalid_feature_id
+unresolved_propagated: []
+provisional_assumptions:
+- source objects are treated as authoritative text fragments only
+- opaque domain values are passed through unchanged
+reservations:
+- no hierarchy, metric, threshold, weight, or moral algorithm is specified
+- scientific meaning remains source-bound
+traceability:
+  feature: TLC-FC-10-VIRTUES-001
+  source_objects: *1
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/math-contracts/TLC-FC-10-VIRTUES-002/artifact.yaml
+++ b/registry/math-contracts/TLC-FC-10-VIRTUES-002/artifact.yaml
@@ -1,0 +1,51 @@
+---
+feature_id: TLC-FC-10-VIRTUES-002
+domain: virtues
+source_objects: &1
+- TLC-SO-VIRTUES-016
+status: limited_engineering_contract_with_reservations
+contract_id: TLC-FC-10-VIRTUES-002-CONTRACT
+title: Apprentissage observationnel et imitation
+responsibility: Register observational-learning assumption evidence as opaque modelage/shadowing/apprenticeship/community
+  exposure claims without deriving a learning algorithm.
+inputs:
+  artifact: opaque Virtues artifact or evidence bundle
+  provenance: source object ids and source lines
+  reservations: caller-supplied unresolved and assumptions
+outputs:
+  contract_result: accepted/rejected engineering envelope with no moral score
+types:
+  OpaqueVirtue: uninterpreted label
+  OpaqueEvidence: uninterpreted evidence payload
+  ProvenanceRef: source object id plus source span
+operation_main: Register observational-learning assumption evidence as opaque modelage/shadowing/apprenticeship/community
+  exposure claims without deriving a learning algorithm.
+preconditions:
+- feature id matches TLC-FC-10-VIRTUES-002
+- all source object ids are present in provenance
+- caller does not request moral ranking, scoring, weighting, thresholds, or formula
+  completion
+postconditions:
+- output preserves source object provenance
+- output states reservations and unresolved items
+- output contains no computed virtue score or moral decision
+errors:
+- missing_provenance
+- unsupported_scientific_completion_request
+- invalid_feature_id
+unresolved_propagated:
+- scientific ambiguity
+provisional_assumptions:
+- source objects are treated as authoritative text fragments only
+- opaque domain values are passed through unchanged
+reservations:
+- no hierarchy, metric, threshold, weight, or moral algorithm is specified
+- scientific meaning remains source-bound
+traceability:
+  feature: TLC-FC-10-VIRTUES-002
+  source_objects: *1
+readiness:
+  python_prototype: false
+  cpp_prototype: false
+  canonical_ir: false
+  production: false

--- a/registry/math-contracts/TLC-FC-10-VIRTUES-005/artifact.yaml
+++ b/registry/math-contracts/TLC-FC-10-VIRTUES-005/artifact.yaml
@@ -1,0 +1,51 @@
+---
+feature_id: TLC-FC-10-VIRTUES-005
+domain: virtues
+source_objects: &1
+- TLC-SO-VIRTUES-196
+- TLC-SO-VIRTUES-199
+status: limited_engineering_contract_with_reservations
+contract_id: TLC-FC-10-VIRTUES-005-CONTRACT
+title: Dynamique développementale et dynamique vice-vertu
+responsibility: Package supplied symbolic right-hand-side terms for developmental
+  and vice-virtue dynamics and reject numeric integration requests.
+inputs:
+  artifact: opaque Virtues artifact or evidence bundle
+  provenance: source object ids and source lines
+  reservations: caller-supplied unresolved and assumptions
+outputs:
+  contract_result: accepted/rejected engineering envelope with no moral score
+types:
+  OpaqueVirtue: uninterpreted label
+  OpaqueEvidence: uninterpreted evidence payload
+  ProvenanceRef: source object id plus source span
+operation_main: Package supplied symbolic right-hand-side terms for developmental
+  and vice-virtue dynamics and reject numeric integration requests.
+preconditions:
+- feature id matches TLC-FC-10-VIRTUES-005
+- all source object ids are present in provenance
+- caller does not request moral ranking, scoring, weighting, thresholds, or formula
+  completion
+postconditions:
+- output preserves source object provenance
+- output states reservations and unresolved items
+- output contains no computed virtue score or moral decision
+errors:
+- missing_provenance
+- unsupported_scientific_completion_request
+- invalid_feature_id
+unresolved_propagated: []
+provisional_assumptions:
+- source objects are treated as authoritative text fragments only
+- opaque domain values are passed through unchanged
+reservations:
+- no hierarchy, metric, threshold, weight, or moral algorithm is specified
+- scientific meaning remains source-bound
+traceability:
+  feature: TLC-FC-10-VIRTUES-005
+  source_objects: *1
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/math-contracts/TLC-FC-10-VIRTUES-006/artifact.yaml
+++ b/registry/math-contracts/TLC-FC-10-VIRTUES-006/artifact.yaml
@@ -1,0 +1,54 @@
+---
+feature_id: TLC-FC-10-VIRTUES-006
+domain: virtues
+source_objects: &1
+- TLC-SO-VIRTUES-070
+- TLC-SO-VIRTUES-194
+- TLC-SO-VIRTUES-195
+- TLC-SO-VIRTUES-197
+- TLC-SO-VIRTUES-198
+status: limited_engineering_contract_with_reservations
+contract_id: TLC-FC-10-VIRTUES-006-CONTRACT
+title: Représentations et mappings formels
+responsibility: Register source equation forms, free symbols, duplicate-candidate
+  links, and required opaque operators without solving or ranking them.
+inputs:
+  artifact: opaque Virtues artifact or evidence bundle
+  provenance: source object ids and source lines
+  reservations: caller-supplied unresolved and assumptions
+outputs:
+  contract_result: accepted/rejected engineering envelope with no moral score
+types:
+  OpaqueVirtue: uninterpreted label
+  OpaqueEvidence: uninterpreted evidence payload
+  ProvenanceRef: source object id plus source span
+operation_main: Register source equation forms, free symbols, duplicate-candidate
+  links, and required opaque operators without solving or ranking them.
+preconditions:
+- feature id matches TLC-FC-10-VIRTUES-006
+- all source object ids are present in provenance
+- caller does not request moral ranking, scoring, weighting, thresholds, or formula
+  completion
+postconditions:
+- output preserves source object provenance
+- output states reservations and unresolved items
+- output contains no computed virtue score or moral decision
+errors:
+- missing_provenance
+- unsupported_scientific_completion_request
+- invalid_feature_id
+unresolved_propagated: []
+provisional_assumptions:
+- source objects are treated as authoritative text fragments only
+- opaque domain values are passed through unchanged
+reservations:
+- no hierarchy, metric, threshold, weight, or moral algorithm is specified
+- scientific meaning remains source-bound
+traceability:
+  feature: TLC-FC-10-VIRTUES-006
+  source_objects: *1
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/math-contracts/TLC-FC-10-VIRTUES-007/artifact.yaml
+++ b/registry/math-contracts/TLC-FC-10-VIRTUES-007/artifact.yaml
@@ -1,0 +1,50 @@
+---
+feature_id: TLC-FC-10-VIRTUES-007
+domain: virtues
+source_objects: &1
+- TLC-SO-VIRTUES-060
+status: limited_engineering_contract_with_reservations
+contract_id: TLC-FC-10-VIRTUES-007-CONTRACT
+title: "$V_{fonction}$"
+responsibility: Check that an artifact preserves the source-declared invariant role
+  labels ancrage, guidage, unification, and contrainte as labels only.
+inputs:
+  artifact: opaque Virtues artifact or evidence bundle
+  provenance: source object ids and source lines
+  reservations: caller-supplied unresolved and assumptions
+outputs:
+  contract_result: accepted/rejected engineering envelope with no moral score
+types:
+  OpaqueVirtue: uninterpreted label
+  OpaqueEvidence: uninterpreted evidence payload
+  ProvenanceRef: source object id plus source span
+operation_main: Check that an artifact preserves the source-declared invariant role
+  labels ancrage, guidage, unification, and contrainte as labels only.
+preconditions:
+- feature id matches TLC-FC-10-VIRTUES-007
+- all source object ids are present in provenance
+- caller does not request moral ranking, scoring, weighting, thresholds, or formula
+  completion
+postconditions:
+- output preserves source object provenance
+- output states reservations and unresolved items
+- output contains no computed virtue score or moral decision
+errors:
+- missing_provenance
+- unsupported_scientific_completion_request
+- invalid_feature_id
+unresolved_propagated: []
+provisional_assumptions:
+- source objects are treated as authoritative text fragments only
+- opaque domain values are passed through unchanged
+reservations:
+- no hierarchy, metric, threshold, weight, or moral algorithm is specified
+- scientific meaning remains source-bound
+traceability:
+  feature: TLC-FC-10-VIRTUES-007
+  source_objects: *1
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/math-contracts/TLC-FC-10-VIRTUES-008/artifact.yaml
+++ b/registry/math-contracts/TLC-FC-10-VIRTUES-008/artifact.yaml
@@ -1,0 +1,56 @@
+---
+feature_id: TLC-FC-10-VIRTUES-008
+domain: virtues
+source_objects: &1
+- TLC-SO-VIRTUES-007
+- TLC-SO-VIRTUES-019
+- TLC-SO-VIRTUES-021
+- TLC-SO-VIRTUES-025
+- TLC-SO-VIRTUES-026
+- TLC-SO-VIRTUES-112
+- TLC-SO-VIRTUES-136
+status: limited_engineering_contract_with_reservations
+contract_id: TLC-FC-10-VIRTUES-008-CONTRACT
+title: Évaluation, reconnaissance, correction et compensation
+responsibility: Build an observation-ledger schema for cited measurement families
+  and reject requests for weights, thresholds, or virtue scores.
+inputs:
+  artifact: opaque Virtues artifact or evidence bundle
+  provenance: source object ids and source lines
+  reservations: caller-supplied unresolved and assumptions
+outputs:
+  contract_result: accepted/rejected engineering envelope with no moral score
+types:
+  OpaqueVirtue: uninterpreted label
+  OpaqueEvidence: uninterpreted evidence payload
+  ProvenanceRef: source object id plus source span
+operation_main: Build an observation-ledger schema for cited measurement families
+  and reject requests for weights, thresholds, or virtue scores.
+preconditions:
+- feature id matches TLC-FC-10-VIRTUES-008
+- all source object ids are present in provenance
+- caller does not request moral ranking, scoring, weighting, thresholds, or formula
+  completion
+postconditions:
+- output preserves source object provenance
+- output states reservations and unresolved items
+- output contains no computed virtue score or moral decision
+errors:
+- missing_provenance
+- unsupported_scientific_completion_request
+- invalid_feature_id
+unresolved_propagated: []
+provisional_assumptions:
+- source objects are treated as authoritative text fragments only
+- opaque domain values are passed through unchanged
+reservations:
+- no hierarchy, metric, threshold, weight, or moral algorithm is specified
+- scientific meaning remains source-bound
+traceability:
+  feature: TLC-FC-10-VIRTUES-008
+  source_objects: *1
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/math-contracts/TLC-FC-10-VIRTUES-009/artifact.yaml
+++ b/registry/math-contracts/TLC-FC-10-VIRTUES-009/artifact.yaml
@@ -1,0 +1,51 @@
+---
+feature_id: TLC-FC-10-VIRTUES-009
+domain: virtues
+source_objects: &1
+- TLC-SO-VIRTUES-022
+status: limited_engineering_contract_with_reservations
+contract_id: TLC-FC-10-VIRTUES-009-CONTRACT
+title: Mesures quantitatives
+responsibility: Record the named quantitative measurement dimensions as unresolved
+  semantic commitments because scales and thresholds are absent.
+inputs:
+  artifact: opaque Virtues artifact or evidence bundle
+  provenance: source object ids and source lines
+  reservations: caller-supplied unresolved and assumptions
+outputs:
+  contract_result: accepted/rejected engineering envelope with no moral score
+types:
+  OpaqueVirtue: uninterpreted label
+  OpaqueEvidence: uninterpreted evidence payload
+  ProvenanceRef: source object id plus source span
+operation_main: Record the named quantitative measurement dimensions as unresolved
+  semantic commitments because scales and thresholds are absent.
+preconditions:
+- feature id matches TLC-FC-10-VIRTUES-009
+- all source object ids are present in provenance
+- caller does not request moral ranking, scoring, weighting, thresholds, or formula
+  completion
+postconditions:
+- output preserves source object provenance
+- output states reservations and unresolved items
+- output contains no computed virtue score or moral decision
+errors:
+- missing_provenance
+- unsupported_scientific_completion_request
+- invalid_feature_id
+unresolved_propagated:
+- scientific ambiguity
+provisional_assumptions:
+- source objects are treated as authoritative text fragments only
+- opaque domain values are passed through unchanged
+reservations:
+- no hierarchy, metric, threshold, weight, or moral algorithm is specified
+- scientific meaning remains source-bound
+traceability:
+  feature: TLC-FC-10-VIRTUES-009
+  source_objects: *1
+readiness:
+  python_prototype: false
+  cpp_prototype: false
+  canonical_ir: false
+  production: false

--- a/registry/math-contracts/TLC-FC-10-VIRTUES-010/artifact.yaml
+++ b/registry/math-contracts/TLC-FC-10-VIRTUES-010/artifact.yaml
@@ -1,0 +1,52 @@
+---
+feature_id: TLC-FC-10-VIRTUES-010
+domain: virtues
+source_objects: &1
+- TLC-SO-VIRTUES-003
+- TLC-SO-VIRTUES-067
+status: limited_engineering_contract_with_reservations
+contract_id: TLC-FC-10-VIRTUES-010-CONTRACT
+title: Propriétés essentielles et mesurabilité
+responsibility: Register essential-property indicator categories while preserving
+  opacity of indicators, metrics, and progression semantics.
+inputs:
+  artifact: opaque Virtues artifact or evidence bundle
+  provenance: source object ids and source lines
+  reservations: caller-supplied unresolved and assumptions
+outputs:
+  contract_result: accepted/rejected engineering envelope with no moral score
+types:
+  OpaqueVirtue: uninterpreted label
+  OpaqueEvidence: uninterpreted evidence payload
+  ProvenanceRef: source object id plus source span
+operation_main: Register essential-property indicator categories while preserving
+  opacity of indicators, metrics, and progression semantics.
+preconditions:
+- feature id matches TLC-FC-10-VIRTUES-010
+- all source object ids are present in provenance
+- caller does not request moral ranking, scoring, weighting, thresholds, or formula
+  completion
+postconditions:
+- output preserves source object provenance
+- output states reservations and unresolved items
+- output contains no computed virtue score or moral decision
+errors:
+- missing_provenance
+- unsupported_scientific_completion_request
+- invalid_feature_id
+unresolved_propagated:
+- scientific ambiguity
+provisional_assumptions:
+- source objects are treated as authoritative text fragments only
+- opaque domain values are passed through unchanged
+reservations:
+- no hierarchy, metric, threshold, weight, or moral algorithm is specified
+- scientific meaning remains source-bound
+traceability:
+  feature: TLC-FC-10-VIRTUES-010
+  source_objects: *1
+readiness:
+  python_prototype: false
+  cpp_prototype: false
+  canonical_ir: false
+  production: false

--- a/registry/math-contracts/TLC-FC-10-VIRTUES-011/artifact.yaml
+++ b/registry/math-contracts/TLC-FC-10-VIRTUES-011/artifact.yaml
@@ -1,0 +1,51 @@
+---
+feature_id: TLC-FC-10-VIRTUES-011
+domain: virtues
+source_objects: &1
+- TLC-SO-VIRTUES-055
+- TLC-SO-VIRTUES-212
+status: limited_engineering_contract_with_reservations
+contract_id: TLC-FC-10-VIRTUES-011-CONTRACT
+title: Dialectique vertu-vice et fonction diagnostique
+responsibility: Package diagnostic observations that map vice evidence to development-domain
+  labels supplied by humans without prescribing correction.
+inputs:
+  artifact: opaque Virtues artifact or evidence bundle
+  provenance: source object ids and source lines
+  reservations: caller-supplied unresolved and assumptions
+outputs:
+  contract_result: accepted/rejected engineering envelope with no moral score
+types:
+  OpaqueVirtue: uninterpreted label
+  OpaqueEvidence: uninterpreted evidence payload
+  ProvenanceRef: source object id plus source span
+operation_main: Package diagnostic observations that map vice evidence to development-domain
+  labels supplied by humans without prescribing correction.
+preconditions:
+- feature id matches TLC-FC-10-VIRTUES-011
+- all source object ids are present in provenance
+- caller does not request moral ranking, scoring, weighting, thresholds, or formula
+  completion
+postconditions:
+- output preserves source object provenance
+- output states reservations and unresolved items
+- output contains no computed virtue score or moral decision
+errors:
+- missing_provenance
+- unsupported_scientific_completion_request
+- invalid_feature_id
+unresolved_propagated: []
+provisional_assumptions:
+- source objects are treated as authoritative text fragments only
+- opaque domain values are passed through unchanged
+reservations:
+- no hierarchy, metric, threshold, weight, or moral algorithm is specified
+- scientific meaning remains source-bound
+traceability:
+  feature: TLC-FC-10-VIRTUES-011
+  source_objects: *1
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/math-contracts/TLC-FC-10-VIRTUES-014/artifact.yaml
+++ b/registry/math-contracts/TLC-FC-10-VIRTUES-014/artifact.yaml
@@ -1,0 +1,54 @@
+---
+feature_id: TLC-FC-10-VIRTUES-014
+domain: virtues
+source_objects: &1
+- TLC-SO-VIRTUES-013
+- TLC-SO-VIRTUES-020
+- TLC-SO-VIRTUES-054
+- TLC-SO-VIRTUES-093
+- TLC-SO-VIRTUES-116
+status: limited_engineering_contract_with_reservations
+contract_id: TLC-FC-10-VIRTUES-014-CONTRACT
+title: Relations contextuelles, maître, discours
+responsibility: Map contextual virtue relation claims among supplied entities with
+  provenance and reservations, without inferring endpoint identity.
+inputs:
+  artifact: opaque Virtues artifact or evidence bundle
+  provenance: source object ids and source lines
+  reservations: caller-supplied unresolved and assumptions
+outputs:
+  contract_result: accepted/rejected engineering envelope with no moral score
+types:
+  OpaqueVirtue: uninterpreted label
+  OpaqueEvidence: uninterpreted evidence payload
+  ProvenanceRef: source object id plus source span
+operation_main: Map contextual virtue relation claims among supplied entities with
+  provenance and reservations, without inferring endpoint identity.
+preconditions:
+- feature id matches TLC-FC-10-VIRTUES-014
+- all source object ids are present in provenance
+- caller does not request moral ranking, scoring, weighting, thresholds, or formula
+  completion
+postconditions:
+- output preserves source object provenance
+- output states reservations and unresolved items
+- output contains no computed virtue score or moral decision
+errors:
+- missing_provenance
+- unsupported_scientific_completion_request
+- invalid_feature_id
+unresolved_propagated: []
+provisional_assumptions:
+- source objects are treated as authoritative text fragments only
+- opaque domain values are passed through unchanged
+reservations:
+- no hierarchy, metric, threshold, weight, or moral algorithm is specified
+- scientific meaning remains source-bound
+traceability:
+  feature: TLC-FC-10-VIRTUES-014
+  source_objects: *1
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/test-plans/TLC-FC-10-VIRTUES-001/artifact.yaml
+++ b/registry/test-plans/TLC-FC-10-VIRTUES-001/artifact.yaml
@@ -1,0 +1,54 @@
+---
+feature_id: TLC-FC-10-VIRTUES-001
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-100
+status: limited_engineering_contract_with_reservations
+test_plan_id: TLC-FC-10-VIRTUES-001-TEST-PLAN
+entrypoint: check_apprenticeship_responsibility
+tests:
+- name: nominal operation
+  covers:
+  - real operation
+  - nominal case
+  assertions:
+  - accepted result names check_apprenticeship_responsibility
+  - source objects preserved
+  - observable output present
+- name: postcondition and provenance
+  covers:
+  - postcondition
+  - provenance
+  assertions:
+  - feature id, source objects, unresolved, assumptions, and reservations are echoed
+- name: invalid precondition
+  covers:
+  - error
+  assertions:
+  - missing provenance returns missing_provenance
+  - no accepted result is emitted
+- name: opaque values pass-through
+  covers:
+  - opaque values
+  assertions:
+  - opaque evidence/context/relation labels are not interpreted, scored, ranked, or
+    normalized
+- name: scientific reservation propagation
+  covers:
+  - unresolved
+  - hypotheses
+  - absence of undefined science
+  assertions:
+  - requests for score, threshold, weight, hierarchy, metric selection, formula completion,
+    or moral decision return unsupported_scientific_completion_request
+- name: contract IR conformity
+  covers:
+  - contract to IR conformity
+  assertions:
+  - IR entrypoint implements the contract operation and preserves identical readiness
+    flags
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/test-plans/TLC-FC-10-VIRTUES-002/artifact.yaml
+++ b/registry/test-plans/TLC-FC-10-VIRTUES-002/artifact.yaml
@@ -1,0 +1,54 @@
+---
+feature_id: TLC-FC-10-VIRTUES-002
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-016
+status: limited_engineering_contract_with_reservations
+test_plan_id: TLC-FC-10-VIRTUES-002-TEST-PLAN
+entrypoint: register_observational_learning_assumption
+tests:
+- name: nominal operation
+  covers:
+  - real operation
+  - nominal case
+  assertions:
+  - accepted result names register_observational_learning_assumption
+  - source objects preserved
+  - observable output present
+- name: postcondition and provenance
+  covers:
+  - postcondition
+  - provenance
+  assertions:
+  - feature id, source objects, unresolved, assumptions, and reservations are echoed
+- name: invalid precondition
+  covers:
+  - error
+  assertions:
+  - missing provenance returns missing_provenance
+  - no accepted result is emitted
+- name: opaque values pass-through
+  covers:
+  - opaque values
+  assertions:
+  - opaque evidence/context/relation labels are not interpreted, scored, ranked, or
+    normalized
+- name: scientific reservation propagation
+  covers:
+  - unresolved
+  - hypotheses
+  - absence of undefined science
+  assertions:
+  - requests for score, threshold, weight, hierarchy, metric selection, formula completion,
+    or moral decision return unsupported_scientific_completion_request
+- name: contract IR conformity
+  covers:
+  - contract to IR conformity
+  assertions:
+  - IR entrypoint implements the contract operation and preserves identical readiness
+    flags
+readiness:
+  python_prototype: false
+  cpp_prototype: false
+  canonical_ir: false
+  production: false

--- a/registry/test-plans/TLC-FC-10-VIRTUES-005/artifact.yaml
+++ b/registry/test-plans/TLC-FC-10-VIRTUES-005/artifact.yaml
@@ -1,0 +1,55 @@
+---
+feature_id: TLC-FC-10-VIRTUES-005
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-196
+- TLC-SO-VIRTUES-199
+status: limited_engineering_contract_with_reservations
+test_plan_id: TLC-FC-10-VIRTUES-005-TEST-PLAN
+entrypoint: package_developmental_dynamics_rhs
+tests:
+- name: nominal operation
+  covers:
+  - real operation
+  - nominal case
+  assertions:
+  - accepted result names package_developmental_dynamics_rhs
+  - source objects preserved
+  - observable output present
+- name: postcondition and provenance
+  covers:
+  - postcondition
+  - provenance
+  assertions:
+  - feature id, source objects, unresolved, assumptions, and reservations are echoed
+- name: invalid precondition
+  covers:
+  - error
+  assertions:
+  - missing provenance returns missing_provenance
+  - no accepted result is emitted
+- name: opaque values pass-through
+  covers:
+  - opaque values
+  assertions:
+  - opaque evidence/context/relation labels are not interpreted, scored, ranked, or
+    normalized
+- name: scientific reservation propagation
+  covers:
+  - unresolved
+  - hypotheses
+  - absence of undefined science
+  assertions:
+  - requests for score, threshold, weight, hierarchy, metric selection, formula completion,
+    or moral decision return unsupported_scientific_completion_request
+- name: contract IR conformity
+  covers:
+  - contract to IR conformity
+  assertions:
+  - IR entrypoint implements the contract operation and preserves identical readiness
+    flags
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/test-plans/TLC-FC-10-VIRTUES-006/artifact.yaml
+++ b/registry/test-plans/TLC-FC-10-VIRTUES-006/artifact.yaml
@@ -1,0 +1,58 @@
+---
+feature_id: TLC-FC-10-VIRTUES-006
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-070
+- TLC-SO-VIRTUES-194
+- TLC-SO-VIRTUES-195
+- TLC-SO-VIRTUES-197
+- TLC-SO-VIRTUES-198
+status: limited_engineering_contract_with_reservations
+test_plan_id: TLC-FC-10-VIRTUES-006-TEST-PLAN
+entrypoint: register_virtue_equation_forms
+tests:
+- name: nominal operation
+  covers:
+  - real operation
+  - nominal case
+  assertions:
+  - accepted result names register_virtue_equation_forms
+  - source objects preserved
+  - observable output present
+- name: postcondition and provenance
+  covers:
+  - postcondition
+  - provenance
+  assertions:
+  - feature id, source objects, unresolved, assumptions, and reservations are echoed
+- name: invalid precondition
+  covers:
+  - error
+  assertions:
+  - missing provenance returns missing_provenance
+  - no accepted result is emitted
+- name: opaque values pass-through
+  covers:
+  - opaque values
+  assertions:
+  - opaque evidence/context/relation labels are not interpreted, scored, ranked, or
+    normalized
+- name: scientific reservation propagation
+  covers:
+  - unresolved
+  - hypotheses
+  - absence of undefined science
+  assertions:
+  - requests for score, threshold, weight, hierarchy, metric selection, formula completion,
+    or moral decision return unsupported_scientific_completion_request
+- name: contract IR conformity
+  covers:
+  - contract to IR conformity
+  assertions:
+  - IR entrypoint implements the contract operation and preserves identical readiness
+    flags
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/test-plans/TLC-FC-10-VIRTUES-007/artifact.yaml
+++ b/registry/test-plans/TLC-FC-10-VIRTUES-007/artifact.yaml
@@ -1,0 +1,54 @@
+---
+feature_id: TLC-FC-10-VIRTUES-007
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-060
+status: limited_engineering_contract_with_reservations
+test_plan_id: TLC-FC-10-VIRTUES-007-TEST-PLAN
+entrypoint: check_virtue_function_invariant
+tests:
+- name: nominal operation
+  covers:
+  - real operation
+  - nominal case
+  assertions:
+  - accepted result names check_virtue_function_invariant
+  - source objects preserved
+  - observable output present
+- name: postcondition and provenance
+  covers:
+  - postcondition
+  - provenance
+  assertions:
+  - feature id, source objects, unresolved, assumptions, and reservations are echoed
+- name: invalid precondition
+  covers:
+  - error
+  assertions:
+  - missing provenance returns missing_provenance
+  - no accepted result is emitted
+- name: opaque values pass-through
+  covers:
+  - opaque values
+  assertions:
+  - opaque evidence/context/relation labels are not interpreted, scored, ranked, or
+    normalized
+- name: scientific reservation propagation
+  covers:
+  - unresolved
+  - hypotheses
+  - absence of undefined science
+  assertions:
+  - requests for score, threshold, weight, hierarchy, metric selection, formula completion,
+    or moral decision return unsupported_scientific_completion_request
+- name: contract IR conformity
+  covers:
+  - contract to IR conformity
+  assertions:
+  - IR entrypoint implements the contract operation and preserves identical readiness
+    flags
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/test-plans/TLC-FC-10-VIRTUES-008/artifact.yaml
+++ b/registry/test-plans/TLC-FC-10-VIRTUES-008/artifact.yaml
@@ -1,0 +1,60 @@
+---
+feature_id: TLC-FC-10-VIRTUES-008
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-007
+- TLC-SO-VIRTUES-019
+- TLC-SO-VIRTUES-021
+- TLC-SO-VIRTUES-025
+- TLC-SO-VIRTUES-026
+- TLC-SO-VIRTUES-112
+- TLC-SO-VIRTUES-136
+status: limited_engineering_contract_with_reservations
+test_plan_id: TLC-FC-10-VIRTUES-008-TEST-PLAN
+entrypoint: build_measure_observation_ledger
+tests:
+- name: nominal operation
+  covers:
+  - real operation
+  - nominal case
+  assertions:
+  - accepted result names build_measure_observation_ledger
+  - source objects preserved
+  - observable output present
+- name: postcondition and provenance
+  covers:
+  - postcondition
+  - provenance
+  assertions:
+  - feature id, source objects, unresolved, assumptions, and reservations are echoed
+- name: invalid precondition
+  covers:
+  - error
+  assertions:
+  - missing provenance returns missing_provenance
+  - no accepted result is emitted
+- name: opaque values pass-through
+  covers:
+  - opaque values
+  assertions:
+  - opaque evidence/context/relation labels are not interpreted, scored, ranked, or
+    normalized
+- name: scientific reservation propagation
+  covers:
+  - unresolved
+  - hypotheses
+  - absence of undefined science
+  assertions:
+  - requests for score, threshold, weight, hierarchy, metric selection, formula completion,
+    or moral decision return unsupported_scientific_completion_request
+- name: contract IR conformity
+  covers:
+  - contract to IR conformity
+  assertions:
+  - IR entrypoint implements the contract operation and preserves identical readiness
+    flags
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/test-plans/TLC-FC-10-VIRTUES-009/artifact.yaml
+++ b/registry/test-plans/TLC-FC-10-VIRTUES-009/artifact.yaml
@@ -1,0 +1,54 @@
+---
+feature_id: TLC-FC-10-VIRTUES-009
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-022
+status: limited_engineering_contract_with_reservations
+test_plan_id: TLC-FC-10-VIRTUES-009-TEST-PLAN
+entrypoint: register_quantitative_measure_reservations
+tests:
+- name: nominal operation
+  covers:
+  - real operation
+  - nominal case
+  assertions:
+  - accepted result names register_quantitative_measure_reservations
+  - source objects preserved
+  - observable output present
+- name: postcondition and provenance
+  covers:
+  - postcondition
+  - provenance
+  assertions:
+  - feature id, source objects, unresolved, assumptions, and reservations are echoed
+- name: invalid precondition
+  covers:
+  - error
+  assertions:
+  - missing provenance returns missing_provenance
+  - no accepted result is emitted
+- name: opaque values pass-through
+  covers:
+  - opaque values
+  assertions:
+  - opaque evidence/context/relation labels are not interpreted, scored, ranked, or
+    normalized
+- name: scientific reservation propagation
+  covers:
+  - unresolved
+  - hypotheses
+  - absence of undefined science
+  assertions:
+  - requests for score, threshold, weight, hierarchy, metric selection, formula completion,
+    or moral decision return unsupported_scientific_completion_request
+- name: contract IR conformity
+  covers:
+  - contract to IR conformity
+  assertions:
+  - IR entrypoint implements the contract operation and preserves identical readiness
+    flags
+readiness:
+  python_prototype: false
+  cpp_prototype: false
+  canonical_ir: false
+  production: false

--- a/registry/test-plans/TLC-FC-10-VIRTUES-010/artifact.yaml
+++ b/registry/test-plans/TLC-FC-10-VIRTUES-010/artifact.yaml
@@ -1,0 +1,55 @@
+---
+feature_id: TLC-FC-10-VIRTUES-010
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-003
+- TLC-SO-VIRTUES-067
+status: limited_engineering_contract_with_reservations
+test_plan_id: TLC-FC-10-VIRTUES-010-TEST-PLAN
+entrypoint: register_essential_property_indicators
+tests:
+- name: nominal operation
+  covers:
+  - real operation
+  - nominal case
+  assertions:
+  - accepted result names register_essential_property_indicators
+  - source objects preserved
+  - observable output present
+- name: postcondition and provenance
+  covers:
+  - postcondition
+  - provenance
+  assertions:
+  - feature id, source objects, unresolved, assumptions, and reservations are echoed
+- name: invalid precondition
+  covers:
+  - error
+  assertions:
+  - missing provenance returns missing_provenance
+  - no accepted result is emitted
+- name: opaque values pass-through
+  covers:
+  - opaque values
+  assertions:
+  - opaque evidence/context/relation labels are not interpreted, scored, ranked, or
+    normalized
+- name: scientific reservation propagation
+  covers:
+  - unresolved
+  - hypotheses
+  - absence of undefined science
+  assertions:
+  - requests for score, threshold, weight, hierarchy, metric selection, formula completion,
+    or moral decision return unsupported_scientific_completion_request
+- name: contract IR conformity
+  covers:
+  - contract to IR conformity
+  assertions:
+  - IR entrypoint implements the contract operation and preserves identical readiness
+    flags
+readiness:
+  python_prototype: false
+  cpp_prototype: false
+  canonical_ir: false
+  production: false

--- a/registry/test-plans/TLC-FC-10-VIRTUES-011/artifact.yaml
+++ b/registry/test-plans/TLC-FC-10-VIRTUES-011/artifact.yaml
@@ -1,0 +1,55 @@
+---
+feature_id: TLC-FC-10-VIRTUES-011
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-055
+- TLC-SO-VIRTUES-212
+status: limited_engineering_contract_with_reservations
+test_plan_id: TLC-FC-10-VIRTUES-011-TEST-PLAN
+entrypoint: package_vice_diagnostic_function
+tests:
+- name: nominal operation
+  covers:
+  - real operation
+  - nominal case
+  assertions:
+  - accepted result names package_vice_diagnostic_function
+  - source objects preserved
+  - observable output present
+- name: postcondition and provenance
+  covers:
+  - postcondition
+  - provenance
+  assertions:
+  - feature id, source objects, unresolved, assumptions, and reservations are echoed
+- name: invalid precondition
+  covers:
+  - error
+  assertions:
+  - missing provenance returns missing_provenance
+  - no accepted result is emitted
+- name: opaque values pass-through
+  covers:
+  - opaque values
+  assertions:
+  - opaque evidence/context/relation labels are not interpreted, scored, ranked, or
+    normalized
+- name: scientific reservation propagation
+  covers:
+  - unresolved
+  - hypotheses
+  - absence of undefined science
+  assertions:
+  - requests for score, threshold, weight, hierarchy, metric selection, formula completion,
+    or moral decision return unsupported_scientific_completion_request
+- name: contract IR conformity
+  covers:
+  - contract to IR conformity
+  assertions:
+  - IR entrypoint implements the contract operation and preserves identical readiness
+    flags
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false

--- a/registry/test-plans/TLC-FC-10-VIRTUES-014/artifact.yaml
+++ b/registry/test-plans/TLC-FC-10-VIRTUES-014/artifact.yaml
@@ -1,0 +1,58 @@
+---
+feature_id: TLC-FC-10-VIRTUES-014
+domain: virtues
+source_objects:
+- TLC-SO-VIRTUES-013
+- TLC-SO-VIRTUES-020
+- TLC-SO-VIRTUES-054
+- TLC-SO-VIRTUES-093
+- TLC-SO-VIRTUES-116
+status: limited_engineering_contract_with_reservations
+test_plan_id: TLC-FC-10-VIRTUES-014-TEST-PLAN
+entrypoint: map_contextual_virtue_relations
+tests:
+- name: nominal operation
+  covers:
+  - real operation
+  - nominal case
+  assertions:
+  - accepted result names map_contextual_virtue_relations
+  - source objects preserved
+  - observable output present
+- name: postcondition and provenance
+  covers:
+  - postcondition
+  - provenance
+  assertions:
+  - feature id, source objects, unresolved, assumptions, and reservations are echoed
+- name: invalid precondition
+  covers:
+  - error
+  assertions:
+  - missing provenance returns missing_provenance
+  - no accepted result is emitted
+- name: opaque values pass-through
+  covers:
+  - opaque values
+  assertions:
+  - opaque evidence/context/relation labels are not interpreted, scored, ranked, or
+    normalized
+- name: scientific reservation propagation
+  covers:
+  - unresolved
+  - hypotheses
+  - absence of undefined science
+  assertions:
+  - requests for score, threshold, weight, hierarchy, metric selection, formula completion,
+    or moral decision return unsupported_scientific_completion_request
+- name: contract IR conformity
+  covers:
+  - contract to IR conformity
+  assertions:
+  - IR entrypoint implements the contract operation and preserves identical readiness
+    flags
+readiness:
+  python_prototype: true
+  cpp_prototype: true
+  canonical_ir: false
+  production: false


### PR DESCRIPTION
### Motivation
- Introduce a new `virtues` domain registry so features can be tracked, validated, and tested against engineering contracts and IRs.
- Provide formal IR descriptions for a set of features to capture entrypoints, inputs, observable outputs, error policies, and readiness flags.
- Supply corresponding `math-contracts` to define contract-level I/O, pre/postconditions, errors, and traceability for each feature.
- Add explicit `test-plans` to enumerate nominal, error, provenance, and reservation propagation checks for each feature.

### Description
- Added a domain completion report at `registry/domain-progress/virtues/domain-completion-report.yaml` summarizing feature counts, IR classifications, readiness states, and reservation flags.
- Added IR artifacts for features `TLC-FC-10-VIRTUES-001`, `002`, `005`, `006`, `007`, `008`, `009`, `010`, `011`, and `014` under `registry/ir/*/artifact.yaml`, each declaring `entrypoint`, `operation`, `inputs`, `observable_output`, `error_policy`, `opaque_or_parametric_types`, `classification`/`classification_code`, and `readiness` fields.
- Added matching `math-contracts` for each of the above features at `registry/math-contracts/*/artifact.yaml` defining `contract_id`, `responsibility`, typed `inputs`/`outputs`, `preconditions`, `postconditions`, `errors`, `unresolved_propagated`/`provisional_assumptions`, and `readiness` flags.
- Added test plans for each feature at `registry/test-plans/*/artifact.yaml` enumerating nominal operation, postcondition/provenance checks, invalid precondition assertions, opaque pass-through assertions, scientific reservation propagation tests, and contract-to-IR conformity checks.

### Testing
- No automated unit or integration tests were added as part of these registry YAML additions.
- The change includes `readiness` flags for each artifact to indicate prototype/production state but no runtime artifacts to exercise.
- Please run the repository's CI schema/lint validation to verify YAML formatting and registry consistency prior to merging; this PR does not include CI results.
- Manual inspection was used to ensure each contract/IR/test-plan pair preserves feature identifiers and matching readiness flags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63987f0eec8327a363d8bd1b09a270)

## Summary by Sourcery

Introduce the new `virtues` domain registry with a complete set of contract, IR, and test-plan artifacts for ten features, plus a domain completion report capturing their classification and readiness status.

New Features:
- Define intermediate representation (IR) artifacts for virtues features TLC-FC-10-VIRTUES-001, 002, 005, 006, 007, 008, 009, 010, 011, and 014, including entrypoints, inputs, outputs, and error policies.
- Add math-contract artifacts for the same virtues features, specifying responsibilities, typed I/O, pre/postconditions, errors, reservations, and traceability.
- Create structured test-plan artifacts for each virtues feature to validate nominal behavior, error handling, opaque value pass-through, scientific reservation propagation, and contract–IR conformity.
- Add a domain completion report for the virtues registry summarizing feature counts, IR classifications, test-plan coverage, and readiness flags.

Enhancements:
- Align readiness flags and source object traceability across IRs, math-contracts, and test-plans to ensure consistent lifecycle tracking within the virtues domain.