### PR TITLE
feat(ir): complete competencies domain through canonical IR

### DIFF
--- a/registry/ir-batches/competencies-domain-completion-001/manifest.yaml
+++ b/registry/ir-batches/competencies-domain-completion-001/manifest.yaml
@@ -1,0 +1,149 @@
+batch_id: competencies-domain-completion-001
+domain_id: competencies
+base_commit: 25eb100708ee413c23ab75078c0f7e96677ed042
+catalogue:
+  feature_count: 13
+  feature_ids:
+  - TLC-FC-12-COMPETENCIES-001
+  - TLC-FC-12-COMPETENCIES-002
+  - TLC-FC-12-COMPETENCIES-004
+  - TLC-FC-12-COMPETENCIES-005
+  - TLC-FC-12-COMPETENCIES-006
+  - TLC-FC-12-COMPETENCIES-007
+  - TLC-FC-12-COMPETENCIES-008
+  - TLC-FC-12-COMPETENCIES-009
+  - TLC-FC-12-COMPETENCIES-010
+  - TLC-FC-12-COMPETENCIES-011
+  - TLC-FC-12-COMPETENCIES-012
+  - TLC-FC-12-COMPETENCIES-013
+  - TLC-FC-12-COMPETENCIES-016
+initial_state: preparation_complete_with_reservations; no canonical contracts, IR,
+  or test plans expected
+created:
+  contracts:
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-001/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-002/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-004/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-005/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-006/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-007/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-008/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-009/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-010/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-011/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-012/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-013/contract.yaml
+  - registry/math-contracts/TLC-FC-12-COMPETENCIES-016/contract.yaml
+  irs:
+  - registry/ir/TLC-FC-12-COMPETENCIES-001/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-002/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-004/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-005/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-006/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-007/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-008/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-009/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-010/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-011/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-012/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-013/ir.yaml
+  - registry/ir/TLC-FC-12-COMPETENCIES-016/ir.yaml
+  test_plans:
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-001/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-002/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-004/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-005/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-006/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-007/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-008/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-009/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-010/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-011/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-012/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-013/test-plan.yaml
+  - registry/test-plans/TLC-FC-12-COMPETENCIES-016/test-plan.yaml
+reused:
+- registry/domain-progress/competencies/feature-catalogue.yaml
+- registry/domain-progress/competencies/production-readiness.yaml
+- registry/domain-progress/competencies/scientific-inventory.yaml
+- maths/12-competencies.md as source only, not modified
+consolidated: []
+historical_conserved:
+- preparation artifacts under registry/domain-progress/competencies/ retained as source
+  of catalogue/readiness
+classification: complete_to_canonical_declarative_ir_with_reservations
+readiness:
+  python: structural descriptor ready with reservations; scientific execution non_executable
+  cpp: structural descriptor ready with reservations; scientific execution non_executable
+blockers:
+- scientific unresolved
+- validated executable semantics absent
+- capacities dependency external_unreconciled for catalogue-marked features
+scientific_questions:
+- types/dimensions/units/thresholds/temporal semantics remain unresolved where absent
+  from sources
+- numeric oracles and executable equation semantics require future scientific decisions
+validations:
+- command: git diff --check
+  status: pass
+- command: python scripts/validate_competencies_domain.py
+  status: pass
+  summary: features=13 contracts=13 irs=13 test_plans=13
+- command: PyYAML parse of added/modified YAML files
+  status: pass
+  summary: 40 YAML files parsed
+- command: git diff --name-only HEAD -- maths
+  status: pass
+  summary: no maths changes
+- command: git diff --name-only HEAD | rg "(^|/)artifact\.yaml$"
+  status: pass
+  summary: no added or modified artifact.yaml
+- command: PYTHONPATH=/usr/lib/python3/dist-packages python scripts/validate_competencies_preparation.py
+  status: warning
+  summary: preparation-scope validator reports new completion artifacts as out of
+    scope
+modified_files:
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-001/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-001/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-001/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-002/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-002/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-002/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-004/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-004/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-004/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-005/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-005/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-005/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-006/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-006/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-006/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-007/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-007/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-007/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-008/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-008/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-008/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-009/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-009/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-009/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-010/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-010/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-010/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-011/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-011/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-011/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-012/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-012/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-012/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-013/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-013/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-013/test-plan.yaml
+- registry/math-contracts/TLC-FC-12-COMPETENCIES-016/contract.yaml
+- registry/ir/TLC-FC-12-COMPETENCIES-016/ir.yaml
+- registry/test-plans/TLC-FC-12-COMPETENCIES-016/test-plan.yaml
+- scripts/validate_competencies_domain.py
+- registry/ir-batches/competencies-domain-completion-001/manifest.yaml
+- reports/ir-batches/competencies-domain-completion-001/completion-report.md
+completion_conclusion: 'Structural completion achieved for all 13 canonical competencies
+  features: 13 contracts, 13 IRs, and 13 test plans.'

--- a/registry/ir/TLC-FC-12-COMPETENCIES-001/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-001/ir.yaml
@@ -1,0 +1,101 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-001
+feature_id: TLC-FC-12-COMPETENCIES-001
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-001
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-001/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_constraint_evaluation_record_001
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-001
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-044
+  - TLC-SO-COMPETENCIES-099
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-002/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-002/ir.yaml
@@ -1,0 +1,100 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-002
+feature_id: TLC-FC-12-COMPETENCIES-002
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-002
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-002/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_constraint_evaluation_record_002
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-002
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-031
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-004/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-004/ir.yaml
@@ -1,0 +1,106 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-004
+feature_id: TLC-FC-12-COMPETENCIES-004
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-004
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-004/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_evolution_dynamics_record_004
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-004
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-066
+  - TLC-SO-COMPETENCIES-096
+  - TLC-SO-COMPETENCIES-097
+  - TLC-SO-COMPETENCIES-098
+  - TLC-SO-COMPETENCIES-114
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+- capacities dependency remains external_unreconciled
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+- Capacities external dependency unreconciled
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: false
+  ready_for_cpp_prototype: false
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-005/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-005/ir.yaml
@@ -1,0 +1,102 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-005
+feature_id: TLC-FC-12-COMPETENCIES-005
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-005
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-005/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_evolution_dynamics_record_005
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-005
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-072
+  - TLC-SO-COMPETENCIES-101
+  - TLC-SO-COMPETENCIES-106
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-006/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-006/ir.yaml
@@ -1,0 +1,110 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-006
+feature_id: TLC-FC-12-COMPETENCIES-006
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-006
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-006/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_transformation_record_006
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-006
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-067
+  - TLC-SO-COMPETENCIES-068
+  - TLC-SO-COMPETENCIES-073
+  - TLC-SO-COMPETENCIES-074
+  - TLC-SO-COMPETENCIES-086
+  - TLC-SO-COMPETENCIES-100
+  - TLC-SO-COMPETENCIES-102
+  - TLC-SO-COMPETENCIES-103
+  - TLC-SO-COMPETENCIES-105
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+- capacities dependency remains external_unreconciled
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+- Capacities external dependency unreconciled
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: false
+  ready_for_cpp_prototype: false
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-007/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-007/ir.yaml
@@ -1,0 +1,101 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-007
+feature_id: TLC-FC-12-COMPETENCIES-007
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-007
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-007/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_transformation_record_007
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-007
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-065
+  - TLC-SO-COMPETENCIES-104
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-008/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-008/ir.yaml
@@ -1,0 +1,103 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-008
+feature_id: TLC-FC-12-COMPETENCIES-008
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-008
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-008/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_transformation_record_008
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-008
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-108
+  - TLC-SO-COMPETENCIES-109
+  - TLC-SO-COMPETENCIES-110
+  - TLC-SO-COMPETENCIES-111
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-009/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-009/ir.yaml
@@ -1,0 +1,102 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-009
+feature_id: TLC-FC-12-COMPETENCIES-009
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-009
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-009/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_metric_evaluation_record_009
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-009
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-022
+  - TLC-SO-COMPETENCIES-035
+  - TLC-SO-COMPETENCIES-085
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-010/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-010/ir.yaml
@@ -1,0 +1,100 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-010
+feature_id: TLC-FC-12-COMPETENCIES-010
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-010
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-010/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_metric_evaluation_record_010
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-010
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-023
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-011/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-011/ir.yaml
@@ -1,0 +1,102 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-011
+feature_id: TLC-FC-12-COMPETENCIES-011
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-011
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-011/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_metric_evaluation_record_011
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-011
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-024
+  - TLC-SO-COMPETENCIES-038
+  - TLC-SO-COMPETENCIES-043
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-012/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-012/ir.yaml
@@ -1,0 +1,100 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-012
+feature_id: TLC-FC-12-COMPETENCIES-012
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-012
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-012/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_scientific_operator_record_012
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-012
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-007
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-013/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-013/ir.yaml
@@ -1,0 +1,101 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-013
+feature_id: TLC-FC-12-COMPETENCIES-013
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-013
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-013/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_scientific_operator_record_013
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-013
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-003
+  - TLC-SO-COMPETENCIES-055
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/ir/TLC-FC-12-COMPETENCIES-016/ir.yaml
+++ b/registry/ir/TLC-FC-12-COMPETENCIES-016/ir.yaml
@@ -1,0 +1,100 @@
+---
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-016
+feature_id: TLC-FC-12-COMPETENCIES-016
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-016
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-016/contract.yaml
+ir_kind: canonical_declarative_ir_with_reservations
+entrypoint: competencies_preserve_relation_evaluation_record_016
+primary_operation: build_competencies_canonical_descriptor
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-016
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-056
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+opaque_types:
+- OpaqueScientificObject
+- OpaqueScientificValue
+parameterized_types:
+- Map<ObjectId,OpaqueScientificObject>
+- List<SourceReference>
+operations:
+- name: validate_feature_and_object_set
+  behavior: check feature id, required object ids, duplicates, and provenance presence
+    before descriptor creation
+- name: build_competencies_canonical_descriptor
+  behavior: assemble immutable descriptor from catalogue object ids, declared symbols,
+    category/status labels, source statements, reservations, and provenance without
+    evaluating scientific content
+- name: reject_scientific_evaluation_request
+  behavior: raise ScientificEvaluationRequested for score, threshold, simulation,
+    rank, probability, causal effect, or resolved scientific truth requests
+operation_sequence:
+- validate_feature_and_object_set
+- build_competencies_canonical_descriptor
+- reject_scientific_evaluation_request guard is available for evaluator integrations
+constraints:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+propagated_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+determinism_status: deterministic for identical feature id, object ids, payload identities,
+  symbols, source statements, reservations, and provenance; opaque payload internals
+  ignored
+testability_status: structural, traceability, rejection, and determinism behavior
+  testable; scientific semantics intentionally untestable
+implementation_constraints:
+- do not evaluate formulas or symbols
+- do not infer missing endpoints or relations
+- do not create scores, levels, weights, thresholds, temporal progress, or probabilities
+- preserve catalogue order and provenance
+classification: canonical_declarative_non_executable
+readiness:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-001/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-001/contract.yaml
@@ -1,0 +1,168 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-001
+feature_id: TLC-FC-12-COMPETENCIES-001
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Formalisation mathématique avancée
+  subsection: Fondements axiomatiques
+  start_line: 254
+  end_line: 260
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Dynamique temporelle et évolution
+  subsection: Progression vers la maîtrise
+  start_line: 186
+  end_line: 188
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-044
+  canonical_name: Fondements axiomatiques
+  object_type: Axiom
+  status: candidate
+  symbols:
+  - "\\mathcal{C}_p"
+  - "\\mathcal{X}"
+  - "\\mathcal{A}"
+  - "\\Gamma(\\mathcal{X})"
+  - "\\mathcal"
+  - "\\mu"
+  - "\\mu(\\mathcal{C}_p)"
+  source_statement: |-
+    **Axiome 1 – Actualisation contextuelle** : pour tout système de capacités $\mathcal{C}_p$ et contexte $\mathcal{X}$, il existe un opérateur d’actualisation $\mathcal{A}$ tel que :
+    \[
+    \lim_{t\to\infty} \mu\big( \mathcal{T}^t(\mathcal{C}_p,\mathcal{X}) \cap \mathcal{C}_a \big) = \mu(\mathcal{C}_p) \cdot \Gamma(\mathcal{X})
+    \]
+    où $\Gamma(\mathcal{X})$ est l’adéquation contextuelle (Vygotsky, 1978).
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Formalisation mathématique avancée
+    subsection: Fondements axiomatiques
+    start_line: 254
+    end_line: 260
+- object_id: TLC-SO-COMPETENCIES-099
+  canonical_name: Équation — Progression vers la maîtrise
+  object_type: Constraint
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  source_statement: |-
+    \[
+    \mathcal{C}_{a,\mathrm{maîtrise}} = \arg\max \big( \mathcal{M}(c) \cdot \|\mathcal{C}_{\mathrm{émergent}}\| \big) \quad \text{sous contraintes éthiques}
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Dynamique temporelle et évolution
+    subsection: Progression vers la maîtrise
+    start_line: 186
+    end_line: 188
+covered_relations: []
+functional_purpose: Evaluate the cited constraints, axioms, assumptions, and hypotheses
+  as candidate checks.
+canonical_category: constraint_evaluation
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_constraint_evaluation_record_001: create
+  a provenance-preserving canonical representation for 12-competencies: constraint
+  (blocked_locally); permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-001
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-044
+  - TLC-SO-COMPETENCIES-099
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: constraint (blocked_locally)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-002/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-002/contract.yaml
@@ -1,0 +1,131 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-002
+feature_id: TLC-FC-12-COMPETENCIES-002
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Dynamique temporelle et évolution
+  subsection: Progression vers la maîtrise
+  start_line: 184
+  end_line: 188
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-031
+  canonical_name: Progression vers la maîtrise
+  object_type: Constraint
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  source_statement: |-
+    La maîtrise implique un développement équilibré de toutes les dimensions et l’émergence d’une capacité d’innovation :
+    \[
+    \mathcal{C}_{a,\mathrm{maîtrise}} = \arg\max \big( \mathcal{M}(c) \cdot \|\mathcal{C}_{\mathrm{émergent}}\| \big) \quad \text{sous contraintes éthiques}
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Dynamique temporelle et évolution
+    subsection: Progression vers la maîtrise
+    start_line: 184
+    end_line: 188
+covered_relations: []
+functional_purpose: Evaluate the cited constraints, axioms, assumptions, and hypotheses
+  as candidate checks.
+canonical_category: constraint_evaluation
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_constraint_evaluation_record_002: create
+  a provenance-preserving canonical representation for 12-competencies: constraint
+  (provisionally_separated); permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-002
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-031
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: constraint (provisionally_separated)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-004/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-004/contract.yaml
@@ -1,0 +1,273 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-004
+feature_id: TLC-FC-12-COMPETENCIES-004
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Transformation de la capacité à la compétence
+  subsection: Pratique et application
+  start_line: 82
+  end_line: 84
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Dynamique temporelle et évolution
+  subsection: Acquisition à court terme
+  start_line: 166
+  end_line: 168
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Dynamique temporelle et évolution
+  subsection: Développement à long terme
+  start_line: 172
+  end_line: 174
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Dynamique temporelle et évolution
+  subsection: Adaptation à des situations nouvelles
+  start_line: 179
+  end_line: 181
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Formalisation mathématique avancée
+  subsection: Systèmes dynamiques
+  start_line: 298
+  end_line: 304
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-066
+  canonical_name: Équation — Pratique et application
+  object_type: DifferentialEquation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\alpha"
+  - "\\beta"
+  source_statement: |-
+    \[
+    \frac{d\mathcal{C}_a}{dt} = \alpha \cdot \mathcal{P}(t) \cdot (1 - \mathcal{C}_a / \mathcal{C}_{\max}) + \beta \cdot \mathcal{G}(t) \cdot (\mathcal{C}_p - \mathcal{C}_a)
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Transformation de la capacité à la compétence
+    subsection: Pratique et application
+    start_line: 82
+    end_line: 84
+- object_id: TLC-SO-COMPETENCIES-096
+  canonical_name: Équation — Acquisition à court terme
+  object_type: DifferentialEquation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\Delta"
+  - "\\alpha"
+  - "\\sigma"
+  source_statement: |-
+    \[
+    \mathcal{C}_a(t + \Delta t) = \mathcal{C}_a(t) + \alpha \mathcal{P}(t) \Delta t + \sigma \sqrt{\Delta t} \mathcal{N}(0,1)
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Dynamique temporelle et évolution
+    subsection: Acquisition à court terme
+    start_line: 166
+    end_line: 168
+- object_id: TLC-SO-COMPETENCIES-097
+  canonical_name: Équation — Développement à long terme
+  object_type: DifferentialEquation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\Delta_i"
+  - "\\mathbf"
+  source_statement: |-
+    \[
+    \|\mathcal{C}_a(t)\| = \frac{K}{1 + \exp(-r(t - t_0))} + \sum_i \Delta_i \mathbf{1}_{t > t_i}
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Dynamique temporelle et évolution
+    subsection: Développement à long terme
+    start_line: 172
+    end_line: 174
+- object_id: TLC-SO-COMPETENCIES-098
+  canonical_name: Équation — Adaptation à des situations nouvelles
+  object_type: DifferentialEquation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  - "\\nabla_{\\mathrm{contexte}"
+  - "\\Delta"
+  source_statement: |-
+    \[
+    \mathcal{C}_a^{\mathrm{nouveau}} = \mathcal{C}_a^{\mathrm{ancien}} + \nabla_{\mathrm{contexte}}\mathcal{C}_a \cdot \Delta \mathrm{contexte} + \mathcal{G}(\mathcal{C}_p,\mathcal{F})
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Dynamique temporelle et évolution
+    subsection: Adaptation à des situations nouvelles
+    start_line: 179
+    end_line: 181
+- object_id: TLC-SO-COMPETENCIES-114
+  canonical_name: Équation — Systèmes dynamiques
+  object_type: DifferentialEquation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathbf"
+  - "\\Delta"
+  - "\\nabla_{\\mathcal{C}"
+  - "\\Phi"
+  - "\\epsilon(t)"
+  - "\\eta(t)"
+  - "\\nabla_{\\mathcal{V}"
+  - "\\zeta(t)"
+  source_statement: |-
+    \[
+    \begin{cases}
+    \displaystyle\frac{d\mathcal{C}_a}{dt} = \mathbf{A}(t)\cdot\mathcal{C}_a\cdot(\mathbf{1}-\mathcal{C}_a) + \mathbf{B}\cdot\mathcal{C}_p + \mathbf{\Gamma}(t)\cdot\mathcal{V} + \mathbf{\Delta}\cdot\nabla_{\mathcal{C}_a}\Phi + \mathbf{\Sigma}(t)\epsilon(t)\\[1.5em]
+    \displaystyle\frac{d\mathcal{C}_p}{dt} = \mathbf{M}_p(t)\cdot\mathcal{C}_a\cdot(\mathcal{C}_{p,\max}-\mathcal{C}_p) + \mathbf{N}_p(t)\cdot\mathcal{V}\cdot\mathcal{C}_p + \mathbf{O}_p\cdot\nabla_{\mathcal{C}_p}\Psi + \mathbf{\Xi}_p(t)\eta(t)\\[1.5em]
+    \displaystyle\frac{d\mathcal{V}}{dt} = \mathbf{K}_v(t)\cdot\mathcal{C}_a\cdot(\mathcal{V}_{\max}-\mathcal{V}) + \mathbf{L}_v(t)\cdot\mathcal{C}_p\cdot\mathcal{V} + \mathbf{M}_v\cdot\nabla_{\mathcal{V}}\Omega + \mathbf{N}_v(t)\zeta(t)
+    \end{cases}
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Formalisation mathématique avancée
+    subsection: Systèmes dynamiques
+    start_line: 298
+    end_line: 304
+covered_relations: []
+functional_purpose: Evaluate the evolution laws expressed by the cited differential
+  or stochastic equations.
+canonical_category: evolution_dynamics
+capacities_dependency: external_unreconciled
+primary_responsibility: 'competencies_preserve_evolution_dynamics_record_004: create
+  a provenance-preserving canonical representation for 12-competencies: dynamics (admissible);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-004
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-066
+  - TLC-SO-COMPETENCIES-096
+  - TLC-SO-COMPETENCIES-097
+  - TLC-SO-COMPETENCIES-098
+  - TLC-SO-COMPETENCIES-114
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+- Capacities external dependency unreconciled
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+- capacities dependency remains external_unreconciled
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: dynamics (admissible)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: false
+  ready_for_cpp_prototype: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: true

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-005/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-005/contract.yaml
@@ -1,0 +1,192 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-005
+feature_id: TLC-FC-12-COMPETENCIES-005
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Transmission et modalités d’apprentissage
+  subsection: Instruction directe et mentorat
+  start_line: 109
+  end_line: 111
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Dimensions éthiques, motivationnelles et cognitives
+  subsection: Moteurs motivationnels et engagement
+  start_line: 200
+  end_line: 202
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Interaction avec la communauté et compétences collectives
+  subsection: Boucles de rétroaction dans l’apprentissage collectif
+  start_line: 235
+  end_line: 237
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-072
+  canonical_name: Équation — Instruction directe et mentorat
+  object_type: DifferentialEquation
+  status: candidate
+  symbols:
+  - "\\Delta"
+  - "\\mathcal"
+  - "\\mu"
+  source_statement: |-
+    \[
+    \Delta \mathcal{C}_a = \kappa \cdot \|\mathcal{C}_{a,\mathcal{M}} - \mathcal{C}_{a,\mathcal{D}}\| \cdot \exp(-\mu t)
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Transmission et modalités d’apprentissage
+    subsection: Instruction directe et mentorat
+    start_line: 109
+    end_line: 111
+- object_id: TLC-SO-COMPETENCIES-101
+  canonical_name: Équation — Moteurs motivationnels et engagement
+  object_type: DifferentialEquation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  source_statement: |-
+    \[
+    \frac{d\mathcal{C}_a}{dt} \propto \mathcal{M}(t) \cdot (1 - \mathcal{C}_a / \mathcal{C}_{\max})
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Dimensions éthiques, motivationnelles et cognitives
+    subsection: Moteurs motivationnels et engagement
+    start_line: 200
+    end_line: 202
+- object_id: TLC-SO-COMPETENCIES-106
+  canonical_name: Équation — Boucles de rétroaction dans l’apprentissage collectif
+  object_type: DifferentialEquation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mu(j)"
+  source_statement: |-
+    \[
+    \frac{d\mathcal{C}_{a,i}}{dt} = \int_{\mathcal{C}} K(i,j) (\mathcal{C}_{a,j} - \mathcal{C}_{a,i}) d\mu(j)
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Interaction avec la communauté et compétences collectives
+    subsection: Boucles de rétroaction dans l’apprentissage collectif
+    start_line: 235
+    end_line: 237
+covered_relations: []
+functional_purpose: Evaluate the evolution laws expressed by the cited differential
+  or stochastic equations.
+canonical_category: evolution_dynamics
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_evolution_dynamics_record_005: create
+  a provenance-preserving canonical representation for 12-competencies: dynamics (blocked_locally);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-005
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-072
+  - TLC-SO-COMPETENCIES-101
+  - TLC-SO-COMPETENCIES-106
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: dynamics (blocked_locally)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-006/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-006/contract.yaml
@@ -1,0 +1,394 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-006
+feature_id: TLC-FC-12-COMPETENCIES-006
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Transformation de la capacité à la compétence
+  subsection: Consolidation de l’habileté
+  start_line: 89
+  end_line: 91
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Transformation de la capacité à la compétence
+  subsection: Intégration avec Valeurs, Vertus et Principes
+  start_line: 95
+  end_line: 97
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Transmission et modalités d’apprentissage
+  subsection: Apprentissage observationnel et imitation
+  start_line: 115
+  end_line: 117
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Transmission et modalités d’apprentissage
+  subsection: Apprentissage expérientiel et pratique itérative
+  start_line: 121
+  end_line: 123
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Évaluation et métriques des Compétences
+  subsection: Indicateurs qualitatifs
+  start_line: 144
+  end_line: 146
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Dimensions éthiques, motivationnelles et cognitives
+  subsection: Alignement avec Valeurs, Vertus et Principes
+  start_line: 194
+  end_line: 196
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Dimensions éthiques, motivationnelles et cognitives
+  subsection: Charge cognitive, insight et efficacité de résolution de problèmes
+  start_line: 207
+  end_line: 209
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Dimensions éthiques, motivationnelles et cognitives
+  subsection: Intégration comportementale et performance habituelle
+  start_line: 214
+  end_line: 216
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Interaction avec la communauté et compétences collectives
+  subsection: Compétence collective émergente
+  start_line: 229
+  end_line: 231
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-067
+  canonical_name: Équation — Consolidation de l’habileté
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\gamma"
+  - "\\lambda"
+  - "\\mathrm"
+  source_statement: |-
+    \[
+    \mathcal{C}_a(t+1) = \mathcal{C}_a(t) + \gamma \cdot \exp(-\lambda t) \cdot (\mathcal{C}_{\mathrm{cible}} - \mathcal{C}_a(t))
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Transformation de la capacité à la compétence
+    subsection: Consolidation de l’habileté
+    start_line: 89
+    end_line: 91
+- object_id: TLC-SO-COMPETENCIES-068
+  canonical_name: Équation — Intégration avec Valeurs, Vertus et Principes
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  - "\\eta_1"
+  - "\\Phi(\\mathcal{F},\\mathcal{C}_a)"
+  - "\\eta_2"
+  - "\\nu"
+  - "\\eta_3"
+  - "\\Pi(\\mathcal{P},\\mathcal{C}_a)"
+  source_statement: |-
+    \[
+    \mathcal{C}_a^{\mathrm{intégré}} = \mathcal{C}_a + \eta_1 \Phi(\mathcal{F},\mathcal{C}_a) + \eta_2 \Psi(\nu,\mathcal{C}_a) + \eta_3 \Pi(\mathcal{P},\mathcal{C}_a)
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Transformation de la capacité à la compétence
+    subsection: Intégration avec Valeurs, Vertus et Principes
+    start_line: 95
+    end_line: 97
+- object_id: TLC-SO-COMPETENCIES-073
+  canonical_name: Équation — Apprentissage observationnel et imitation
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  - "\\lambda"
+  source_statement: |-
+    \[
+    \mathcal{C}_a^{\mathrm{nouveau}} = \mathcal{C}_a + \lambda \cdot \mathcal{I}(\mathcal{C}_{a,\mathcal{M}})
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Transmission et modalités d’apprentissage
+    subsection: Apprentissage observationnel et imitation
+    start_line: 115
+    end_line: 117
+- object_id: TLC-SO-COMPETENCIES-074
+  canonical_name: Équation — Apprentissage expérientiel et pratique itérative
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\eta(\\tau)"
+  - "\\mathrm"
+  source_statement: |-
+    \[
+    \mathcal{C}_a(t) = \mathcal{C}_a(0) + \int_0^t \eta(\tau) \cdot \mathcal{E}_{\mathrm{exp}}(\tau)\,d\tau
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Transmission et modalités d’apprentissage
+    subsection: Apprentissage expérientiel et pratique itérative
+    start_line: 121
+    end_line: 123
+- object_id: TLC-SO-COMPETENCIES-086
+  canonical_name: Équation — Indicateurs qualitatifs
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  source_statement: |2-
+      \[
+      \mathcal{M}(c) = \frac{1}{5} \big( \mathcal{E}_{\mathrm{tech}}(c) + \mathcal{E}_{\mathrm{cog}}(c) + \mathcal{E}_{\mathrm{soc}}(c) + \mathcal{E}_{\mathrm{adapt}}(c) + \mathcal{E}_{\mathrm{meta}}(c) \big)
+      \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Évaluation et métriques des Compétences
+    subsection: Indicateurs qualitatifs
+    start_line: 144
+    end_line: 146
+- object_id: TLC-SO-COMPETENCIES-100
+  canonical_name: Équation — Alignement avec Valeurs, Vertus et Principes
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathrm"
+  - "\\mathcal"
+  - "\\nu"
+  source_statement: |-
+    \[
+    \mathrm{Cohérence} = \langle \mathcal{C}_a, \pi_{\mathcal{F}}(\mathcal{C}_a) \rangle + \langle \mathcal{C}_a, \pi_{\nu}(\mathcal{C}_a) \rangle + \langle \mathcal{C}_a, \pi_{\mathcal{P}}(\mathcal{C}_a) \rangle
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Dimensions éthiques, motivationnelles et cognitives
+    subsection: Alignement avec Valeurs, Vertus et Principes
+    start_line: 194
+    end_line: 196
+- object_id: TLC-SO-COMPETENCIES-102
+  canonical_name: Équation — Charge cognitive, insight et efficacité de résolution
+    de problèmes
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathrm"
+  - "\\lambda"
+  - "\\mathcal"
+  source_statement: |-
+    \[
+    \mathrm{Charge}(t) = \mathrm{Charge}_0 \cdot \exp(-\lambda \|\mathcal{C}_a\|)
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Dimensions éthiques, motivationnelles et cognitives
+    subsection: Charge cognitive, insight et efficacité de résolution de problèmes
+    start_line: 207
+    end_line: 209
+- object_id: TLC-SO-COMPETENCIES-103
+  canonical_name: Équation — Intégration comportementale et performance habituelle
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathrm"
+  - "\\mathcal"
+  source_statement: |-
+    \[
+    \mathrm{Réponse}(c) = \mathcal{C}_a(c) \quad \text{sans délibération consciente}
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Dimensions éthiques, motivationnelles et cognitives
+    subsection: Intégration comportementale et performance habituelle
+    start_line: 214
+    end_line: 216
+- object_id: TLC-SO-COMPETENCIES-105
+  canonical_name: Équation — Compétence collective émergente
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  - "\\nu"
+  source_statement: |-
+    \[
+    \mathcal{C}_{a,\mathrm{émergent}} = \mathcal{G}_{\mathrm{collectif}}(\{\mathcal{C}_{a,i}\}, \mathcal{F}, \nu, \mathcal{CP})
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Interaction avec la communauté et compétences collectives
+    subsection: Compétence collective émergente
+    start_line: 229
+    end_line: 231
+covered_relations: []
+functional_purpose: Evaluate the transformations expressed by the cited equations
+  once their mathematical contract is selected.
+canonical_category: transformation
+capacities_dependency: external_unreconciled
+primary_responsibility: 'competencies_preserve_transformation_record_006: create a
+  provenance-preserving canonical representation for 12-competencies: equation (admissible);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-006
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-067
+  - TLC-SO-COMPETENCIES-068
+  - TLC-SO-COMPETENCIES-073
+  - TLC-SO-COMPETENCIES-074
+  - TLC-SO-COMPETENCIES-086
+  - TLC-SO-COMPETENCIES-100
+  - TLC-SO-COMPETENCIES-102
+  - TLC-SO-COMPETENCIES-103
+  - TLC-SO-COMPETENCIES-105
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+- Capacities external dependency unreconciled
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+- capacities dependency remains external_unreconciled
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: equation (admissible)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: false
+  ready_for_cpp_prototype: false
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: true

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-007/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-007/contract.yaml
@@ -1,0 +1,164 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-007
+feature_id: TLC-FC-12-COMPETENCIES-007
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Domaines de validité
+  subsection:
+  start_line: 56
+  end_line: 58
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Interaction avec la communauté et compétences collectives
+  subsection: Cohérence et coordination entre Disciples
+  start_line: 222
+  end_line: 224
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-065
+  canonical_name: Équation — Domaines de validité
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathbb"
+  - "\\mathrm"
+  - "\\rho_{\\min}"
+  source_statement: |-
+    \[
+    \mathcal{U}_{\mathcal{C}_a} = \{ (d,t,c) \in \mathcal{D} \times \mathbb{R}^+ \times \mathcal{C} \mid \mathcal{R}_{\mathrm{aff}}(d,c) > \rho_{\min},\ t > t_{\min},\ \mathcal{E}_{\mathrm{env}} \in \mathcal{E}_{\mathrm{favorable}},\ \mathcal{C}_p(d) \neq \emptyset \}
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Domaines de validité
+    subsection:
+    start_line: 56
+    end_line: 58
+- object_id: TLC-SO-COMPETENCIES-104
+  canonical_name: Équation — Cohérence et coordination entre Disciples
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  - "\\sigma(\\mathcal{CP})"
+  source_statement: |-
+    \[
+    \mathcal{C}_{a,\mathrm{collectif}} = \frac{1}{N}\sum_{i=1}^{N} \mathcal{C}_{a,i} + \sigma(\mathcal{CP}) \cdot \mathrm{Synergie}(\{\mathcal{C}_{a,i}\})
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Interaction avec la communauté et compétences collectives
+    subsection: Cohérence et coordination entre Disciples
+    start_line: 222
+    end_line: 224
+covered_relations: []
+functional_purpose: Evaluate the transformations expressed by the cited equations
+  once their mathematical contract is selected.
+canonical_category: transformation
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_transformation_record_007: create a
+  provenance-preserving canonical representation for 12-competencies: equation (blocked_locally);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-007
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-065
+  - TLC-SO-COMPETENCIES-104
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: equation (blocked_locally)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-008/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-008/contract.yaml
@@ -1,0 +1,225 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-008
+feature_id: TLC-FC-12-COMPETENCIES-008
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Formalisation mathématique avancée
+  subsection: Fondements axiomatiques
+  start_line: 257
+  end_line: 259
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Formalisation mathématique avancée
+  subsection: Fondements axiomatiques
+  start_line: 263
+  end_line: 265
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Formalisation mathématique avancée
+  subsection: Fondements axiomatiques
+  start_line: 269
+  end_line: 271
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Formalisation mathématique avancée
+  subsection: Fondements axiomatiques
+  start_line: 275
+  end_line: 277
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-108
+  canonical_name: Équation — Fondements axiomatiques
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mu"
+  - "\\mathcal"
+  - "\\mu(\\mathcal{C}_p)"
+  source_statement: |-
+    \[
+    \lim_{t\to\infty} \mu\big( \mathcal{T}^t(\mathcal{C}_p,\mathcal{X}) \cap \mathcal{C}_a \big) = \mu(\mathcal{C}_p) \cdot \Gamma(\mathcal{X})
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Formalisation mathématique avancée
+    subsection: Fondements axiomatiques
+    start_line: 257
+    end_line: 259
+- object_id: TLC-SO-COMPETENCIES-109
+  canonical_name: Équation — Fondements axiomatiques
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\rho_{c_1}(c)"
+  - "\\rho_{c_2}(c)"
+  - "\\mathcal"
+  source_statement: |-
+    \[
+    \|\rho_{c_1}(c) - \rho_{c_2}(c)\| \le L \cdot d_{\mathcal{X}}(c_1,c_2) \cdot \mathcal{E}(c)
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Formalisation mathématique avancée
+    subsection: Fondements axiomatiques
+    start_line: 263
+    end_line: 265
+- object_id: TLC-SO-COMPETENCIES-110
+  canonical_name: Équation — Fondements axiomatiques
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  source_statement: |-
+    \[
+    \mathcal{C}_a = \mathcal{C}_{\mathrm{tech}} \oplus \mathcal{C}_{\mathrm{cog}} \oplus \mathcal{C}_{\mathrm{soc}} \oplus \mathcal{C}_{\mathrm{adapt}} \oplus \mathcal{C}_{\mathrm{meta}}
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Formalisation mathématique avancée
+    subsection: Fondements axiomatiques
+    start_line: 269
+    end_line: 271
+- object_id: TLC-SO-COMPETENCIES-111
+  canonical_name: Équation — Fondements axiomatiques
+  object_type: Equation
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  source_statement: |-
+    \[
+    \|\mathcal{D}_{\mathrm{vertu}}(c,v)\| \ge K \cdot [\mathcal{I}(c) \times \mathcal{G}(v)]
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Formalisation mathématique avancée
+    subsection: Fondements axiomatiques
+    start_line: 275
+    end_line: 277
+covered_relations: []
+functional_purpose: Evaluate the transformations expressed by the cited equations
+  once their mathematical contract is selected.
+canonical_category: transformation
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_transformation_record_008: create a
+  provenance-preserving canonical representation for 12-competencies: equation (provisionally_separated);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-008
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-108
+  - TLC-SO-COMPETENCIES-109
+  - TLC-SO-COMPETENCIES-110
+  - TLC-SO-COMPETENCIES-111
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: equation (provisionally_separated)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-009/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-009/contract.yaml
@@ -1,0 +1,184 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-009
+feature_id: TLC-FC-12-COMPETENCIES-009
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Évaluation et métriques des Compétences
+  subsection:
+  start_line: 131
+  end_line: 131
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Dimensions éthiques, motivationnelles et cognitives
+  subsection: Charge cognitive, insight et efficacité de résolution de problèmes
+  start_line: 205
+  end_line: 210
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Évaluation et métriques des Compétences
+  subsection: Indicateurs qualitatifs
+  start_line: 143
+  end_line: 143
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-022
+  canonical_name: Évaluation et métriques des Compétences
+  object_type: Metric
+  status: candidate
+  symbols: []
+  source_statement: Évaluation et métriques des Compétences
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Évaluation et métriques des Compétences
+    subsection:
+    start_line: 131
+    end_line: 131
+- object_id: TLC-SO-COMPETENCIES-035
+  canonical_name: Charge cognitive, insight et efficacité de résolution de problèmes
+  object_type: Metric
+  status: candidate
+  symbols:
+  - "\\mathrm"
+  - "\\lambda"
+  - "\\mathcal"
+  source_statement: |-
+    À mesure que les compétences se développent, la charge cognitive diminue par automatisation :
+    \[
+    \mathrm{Charge}(t) = \mathrm{Charge}_0 \cdot \exp(-\lambda \|\mathcal{C}_a\|)
+    \]
+    L’insight émerge lorsque les compétences sont suffisamment intégrées.
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Dimensions éthiques, motivationnelles et cognitives
+    subsection: Charge cognitive, insight et efficacité de résolution de problèmes
+    start_line: 205
+    end_line: 210
+- object_id: TLC-SO-COMPETENCIES-085
+  canonical_name: Indice de maîtrise
+  object_type: Metric
+  status: candidate
+  symbols: []
+  source_statement: "- **Indice de maîtrise** : mesure composite :"
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Évaluation et métriques des Compétences
+    subsection: Indicateurs qualitatifs
+    start_line: 143
+    end_line: 143
+covered_relations: []
+functional_purpose: Evaluate the cited scientific metrics.
+canonical_category: metric_evaluation
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_metric_evaluation_record_009: create
+  a provenance-preserving canonical representation for 12-competencies: metric (admissible);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-009
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-022
+  - TLC-SO-COMPETENCIES-035
+  - TLC-SO-COMPETENCIES-085
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: metric (admissible)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-010/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-010/contract.yaml
@@ -1,0 +1,132 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-010
+feature_id: TLC-FC-12-COMPETENCIES-010
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Évaluation et métriques des Compétences
+  subsection: Mesures quantitatives
+  start_line: 133
+  end_line: 137
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-023
+  canonical_name: Mesures quantitatives
+  object_type: Metric
+  status: candidate
+  symbols:
+  - "\\mathrm{Acc} = \\frac{\\text{tentatives réussies}}{\\text{total tentatives}}"
+  - "\\mathrm{Eff} = \\frac{\\text{output}}{\\text{temps – ressources}}"
+  - P_{\mathrm{succès}} = \mathbb{E}[\mathbf{1}_{\mathrm{succès}}]
+  - "\\tau_{\\mathrm{act}} = \\frac{\\|\\mathcal{A}(\\mathcal{C}_p,t)\\|}{\\|\\mathcal{C}_p\\|}"
+  source_statement: |-
+    - **Précision** : $\mathrm{Acc} = \frac{\text{tentatives réussies}}{\text{total tentatives}}$.
+    - **Efficacité** : $\mathrm{Eff} = \frac{\text{output}}{\text{temps – ressources}}$.
+    - **Taux de succès** : $P_{\mathrm{succès}} = \mathbb{E}[\mathbf{1}_{\mathrm{succès}}]$.
+    - **Taux d’actualisation** : $\tau_{\mathrm{act}} = \frac{\|\mathcal{A}(\mathcal{C}_p,t)\|}{\|\mathcal{C}_p\|}$.
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Évaluation et métriques des Compétences
+    subsection: Mesures quantitatives
+    start_line: 133
+    end_line: 137
+covered_relations: []
+functional_purpose: Evaluate the cited scientific metrics.
+canonical_category: metric_evaluation
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_metric_evaluation_record_010: create
+  a provenance-preserving canonical representation for 12-competencies: metric (blocked_locally);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-010
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-023
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: metric (blocked_locally)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-011/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-011/contract.yaml
@@ -1,0 +1,209 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-011
+feature_id: TLC-FC-12-COMPETENCIES-011
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Évaluation et métriques des Compétences
+  subsection: Indicateurs qualitatifs
+  start_line: 139
+  end_line: 146
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Interaction avec la communauté et compétences collectives
+  subsection: Cohérence et coordination entre Disciples
+  start_line: 220
+  end_line: 225
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Formalisation mathématique avancée
+  subsection: Espaces et structures
+  start_line: 245
+  end_line: 252
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-024
+  canonical_name: Indicateurs qualitatifs
+  object_type: Metric
+  status: candidate
+  symbols:
+  - "\\mathcal"
+  - "\\mathrm"
+  source_statement: |-
+    - **Profondeur** : sophistication de la compréhension et de l’application.
+    - **Créativité** : solutions nouvelles et appropriées aux problèmes.
+    - **Adaptation contextuelle** : capacité à s’ajuster aux exigences situationnelles.
+    - **Indice de maîtrise** : mesure composite :
+    \[
+    \mathcal{M}(c) = \frac{1}{5} \big( \mathcal{E}_{\mathrm{tech}}(c) + \mathcal{E}_{\mathrm{cog}}(c) + \mathcal{E}_{\mathrm{soc}}(c) + \mathcal{E}_{\mathrm{adapt}}(c) + \mathcal{E}_{\mathrm{meta}}(c) \big)
+    \]
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Évaluation et métriques des Compétences
+    subsection: Indicateurs qualitatifs
+    start_line: 139
+    end_line: 146
+- object_id: TLC-SO-COMPETENCIES-038
+  canonical_name: Cohérence et coordination entre Disciples
+  object_type: Metric
+  status: candidate
+  symbols:
+  - "\\sigma(\\mathcal{CP})"
+  - "\\mathcal"
+  - "\\mathrm"
+  source_statement: |-
+    La compétence collective émerge des compétences individuelles :
+    \[
+    \mathcal{C}_{a,\mathrm{collectif}} = \frac{1}{N}\sum_{i=1}^{N} \mathcal{C}_{a,i} + \sigma(\mathcal{CP}) \cdot \mathrm{Synergie}(\{\mathcal{C}_{a,i}\})
+    \]
+    où $\sigma(\mathcal{CP})$ dépend du cadre pratique et Synergie mesure les complémentarités.
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Interaction avec la communauté et compétences collectives
+    subsection: Cohérence et coordination entre Disciples
+    start_line: 220
+    end_line: 225
+- object_id: TLC-SO-COMPETENCIES-043
+  canonical_name: Espaces et structures
+  object_type: Metric
+  status: candidate
+  symbols:
+  - "\\mathcal{C}_a"
+  - g_a
+  - R_{\mathcal{C}_a}
+  - "\\Phi"
+  - "\\pi : \\mathcal{C}_p \\to \\mathcal{C}_a"
+  - "\\mathcal"
+  - "\\alpha"
+  - "\\beta"
+  - "\\Phi(\\mathcal{I}(u)"
+  source_statement: |-
+    - $\mathcal{C}_a$ est une variété hilbertienne de dimension finie (chaque composante est euclidienne).
+    - La métrique $g_a$ est définie par :
+    \[
+    g_a(u,v) = \langle u,v \rangle_{\mathcal{C}_a} + \alpha R_{\mathcal{C}_a}(u,v) + \beta \Phi(\mathcal{I}(u),\mathcal{I}(v))
+    \]
+    où $R_{\mathcal{C}_a}$ est la courbure sectionnelle (mesurant la difficulté de combiner des compétences), et $\Phi$ mesure la compatibilité entre les intégrations identitaires associées.
+    - La projection $\pi : \mathcal{C}_p \to \mathcal{C}_a$ (via l’opérateur d’actualisation) est une submersion riemannienne.
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Formalisation mathématique avancée
+    subsection: Espaces et structures
+    start_line: 245
+    end_line: 252
+covered_relations: []
+functional_purpose: Evaluate the cited scientific metrics.
+canonical_category: metric_evaluation
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_metric_evaluation_record_011: create
+  a provenance-preserving canonical representation for 12-competencies: metric (provisionally_separated);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-011
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-024
+  - TLC-SO-COMPETENCIES-038
+  - TLC-SO-COMPETENCIES-043
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: metric (provisionally_separated)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-012/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-012/contract.yaml
@@ -1,0 +1,127 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-012
+feature_id: TLC-FC-12-COMPETENCIES-012
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Types et formes de Compétences
+  subsection: Compétences techniques / fonctionnelles
+  start_line: 63
+  end_line: 64
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-007
+  canonical_name: Compétences techniques / fonctionnelles
+  object_type: Function
+  status: candidate
+  symbols: []
+  source_statement: Maîtrise de gestes spécifiques, d’outils, de procédures et de
+    techniques propres à un domaine. Elles constituent le fondement de la pratique
+    professionnelle et s’acquièrent par répétition et raffinement (Dreyfus & Dreyfus,
+    1986 ; Ericsson, Krampe & Tesch‑Römer, 1993).
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Types et formes de Compétences
+    subsection: Compétences techniques / fonctionnelles
+    start_line: 63
+    end_line: 64
+covered_relations: []
+functional_purpose: Evaluate the cited scientific functions and operators.
+canonical_category: scientific_operator
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_scientific_operator_record_012: create
+  a provenance-preserving canonical representation for 12-competencies: operator (admissible);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-012
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-007
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: operator (admissible)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-013/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-013/contract.yaml
@@ -1,0 +1,173 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-013
+feature_id: TLC-FC-12-COMPETENCIES-013
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Propriétés essentielles
+  subsection:
+  start_line: 35
+  end_line: 42
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+- source_path: maths/12-competencies.md
+  section: Propriétés essentielles
+  subsection:
+  start_line: 38
+  end_line: 38
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-003
+  canonical_name: Propriétés essentielles
+  object_type: Operator
+  status: candidate
+  symbols:
+  - "\\mathcal{C}_a \\subset \\mathcal{C}_p"
+  - "\\mu(\\mathcal{C}_a) > 0"
+  - c \in \mathcal{X}
+  - "\\rho_c : \\mathcal{C}_a \\to \\mathcal{C}_a(c)"
+  - "\\|\\rho_c\\| \\le 1"
+  - "\\rho_c"
+  - "\\mathcal{C}_a"
+  - "\\mathbb{E}[\\mathcal{C}_{\\mathrm{tech}} \\cdot \\mathcal{C}_{\\mathrm{cog}}]
+    > 0"
+  - "\\dim(\\mathcal{C}_a(t)) \\le D_{\\max}"
+  source_statement: |-
+    - **Actualisation** : $\mathcal{C}_a \subset \mathcal{C}_p$ et $\mu(\mathcal{C}_a) > 0$. La compétence occupe une partie mesurable de l’espace des capacités.
+    - **Contextualisation** : pour tout contexte $c \in \mathcal{X}$, il existe un opérateur de restriction $\rho_c : \mathcal{C}_a \to \mathcal{C}_a(c)$ tel que $\|\rho_c\| \le 1$ et $\rho_c$ est une isométrie sur son image. La compétence s’exprime différemment selon le contexte sans perdre sa structure.
+    - **Intégration** : les composantes de $\mathcal{C}_a$ sont liées par des relations de covariance : $\mathbb{E}[\mathcal{C}_{\mathrm{tech}} \cdot \mathcal{C}_{\mathrm{cog}}] > 0$. Une solide compétence technique est généralement associée à une bonne compréhension cognitive.
+    - **Évolutivité** : la dimension de $\mathcal{C}_a$ peut croître par innovation mais reste bornée : $\dim(\mathcal{C}_a(t)) \le D_{\max}$.
+    - **Démontrabilité** : une compétence doit être observable et démontrable dans l’action pour être reconnue.
+    - **Validité** : la compétence est confirmée par la démonstration et la reconnaissance sociale (Maître, pairs, communauté).
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Propriétés essentielles
+    subsection:
+    start_line: 35
+    end_line: 42
+- object_id: TLC-SO-COMPETENCIES-055
+  canonical_name: Contextualisation
+  object_type: Operator
+  status: candidate
+  symbols:
+  - c \in \mathcal{X}
+  - "\\rho_c : \\mathcal{C}_a \\to \\mathcal{C}_a(c)"
+  - "\\|\\rho_c\\| \\le 1"
+  - "\\rho_c"
+  source_statement: "- **Contextualisation** : pour tout contexte $c \\in \\mathcal{X}$,
+    il existe un opérateur de restriction $\\rho_c : \\mathcal{C}_a \\to \\mathcal{C}_a(c)$
+    tel que $\\|\\rho_c\\| \\le 1$ et $\\rho_c$ est une isométrie sur son image. La
+    compétence s’exprime différemment selon le contexte sans perdre sa structure."
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Propriétés essentielles
+    subsection:
+    start_line: 38
+    end_line: 38
+covered_relations: []
+functional_purpose: Evaluate the cited scientific functions and operators.
+canonical_category: scientific_operator
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_scientific_operator_record_013: create
+  a provenance-preserving canonical representation for 12-competencies: operator (provisionally_separated);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-013
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-003
+  - TLC-SO-COMPETENCIES-055
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: operator (provisionally_separated)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/math-contracts/TLC-FC-12-COMPETENCIES-016/contract.yaml
+++ b/registry/math-contracts/TLC-FC-12-COMPETENCIES-016/contract.yaml
@@ -1,0 +1,131 @@
+---
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-016
+feature_id: TLC-FC-12-COMPETENCIES-016
+contract_kind: canonical_declarative_contract_with_reservations
+domain_id: competencies
+scientific_authority: maths/12-competencies.md and competencies preparation artifacts
+  only; no scientific semantics promoted beyond cited objects
+source_references:
+- source_path: maths/12-competencies.md
+  section: Propriétés essentielles
+  subsection:
+  start_line: 39
+  end_line: 39
+  source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+  feature_source: feature-catalogue
+covered_objects:
+- object_id: TLC-SO-COMPETENCIES-056
+  canonical_name: Intégration
+  object_type: Relation
+  status: candidate
+  symbols:
+  - "\\mathcal{C}_a"
+  - "\\mathbb{E}[\\mathcal{C}_{\\mathrm{tech}} \\cdot \\mathcal{C}_{\\mathrm{cog}}]
+    > 0"
+  source_statement: "- **Intégration** : les composantes de $\\mathcal{C}_a$ sont
+    liées par des relations de covariance : $\\mathbb{E}[\\mathcal{C}_{\\mathrm{tech}}
+    \\cdot \\mathcal{C}_{\\mathrm{cog}}] > 0$. Une solide compétence technique est
+    généralement associée à une bonne compréhension cognitive."
+  source_reference:
+    repository: Tradition-Learning-Community/tllib-specs
+    source_path: maths/12-competencies.md
+    source_url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies.md
+    source_branch: main
+    source_commit: aef09e74f85b5f0c930d5940f1753536af61686f
+    source_blob_sha: e8fcc07461672056d4ef0249f4eee51c2b7e18d3
+    document_title: Compétences (Competencies)
+    section: Propriétés essentielles
+    subsection:
+    start_line: 39
+    end_line: 39
+covered_relations: []
+functional_purpose: Evaluate the cited scientific relations without inferring endpoint
+  identity.
+canonical_category: relation_evaluation
+capacities_dependency: not_directly_evidenced
+primary_responsibility: 'competencies_preserve_relation_evaluation_record_016: create
+  a provenance-preserving canonical representation for 12-competencies: relation (provisionally_separated);
+  permit structural validation only, not scientific evaluation.'
+inputs:
+- name: competencies_feature_id
+  type: FeatureId
+  required: true
+  expected_value: TLC-FC-12-COMPETENCIES-016
+- name: object_payloads
+  type: Map<ObjectId,OpaqueScientificObject>
+  required: true
+  required_keys:
+  - TLC-SO-COMPETENCIES-056
+- name: provenance
+  type: Map<ObjectId,SourceReference>
+  required: true
+outputs:
+- name: artifact
+  type: CompetenciesCanonicalDescriptor
+  observable_effect: returns descriptor containing feature id, category, object ids,
+    source statements, symbols, provenance, reservations, blockers, and no evaluated
+    scientific value
+types:
+  FeatureId: string matching TLC-FC-12-COMPETENCIES-*
+  OpaqueScientificObject: caller supplied payload preserved without interpretation
+  SourceReference: source path, line span, commit, section
+  CompetenciesCanonicalDescriptor: immutable record with domain/category/status/object_ids/symbols/provenance/reservations/blockers
+preconditions:
+- feature id equals contract feature_id
+- all covered object ids are present exactly once in object_payloads
+- each covered object has a source reference
+- caller does not request numeric scoring, thresholds, learning dynamics, temporal
+  simulation, or scientific evaluation
+postconditions:
+- output feature_id equals input feature id
+- output covered_objects preserves catalogue order
+- output provenance contains a source reference for every covered object
+- output contains no generated scientific metric, score, threshold, rank, probability,
+  or temporal inference
+- descriptor is marked structurally_valid only for provenance and coverage completeness
+explicitly_sourced_invariants:
+- covered object set is exactly the feature catalogue object set
+- source statements and equations remain opaque and are not reinterpreted
+- scientific reservations, non-invention notes, and blockers are propagated
+errors:
+- UnknownFeatureId
+- MissingCoveredObject
+- DuplicateCoveredObject
+- MissingSourceReference
+- ScientificEvaluationRequested
+- BlockedScientificDecision
+undefined_behaviors:
+- numeric interpretation of symbols or equations
+- selection of dimensions, units, thresholds, initial conditions, or temporal semantics
+- resolution of blocked/provisionally separated/admissible scientific status
+- conversion of capacities dependencies into local competencies semantics
+propagated_unresolved: []
+implementation_decisions_required:
+- descriptor schema finalization for downstream code generation
+- runtime representation of opaque source statements and symbols
+scientific_decisions_required:
+- scientific unresolved
+- validated contract absent
+scientific_reservations:
+- no full mathematical contract or production semantics asserted
+- types, dimensions, units, thresholds, and temporal semantics are not completed
+- scientific unresolved blockers are preserved rather than resolved
+traceability:
+  prepared_from: registry/domain-progress/competencies/feature-catalogue.yaml
+  readiness_from: registry/domain-progress/competencies/production-readiness.yaml
+  source_file: maths/12-competencies.md
+  working_base_commit: d8e616c71173495b9a014d4a5909df9f30e2a7ae
+  feature_name: '12-competencies: relation (provisionally_separated)'
+validation_criteria:
+- YAML parses
+- contract feature id matches directory and IR
+- covered object ids match feature catalogue
+- evaluation requests are rejected
+- reservations and blockers are preserved
+execution_status: non_executable_scientific_content; structurally_validatable_descriptor_only
+readiness:
+  status: canonical_declarative_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false
+  blocks_all_prototype_progress: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-001/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-001/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-001
+feature_id: TLC-FC-12-COMPETENCIES-001
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-001
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-001
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-001/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-001/ir.yaml
+entrypoint: competencies_preserve_constraint_evaluation_record_001
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-002/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-002/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-002
+feature_id: TLC-FC-12-COMPETENCIES-002
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-002
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-002
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-002/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-002/ir.yaml
+entrypoint: competencies_preserve_constraint_evaluation_record_002
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-004/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-004/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-004
+feature_id: TLC-FC-12-COMPETENCIES-004
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-004
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-004
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-004/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-004/ir.yaml
+entrypoint: competencies_preserve_evolution_dynamics_record_004
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: false
+  ready_for_cpp_prototype: false
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-005/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-005/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-005
+feature_id: TLC-FC-12-COMPETENCIES-005
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-005
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-005
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-005/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-005/ir.yaml
+entrypoint: competencies_preserve_evolution_dynamics_record_005
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-006/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-006/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-006
+feature_id: TLC-FC-12-COMPETENCIES-006
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-006
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-006
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-006/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-006/ir.yaml
+entrypoint: competencies_preserve_transformation_record_006
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: false
+  ready_for_cpp_prototype: false
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-007/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-007/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-007
+feature_id: TLC-FC-12-COMPETENCIES-007
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-007
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-007
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-007/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-007/ir.yaml
+entrypoint: competencies_preserve_transformation_record_007
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-008/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-008/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-008
+feature_id: TLC-FC-12-COMPETENCIES-008
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-008
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-008
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-008/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-008/ir.yaml
+entrypoint: competencies_preserve_transformation_record_008
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-009/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-009/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-009
+feature_id: TLC-FC-12-COMPETENCIES-009
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-009
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-009
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-009/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-009/ir.yaml
+entrypoint: competencies_preserve_metric_evaluation_record_009
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-010/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-010/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-010
+feature_id: TLC-FC-12-COMPETENCIES-010
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-010
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-010
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-010/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-010/ir.yaml
+entrypoint: competencies_preserve_metric_evaluation_record_010
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-011/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-011/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-011
+feature_id: TLC-FC-12-COMPETENCIES-011
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-011
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-011
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-011/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-011/ir.yaml
+entrypoint: competencies_preserve_metric_evaluation_record_011
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-012/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-012/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-012
+feature_id: TLC-FC-12-COMPETENCIES-012
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-012
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-012
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-012/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-012/ir.yaml
+entrypoint: competencies_preserve_scientific_operator_record_012
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-013/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-013/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-013
+feature_id: TLC-FC-12-COMPETENCIES-013
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-013
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-013
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-013/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-013/ir.yaml
+entrypoint: competencies_preserve_scientific_operator_record_013
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/registry/test-plans/TLC-FC-12-COMPETENCIES-016/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-12-COMPETENCIES-016/test-plan.yaml
@@ -1,0 +1,49 @@
+---
+test_plan_id: TLC-TP-TLC-FC-12-COMPETENCIES-016
+feature_id: TLC-FC-12-COMPETENCIES-016
+contract_id: TLC-MC-TLC-FC-12-COMPETENCIES-016
+ir_id: TLC-IR-TLC-FC-12-COMPETENCIES-016
+contract_path: registry/math-contracts/TLC-FC-12-COMPETENCIES-016/contract.yaml
+ir_path: registry/ir/TLC-FC-12-COMPETENCIES-016/ir.yaml
+entrypoint: competencies_preserve_relation_evaluation_record_016
+plan_kind: canonical_declarative_ir_test_plan_with_reservations
+scope: structural and rejection tests for canonical declarative descriptor only
+test_categories:
+- nominal
+- errors
+- types
+- preconditions
+- postconditions
+- invariants
+- properties
+- determinism
+- reproducibility
+- conformity Python/C++
+- rejection or explicit blocking
+test_cases:
+- name: nominal_build_preserves_competencies_objects
+  then: returns descriptor with same feature id, covered object ids in catalogue order,
+    symbols, reservations, blockers, and provenance
+- name: reject_missing_covered_object
+  then: raises MissingCoveredObject before descriptor creation
+- name: reject_duplicate_covered_object
+  then: raises DuplicateCoveredObject
+- name: reject_missing_provenance
+  then: raises MissingSourceReference
+- name: propagate_reservations_without_resolution
+  then: output includes the same blocker/reservation text and does not mark scientific
+    resolution
+- name: reject_absent_scientific_calculation
+  then: raises ScientificEvaluationRequested and no numeric result is returned
+- name: contract_ir_alignment
+  then: feature to contract to IR chain is unique and consistent
+blocked_tests:
+- numeric oracle tests blocked by missing authorized numerical semantics
+- precision/stability/gradient/conservation/monotonicity tests blocked unless a future
+  scientific decision defines executable equations and domains
+readiness_expectation:
+  python: structural_descriptor_ready_with_reservations
+  cpp: structural_descriptor_ready_with_reservations
+  ready_for_reference_python: true
+  ready_for_cpp_prototype: true
+  ready_for_production_implementation: false

--- a/reports/ir-batches/competencies-domain-completion-001/completion-report.md
+++ b/reports/ir-batches/competencies-domain-completion-001/completion-report.md
@@ -1,0 +1,91 @@
+# Competencies domain completion 001
+
+## Base commit
+
+25eb100708ee413c23ab75078c0f7e96677ed042
+
+## Catalogue exact
+
+Feature count: 13.
+
+- TLC-FC-12-COMPETENCIES-001
+- TLC-FC-12-COMPETENCIES-002
+- TLC-FC-12-COMPETENCIES-004
+- TLC-FC-12-COMPETENCIES-005
+- TLC-FC-12-COMPETENCIES-006
+- TLC-FC-12-COMPETENCIES-007
+- TLC-FC-12-COMPETENCIES-008
+- TLC-FC-12-COMPETENCIES-009
+- TLC-FC-12-COMPETENCIES-010
+- TLC-FC-12-COMPETENCIES-011
+- TLC-FC-12-COMPETENCIES-012
+- TLC-FC-12-COMPETENCIES-013
+- TLC-FC-12-COMPETENCIES-016
+
+## Initial state
+
+The manifest and preparation registers state `preparation_complete_with_reservations`, with 13 declared features and 0 expected canonical contracts, IRs, or test plans.
+
+## Artefacts reused
+
+- `maths/12-competencies.md` as authoritative source only; it was not modified.
+- `registry/domain-progress/competencies/feature-catalogue.yaml` as primary planned catalogue.
+- `registry/domain-progress/competencies/production-readiness.yaml` for readiness and blockers.
+- `registry/domain-progress/competencies/scientific-inventory.yaml` for object names, source statements, symbols, and provenance.
+
+## Artefacts created
+
+- 13 canonical contracts under `registry/math-contracts/<FEATURE-ID>/contract.yaml`.
+- 13 canonical IRs under `registry/ir/<FEATURE-ID>/ir.yaml`.
+- 13 canonical test plans under `registry/test-plans/<FEATURE-ID>/test-plan.yaml`.
+- Domain validator: `scripts/validate_competencies_domain.py`.
+- Machine-readable batch manifest: `registry/ir-batches/competencies-domain-completion-001/manifest.yaml`.
+
+## Artefacts consolidated and historical artefacts conserved
+
+No historical competencies canonical contracts, canonical IRs, canonical test plans, or limited lots were present to migrate. Preparation artefacts are conserved as provenance and readiness evidence.
+
+## Classifications and readiness
+
+| Feature | Category | Capacities dependency | Classification | Python readiness | C++ readiness |
+| --- | --- | --- | --- | --- | --- |
+| TLC-FC-12-COMPETENCIES-001 | constraint_evaluation | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-002 | constraint_evaluation | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-004 | evolution_dynamics | external_unreconciled | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-005 | evolution_dynamics | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-006 | transformation | external_unreconciled | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-007 | transformation | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-008 | transformation | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-009 | metric_evaluation | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-010 | metric_evaluation | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-011 | metric_evaluation | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-012 | scientific_operator | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-013 | scientific_operator | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+| TLC-FC-12-COMPETENCIES-016 | relation_evaluation | not_directly_evidenced | canonical_declarative_non_executable | structural_descriptor_ready_with_reservations | structural_descriptor_ready_with_reservations |
+
+## Blockages and scientific questions
+
+- Scientific unresolved blockers are propagated and not resolved.
+- Types, dimensions, units, thresholds, initial conditions, and temporal semantics are not invented.
+- Numeric oracle, precision, stability, gradient, conservation, monotonicity, and executable-equation tests remain blocked unless future scientific decisions authorize executable semantics.
+- Features marked with `capacities_dependency: external_unreconciled` preserve that classification.
+
+## Validation results
+
+- PASS: `git diff --check`.
+- PASS: `python scripts/validate_competencies_domain.py` reported 13 features, 13 contracts, 13 IRs, and 13 test plans with no maths changes or new artifact.yaml.
+- PASS: PyYAML parsed 40 added/modified YAML files.
+- PASS: no modified path under `maths/`.
+- PASS: no added or modified `artifact.yaml`.
+- PASS: canonical counts match catalogue: 13/13/13/13.
+- PASS: every IR references `registry/math-contracts/<FEATURE-ID>/contract.yaml`.
+- PASS: every test plan references the corresponding feature, contract, and IR.
+- WARNING: `PYTHONPATH=/usr/lib/python3/dist-packages python scripts/validate_competencies_preparation.py` remains preparation-scope-only and reports the new completion artifacts as out of scope; this is expected for the prior preparation validator.
+
+## Modified files
+
+See batch manifest `modified_files` for the complete expected list.
+
+## Conclusion
+
+Structural completion is achieved honestly for all 13 canonical competencies features: every catalogue feature has exactly one canonical contract, one canonical declarative IR, and one canonical test plan, while scientific executability remains non-executable where unsupported by authorized sources.

--- a/scripts/validate_competencies_domain.py
+++ b/scripts/validate_competencies_domain.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+from pathlib import Path
+import sys, subprocess
+try:
+    import yaml
+except ModuleNotFoundError:
+    sys.path.append('/usr/lib/python3/dist-packages')
+    import yaml
+ROOT=Path(__file__).resolve().parents[1]
+PREFIX='TLC-FC-12-COMPETENCIES-'
+errors=[]
+def load(p):
+    try: return yaml.safe_load((ROOT/p).read_text(encoding='utf-8'))
+    except Exception as e:
+        errors.append(f'invalid YAML {p}: {e}'); return {}
+cat=load(Path('registry/domain-progress/competencies/feature-catalogue.yaml'))
+features=[f['feature_id'] for f in cat.get('features',[]) if f.get('feature_id','').startswith(PREFIX)]
+if len(features)!=13 or len(set(features))!=13: errors.append(f'feature count expected 13 got {len(features)}/{len(set(features))}')
+for fid in features:
+    c=Path(f'registry/math-contracts/{fid}/contract.yaml'); i=Path(f'registry/ir/{fid}/ir.yaml'); t=Path(f'registry/test-plans/{fid}/test-plan.yaml')
+    for p in (c,i,t):
+        if not (ROOT/p).exists(): errors.append(f'missing {p}')
+    cy=load(c); iy=load(i); ty=load(t)
+    if cy.get('feature_id')!=fid or cy.get('contract_id')!=f'TLC-MC-{fid}': errors.append(f'contract id mismatch {fid}')
+    if iy.get('feature_id')!=fid or iy.get('contract_id')!=cy.get('contract_id') or iy.get('contract_path')!=str(c): errors.append(f'IR contract reference mismatch {fid}')
+    if ty.get('feature_id')!=fid or ty.get('contract_id')!=cy.get('contract_id') or ty.get('ir_id')!=iy.get('ir_id'): errors.append(f'test plan reference mismatch {fid}')
+    if set(cy.get('inputs',[{},{}])[1].get('required_keys',[])) != set(next(f for f in cat['features'] if f['feature_id']==fid).get('source_objects',[])): errors.append(f'covered objects mismatch {fid}')
+    if cy.get('execution_status') is None: errors.append(f'execution status missing {fid}')
+    if 'readiness' not in iy or 'python' not in iy['readiness'] or 'cpp' not in iy['readiness']: errors.append(f'IR readiness missing {fid}')
+new_artifacts=list(ROOT.rglob('artifact.yaml'))
+# Existing artifact.yaml files would be reported only if under competencies canonical outputs.
+if any(PREFIX in str(p) for p in new_artifacts): errors.append('new competencies artifact.yaml found')
+changed=subprocess.run(['git','diff','--name-only','HEAD'],cwd=ROOT,text=True,capture_output=True).stdout.splitlines()
+if any(p.startswith('maths/') for p in changed): errors.append('maths/ modified')
+allowed_prefixes=('registry/math-contracts/TLC-FC-12-COMPETENCIES-','registry/ir/TLC-FC-12-COMPETENCIES-','registry/test-plans/TLC-FC-12-COMPETENCIES-','registry/domain-progress/competencies/','registry/ir-batches/competencies-domain-completion-001/','reports/ir-batches/competencies-domain-completion-001/','scripts/validate_competencies_domain.py')
+bad=[p for p in changed if not p.startswith(allowed_prefixes)]
+if bad: errors.append(f'out-of-scope paths: {bad}')
+if errors:
+    print('COMPETENCIES DOMAIN VALIDATION FAILED')
+    print('\n'.join('- '+e for e in errors)); sys.exit(1)
+print('COMPETENCIES DOMAIN VALIDATION PASSED')
+print('features=13 contracts=13 irs=13 test_plans=13')
+print('maths_modified=false new_artifact_yaml=false ir_contract_references=true test_plan_feature_references=true')


### PR DESCRIPTION
### Motivation

- Bring the Competencies domain to the same structural maturity as previously completed domains by producing canonical math contracts, canonical IRs, and canonical test plans for every feature in the catalogue while strictly preserving provenance and non-invention constraints. 
- Preserve preparation reservations and external `capacities` classifications (e.g. `external_unreconciled`) and avoid inventing missing scientific semantics or executable interpretations.

### Description

- Added canonical declarative math contracts for all 13 catalogue features under `registry/math-contracts/TLC-FC-12-COMPETENCIES-*/contract.yaml`, each preserving source references, covered objects, symbols, provenance, reservations, and an explicit non-executable status. 
- Added canonical declarative IRs under `registry/ir/TLC-FC-12-COMPETENCIES-*/ir.yaml` that reference their contracts, declare structural descriptor operations, propagate reservations/blockers, and mark readiness for structural descriptor use only. 
- Added canonical test plans under `registry/test-plans/TLC-FC-12-COMPETENCIES-*/test-plan.yaml`, covering structural, provenance, error, determinism, rejection, and blocked-oracle cases, and added a machine-readable batch manifest at `registry/ir-batches/competencies-domain-completion-001/manifest.yaml` plus a human-readable completion report at `reports/ir-batches/competencies-domain-completion-001/completion-report.md`. 
- Added a domain validator script `scripts/validate_competencies_domain.py` that enforces exact catalogue coverage (13 features), contract/IR/test-plan existence and reference integrity, YAML parseability, no `maths/` modifications, and allowed change scope.

### Testing

- `git diff --check` was executed and reported no whitespace/format issues (PASS). 
- `python scripts/validate_competencies_domain.py` ran successfully and reported `features=13 contracts=13 irs=13 test_plans=13` (PASS). 
- PyYAML parsing of the added/modified YAML artifacts was validated (40 YAML files parsed successfully) (PASS). 
- The existing preparation validator (`scripts/validate_competencies_preparation.py`) produced an expected warning because it is preparation-scoped and therefore flags the new canonical completion artifacts as out-of-scope (EXPECTED WARNING), and a remote push could not be performed from this execution environment because no remote is configured (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64a2b17a90832cb83e3fa5b52d055a)

## Summary by Sourcery

Complete the competencies domain by adding canonical declarative math contracts, IRs, and test plans for all catalogue features, plus validation and reporting for the new batch.

New Features:
- Add canonical declarative math contracts for all 13 competencies catalogue features, covering equations, constraints, metrics, operators, and relations with preserved provenance and reservations.
- Introduce canonical declarative IRs for each competencies feature that expose structural descriptor operations without enabling scientific execution.
- Define canonical test plans for each competencies IR focusing on structural, invariants, determinism, and rejection behavior while explicitly blocking scientific numeric oracles.
- Create a machine-readable IR batch manifest and human-readable completion report documenting competencies domain completion and validations.

Enhancements:
- Add a competencies domain validator script to enforce exact feature coverage, artifact presence and linkage, YAML validity, and constrained change scope across the registry.

Tests:
- Codify test expectations for all competencies IRs via new canonical test plans and validate the domain with git diff checks, YAML parsing, and preparation validator runs.