### PR TITLE
feat(ir): complete disciple candidate structure

### DIFF
--- a/registry/ir-batches/disciple-domain-completion-001/manifest.yaml
+++ b/registry/ir-batches/disciple-domain-completion-001/manifest.yaml
@@ -1,0 +1,69 @@
+schema_version: '1.0'
+domain: disciple
+source_ref: maths/01-disciple.md
+completion_level: candidate_structural_uniformity
+canonical_selection_performed: false
+feature_count: 10
+features:
+- feature_id: TLC-FC-01-DISCIPLE-001
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-001/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-001/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-001/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-001/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-002
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-002/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-002/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-002/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-002/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-003
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-003/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-003/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-003/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-003/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-004
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-004/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-004/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-004/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-004/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-005
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-005/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-005/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-005/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-005/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-006
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-006/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-006/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-006/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-006/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-007
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-007/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-007/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-007/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-007/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-008
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-008/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-008/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-008/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-008/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-009
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-009/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-009/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-009/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-009/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-010
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-010/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-010/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-010/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-010/test-plan.yaml
+  status: complete_at_candidate_structural_level
+excluded_lineage: []
+batch_kind: ir

--- a/registry/ir/TLC-FC-01-DISCIPLE-001/ir.yaml
+++ b/registry/ir/TLC-FC-01-DISCIPLE-001/ir.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+registry_entry_id: TLC-IR-REGISTRY-TLC-FC-01-DISCIPLE-001
+feature_id: TLC-FC-01-DISCIPLE-001
+domain: disciple
+artifact_role: ir_candidate_registry_entry
+selection_status: active_candidate_not_canonical
+scientific_status: engineering_candidate
+engineering_status: engineering_candidate
+execution_status: unresolved_not_executable
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-001/contract.yaml
+candidate_ref: ir/TLC-FC-01-DISCIPLE-001/ir.candidate.json
+candidate_ir_id: TLC-IR-TLC-FC-01-DISCIPLE-001
+candidate_variant: validation
+source_ref: maths/01-disciple.md
+preservation_rules:
+- Do not infer missing scientific definitions, types, dimensions, aliases, equations,
+  or numerical methods.
+- Preserve unresolved operations and reservations explicitly.
+- This registry entry does not select a canonical executable IR.
+next_stage: scientific_review_then_ir_selection_or_revision

--- a/registry/ir/TLC-FC-01-DISCIPLE-002/ir.yaml
+++ b/registry/ir/TLC-FC-01-DISCIPLE-002/ir.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+registry_entry_id: TLC-IR-REGISTRY-TLC-FC-01-DISCIPLE-002
+feature_id: TLC-FC-01-DISCIPLE-002
+domain: disciple
+artifact_role: ir_candidate_registry_entry
+selection_status: active_candidate_not_canonical
+scientific_status: engineering_candidate
+engineering_status: engineering_candidate
+execution_status: unresolved_not_executable
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-002/contract.yaml
+candidate_ref: ir/TLC-FC-01-DISCIPLE-002/ir.candidate.json
+candidate_ir_id: TLC-IR-TLC-FC-01-DISCIPLE-002
+candidate_variant: declarative
+source_ref: maths/01-disciple.md
+preservation_rules:
+- Do not infer missing scientific definitions, types, dimensions, aliases, equations,
+  or numerical methods.
+- Preserve unresolved operations and reservations explicitly.
+- This registry entry does not select a canonical executable IR.
+next_stage: scientific_review_then_ir_selection_or_revision

--- a/registry/ir/TLC-FC-01-DISCIPLE-003/ir.yaml
+++ b/registry/ir/TLC-FC-01-DISCIPLE-003/ir.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+registry_entry_id: TLC-IR-REGISTRY-TLC-FC-01-DISCIPLE-003
+feature_id: TLC-FC-01-DISCIPLE-003
+domain: disciple
+artifact_role: ir_candidate_registry_entry
+selection_status: active_candidate_not_canonical
+scientific_status: engineering_candidate
+engineering_status: engineering_candidate
+execution_status: unresolved_not_executable
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-003/contract.yaml
+candidate_ref: ir/TLC-FC-01-DISCIPLE-003/ir.candidate.json
+candidate_ir_id: TLC-IR-TLC-FC-01-DISCIPLE-003
+candidate_variant: functional
+source_ref: maths/01-disciple.md
+preservation_rules:
+- Do not infer missing scientific definitions, types, dimensions, aliases, equations,
+  or numerical methods.
+- Preserve unresolved operations and reservations explicitly.
+- This registry entry does not select a canonical executable IR.
+next_stage: scientific_review_then_ir_selection_or_revision

--- a/registry/ir/TLC-FC-01-DISCIPLE-004/ir.yaml
+++ b/registry/ir/TLC-FC-01-DISCIPLE-004/ir.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+registry_entry_id: TLC-IR-REGISTRY-TLC-FC-01-DISCIPLE-004
+feature_id: TLC-FC-01-DISCIPLE-004
+domain: disciple
+artifact_role: ir_candidate_registry_entry
+selection_status: active_candidate_not_canonical
+scientific_status: engineering_candidate
+engineering_status: engineering_candidate
+execution_status: unresolved_not_executable
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-004/contract.yaml
+candidate_ref: ir/TLC-FC-01-DISCIPLE-004/ir.candidate.json
+candidate_ir_id: TLC-IR-TLC-FC-01-DISCIPLE-004
+candidate_variant: structural
+source_ref: maths/01-disciple.md
+preservation_rules:
+- Do not infer missing scientific definitions, types, dimensions, aliases, equations,
+  or numerical methods.
+- Preserve unresolved operations and reservations explicitly.
+- This registry entry does not select a canonical executable IR.
+next_stage: scientific_review_then_ir_selection_or_revision

--- a/registry/ir/TLC-FC-01-DISCIPLE-005/ir.yaml
+++ b/registry/ir/TLC-FC-01-DISCIPLE-005/ir.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+registry_entry_id: TLC-IR-REGISTRY-TLC-FC-01-DISCIPLE-005
+feature_id: TLC-FC-01-DISCIPLE-005
+domain: disciple
+artifact_role: ir_candidate_registry_entry
+selection_status: active_candidate_not_canonical
+scientific_status: engineering_candidate
+engineering_status: engineering_candidate
+execution_status: unresolved_not_executable
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-005/contract.yaml
+candidate_ref: ir/TLC-FC-01-DISCIPLE-005/ir.candidate.json
+candidate_ir_id: TLC-IR-TLC-FC-01-DISCIPLE-005
+candidate_variant: functional
+source_ref: maths/01-disciple.md
+preservation_rules:
+- Do not infer missing scientific definitions, types, dimensions, aliases, equations,
+  or numerical methods.
+- Preserve unresolved operations and reservations explicitly.
+- This registry entry does not select a canonical executable IR.
+next_stage: scientific_review_then_ir_selection_or_revision

--- a/registry/ir/TLC-FC-01-DISCIPLE-006/ir.yaml
+++ b/registry/ir/TLC-FC-01-DISCIPLE-006/ir.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+registry_entry_id: TLC-IR-REGISTRY-TLC-FC-01-DISCIPLE-006
+feature_id: TLC-FC-01-DISCIPLE-006
+domain: disciple
+artifact_role: ir_candidate_registry_entry
+selection_status: active_candidate_not_canonical
+scientific_status: engineering_candidate
+engineering_status: engineering_candidate
+execution_status: unresolved_not_executable
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-006/contract.yaml
+candidate_ref: ir/TLC-FC-01-DISCIPLE-006/ir.candidate.json
+candidate_ir_id: TLC-IR-TLC-FC-01-DISCIPLE-006
+candidate_variant: validation
+source_ref: maths/01-disciple.md
+preservation_rules:
+- Do not infer missing scientific definitions, types, dimensions, aliases, equations,
+  or numerical methods.
+- Preserve unresolved operations and reservations explicitly.
+- This registry entry does not select a canonical executable IR.
+next_stage: scientific_review_then_ir_selection_or_revision

--- a/registry/ir/TLC-FC-01-DISCIPLE-007/ir.yaml
+++ b/registry/ir/TLC-FC-01-DISCIPLE-007/ir.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+registry_entry_id: TLC-IR-REGISTRY-TLC-FC-01-DISCIPLE-007
+feature_id: TLC-FC-01-DISCIPLE-007
+domain: disciple
+artifact_role: ir_candidate_registry_entry
+selection_status: active_candidate_not_canonical
+scientific_status: engineering_candidate
+engineering_status: engineering_candidate
+execution_status: unresolved_not_executable
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-007/contract.yaml
+candidate_ref: ir/TLC-FC-01-DISCIPLE-007/ir.candidate.json
+candidate_ir_id: TLC-IR-TLC-FC-01-DISCIPLE-007
+candidate_variant: structural
+source_ref: maths/01-disciple.md
+preservation_rules:
+- Do not infer missing scientific definitions, types, dimensions, aliases, equations,
+  or numerical methods.
+- Preserve unresolved operations and reservations explicitly.
+- This registry entry does not select a canonical executable IR.
+next_stage: scientific_review_then_ir_selection_or_revision

--- a/registry/ir/TLC-FC-01-DISCIPLE-008/ir.yaml
+++ b/registry/ir/TLC-FC-01-DISCIPLE-008/ir.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+registry_entry_id: TLC-IR-REGISTRY-TLC-FC-01-DISCIPLE-008
+feature_id: TLC-FC-01-DISCIPLE-008
+domain: disciple
+artifact_role: ir_candidate_registry_entry
+selection_status: active_candidate_not_canonical
+scientific_status: engineering_candidate
+engineering_status: engineering_candidate
+execution_status: unresolved_not_executable
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-008/contract.yaml
+candidate_ref: ir/TLC-FC-01-DISCIPLE-008/ir.candidate.json
+candidate_ir_id: TLC-IR-TLC-FC-01-DISCIPLE-008
+candidate_variant: structural
+source_ref: maths/01-disciple.md
+preservation_rules:
+- Do not infer missing scientific definitions, types, dimensions, aliases, equations,
+  or numerical methods.
+- Preserve unresolved operations and reservations explicitly.
+- This registry entry does not select a canonical executable IR.
+next_stage: scientific_review_then_ir_selection_or_revision

--- a/registry/ir/TLC-FC-01-DISCIPLE-009/ir.yaml
+++ b/registry/ir/TLC-FC-01-DISCIPLE-009/ir.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+registry_entry_id: TLC-IR-REGISTRY-TLC-FC-01-DISCIPLE-009
+feature_id: TLC-FC-01-DISCIPLE-009
+domain: disciple
+artifact_role: ir_candidate_registry_entry
+selection_status: active_candidate_not_canonical
+scientific_status: engineering_candidate
+engineering_status: engineering_candidate
+execution_status: unresolved_not_executable
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-009/contract.yaml
+candidate_ref: ir/TLC-FC-01-DISCIPLE-009/ir.candidate.json
+candidate_ir_id: TLC-IR-TLC-FC-01-DISCIPLE-009
+candidate_variant: structural
+source_ref: maths/01-disciple.md
+preservation_rules:
+- Do not infer missing scientific definitions, types, dimensions, aliases, equations,
+  or numerical methods.
+- Preserve unresolved operations and reservations explicitly.
+- This registry entry does not select a canonical executable IR.
+next_stage: scientific_review_then_ir_selection_or_revision

--- a/registry/ir/TLC-FC-01-DISCIPLE-010/ir.yaml
+++ b/registry/ir/TLC-FC-01-DISCIPLE-010/ir.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+registry_entry_id: TLC-IR-REGISTRY-TLC-FC-01-DISCIPLE-010
+feature_id: TLC-FC-01-DISCIPLE-010
+domain: disciple
+artifact_role: ir_candidate_registry_entry
+selection_status: active_candidate_not_canonical
+scientific_status: engineering_candidate
+engineering_status: engineering_candidate
+execution_status: unresolved_not_executable
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-010/contract.yaml
+candidate_ref: ir/TLC-FC-01-DISCIPLE-010/ir.candidate.json
+candidate_ir_id: TLC-IR-TLC-FC-01-DISCIPLE-010
+candidate_variant: structural
+source_ref: maths/01-disciple.md
+preservation_rules:
+- Do not infer missing scientific definitions, types, dimensions, aliases, equations,
+  or numerical methods.
+- Preserve unresolved operations and reservations explicitly.
+- This registry entry does not select a canonical executable IR.
+next_stage: scientific_review_then_ir_selection_or_revision

--- a/registry/math-contract-batches/disciple-domain-completion-001/manifest.yaml
+++ b/registry/math-contract-batches/disciple-domain-completion-001/manifest.yaml
@@ -1,0 +1,69 @@
+schema_version: '1.0'
+domain: disciple
+source_ref: maths/01-disciple.md
+completion_level: candidate_structural_uniformity
+canonical_selection_performed: false
+feature_count: 10
+features:
+- feature_id: TLC-FC-01-DISCIPLE-001
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-001/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-001/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-001/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-001/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-002
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-002/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-002/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-002/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-002/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-003
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-003/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-003/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-003/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-003/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-004
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-004/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-004/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-004/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-004/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-005
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-005/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-005/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-005/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-005/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-006
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-006/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-006/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-006/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-006/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-007
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-007/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-007/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-007/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-007/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-008
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-008/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-008/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-008/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-008/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-009
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-009/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-009/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-009/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-009/test-plan.yaml
+  status: complete_at_candidate_structural_level
+- feature_id: TLC-FC-01-DISCIPLE-010
+  contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-010/contract.yaml
+  ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-010/ir.yaml
+  ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-010/ir.candidate.json
+  test_plan_ref: registry/test-plans/TLC-FC-01-DISCIPLE-010/test-plan.yaml
+  status: complete_at_candidate_structural_level
+excluded_lineage: []
+batch_kind: math-contract

--- a/registry/test-plans/TLC-FC-01-DISCIPLE-001/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-01-DISCIPLE-001/test-plan.yaml
@@ -1,0 +1,33 @@
+schema_version: '1.0'
+test_plan_id: TLC-TP-TLC-FC-01-DISCIPLE-001
+feature_id: TLC-FC-01-DISCIPLE-001
+domain: disciple
+test_plan_status: structural_candidate
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-001/contract.yaml
+ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-001/ir.yaml
+ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-001/ir.candidate.json
+scope: artifact_conformance_and_reservation_preservation
+tests:
+- test_id: TLC-FC-01-DISCIPLE-001-TP-001
+  category: presence
+  assertion: contract, IR registry entry, and candidate IR paths exist
+- test_id: TLC-FC-01-DISCIPLE-001-TP-002
+  category: identity
+  assertion: feature_id is identical across contract, registry entry, and candidate
+    IR
+- test_id: TLC-FC-01-DISCIPLE-001-TP-003
+  category: traceability
+  assertion: source provenance includes maths/01-disciple.md
+- test_id: TLC-FC-01-DISCIPLE-001-TP-004
+  category: reservation
+  assertion: unresolved scientific semantics remain explicit and are not converted
+    into executable behavior
+- test_id: TLC-FC-01-DISCIPLE-001-TP-005
+  category: non_invention
+  assertion: no new equation, type, dimension, alias, or numerical method is introduced
+    by the registry wrapper
+- test_id: TLC-FC-01-DISCIPLE-001-TP-006
+  category: determinism
+  assertion: parsing and validation of the structured artifacts is deterministic
+execution_readiness: not_an_executable_scientific_oracle
+next_stage: extend_after_scientific_selection_of_contract_and_ir

--- a/registry/test-plans/TLC-FC-01-DISCIPLE-002/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-01-DISCIPLE-002/test-plan.yaml
@@ -1,0 +1,33 @@
+schema_version: '1.0'
+test_plan_id: TLC-TP-TLC-FC-01-DISCIPLE-002
+feature_id: TLC-FC-01-DISCIPLE-002
+domain: disciple
+test_plan_status: structural_candidate
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-002/contract.yaml
+ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-002/ir.yaml
+ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-002/ir.candidate.json
+scope: artifact_conformance_and_reservation_preservation
+tests:
+- test_id: TLC-FC-01-DISCIPLE-002-TP-001
+  category: presence
+  assertion: contract, IR registry entry, and candidate IR paths exist
+- test_id: TLC-FC-01-DISCIPLE-002-TP-002
+  category: identity
+  assertion: feature_id is identical across contract, registry entry, and candidate
+    IR
+- test_id: TLC-FC-01-DISCIPLE-002-TP-003
+  category: traceability
+  assertion: source provenance includes maths/01-disciple.md
+- test_id: TLC-FC-01-DISCIPLE-002-TP-004
+  category: reservation
+  assertion: unresolved scientific semantics remain explicit and are not converted
+    into executable behavior
+- test_id: TLC-FC-01-DISCIPLE-002-TP-005
+  category: non_invention
+  assertion: no new equation, type, dimension, alias, or numerical method is introduced
+    by the registry wrapper
+- test_id: TLC-FC-01-DISCIPLE-002-TP-006
+  category: determinism
+  assertion: parsing and validation of the structured artifacts is deterministic
+execution_readiness: not_an_executable_scientific_oracle
+next_stage: extend_after_scientific_selection_of_contract_and_ir

--- a/registry/test-plans/TLC-FC-01-DISCIPLE-003/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-01-DISCIPLE-003/test-plan.yaml
@@ -1,0 +1,33 @@
+schema_version: '1.0'
+test_plan_id: TLC-TP-TLC-FC-01-DISCIPLE-003
+feature_id: TLC-FC-01-DISCIPLE-003
+domain: disciple
+test_plan_status: structural_candidate
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-003/contract.yaml
+ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-003/ir.yaml
+ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-003/ir.candidate.json
+scope: artifact_conformance_and_reservation_preservation
+tests:
+- test_id: TLC-FC-01-DISCIPLE-003-TP-001
+  category: presence
+  assertion: contract, IR registry entry, and candidate IR paths exist
+- test_id: TLC-FC-01-DISCIPLE-003-TP-002
+  category: identity
+  assertion: feature_id is identical across contract, registry entry, and candidate
+    IR
+- test_id: TLC-FC-01-DISCIPLE-003-TP-003
+  category: traceability
+  assertion: source provenance includes maths/01-disciple.md
+- test_id: TLC-FC-01-DISCIPLE-003-TP-004
+  category: reservation
+  assertion: unresolved scientific semantics remain explicit and are not converted
+    into executable behavior
+- test_id: TLC-FC-01-DISCIPLE-003-TP-005
+  category: non_invention
+  assertion: no new equation, type, dimension, alias, or numerical method is introduced
+    by the registry wrapper
+- test_id: TLC-FC-01-DISCIPLE-003-TP-006
+  category: determinism
+  assertion: parsing and validation of the structured artifacts is deterministic
+execution_readiness: not_an_executable_scientific_oracle
+next_stage: extend_after_scientific_selection_of_contract_and_ir

--- a/registry/test-plans/TLC-FC-01-DISCIPLE-004/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-01-DISCIPLE-004/test-plan.yaml
@@ -1,0 +1,33 @@
+schema_version: '1.0'
+test_plan_id: TLC-TP-TLC-FC-01-DISCIPLE-004
+feature_id: TLC-FC-01-DISCIPLE-004
+domain: disciple
+test_plan_status: structural_candidate
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-004/contract.yaml
+ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-004/ir.yaml
+ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-004/ir.candidate.json
+scope: artifact_conformance_and_reservation_preservation
+tests:
+- test_id: TLC-FC-01-DISCIPLE-004-TP-001
+  category: presence
+  assertion: contract, IR registry entry, and candidate IR paths exist
+- test_id: TLC-FC-01-DISCIPLE-004-TP-002
+  category: identity
+  assertion: feature_id is identical across contract, registry entry, and candidate
+    IR
+- test_id: TLC-FC-01-DISCIPLE-004-TP-003
+  category: traceability
+  assertion: source provenance includes maths/01-disciple.md
+- test_id: TLC-FC-01-DISCIPLE-004-TP-004
+  category: reservation
+  assertion: unresolved scientific semantics remain explicit and are not converted
+    into executable behavior
+- test_id: TLC-FC-01-DISCIPLE-004-TP-005
+  category: non_invention
+  assertion: no new equation, type, dimension, alias, or numerical method is introduced
+    by the registry wrapper
+- test_id: TLC-FC-01-DISCIPLE-004-TP-006
+  category: determinism
+  assertion: parsing and validation of the structured artifacts is deterministic
+execution_readiness: not_an_executable_scientific_oracle
+next_stage: extend_after_scientific_selection_of_contract_and_ir

--- a/registry/test-plans/TLC-FC-01-DISCIPLE-005/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-01-DISCIPLE-005/test-plan.yaml
@@ -1,0 +1,33 @@
+schema_version: '1.0'
+test_plan_id: TLC-TP-TLC-FC-01-DISCIPLE-005
+feature_id: TLC-FC-01-DISCIPLE-005
+domain: disciple
+test_plan_status: structural_candidate
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-005/contract.yaml
+ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-005/ir.yaml
+ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-005/ir.candidate.json
+scope: artifact_conformance_and_reservation_preservation
+tests:
+- test_id: TLC-FC-01-DISCIPLE-005-TP-001
+  category: presence
+  assertion: contract, IR registry entry, and candidate IR paths exist
+- test_id: TLC-FC-01-DISCIPLE-005-TP-002
+  category: identity
+  assertion: feature_id is identical across contract, registry entry, and candidate
+    IR
+- test_id: TLC-FC-01-DISCIPLE-005-TP-003
+  category: traceability
+  assertion: source provenance includes maths/01-disciple.md
+- test_id: TLC-FC-01-DISCIPLE-005-TP-004
+  category: reservation
+  assertion: unresolved scientific semantics remain explicit and are not converted
+    into executable behavior
+- test_id: TLC-FC-01-DISCIPLE-005-TP-005
+  category: non_invention
+  assertion: no new equation, type, dimension, alias, or numerical method is introduced
+    by the registry wrapper
+- test_id: TLC-FC-01-DISCIPLE-005-TP-006
+  category: determinism
+  assertion: parsing and validation of the structured artifacts is deterministic
+execution_readiness: not_an_executable_scientific_oracle
+next_stage: extend_after_scientific_selection_of_contract_and_ir

--- a/registry/test-plans/TLC-FC-01-DISCIPLE-006/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-01-DISCIPLE-006/test-plan.yaml
@@ -1,0 +1,33 @@
+schema_version: '1.0'
+test_plan_id: TLC-TP-TLC-FC-01-DISCIPLE-006
+feature_id: TLC-FC-01-DISCIPLE-006
+domain: disciple
+test_plan_status: structural_candidate
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-006/contract.yaml
+ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-006/ir.yaml
+ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-006/ir.candidate.json
+scope: artifact_conformance_and_reservation_preservation
+tests:
+- test_id: TLC-FC-01-DISCIPLE-006-TP-001
+  category: presence
+  assertion: contract, IR registry entry, and candidate IR paths exist
+- test_id: TLC-FC-01-DISCIPLE-006-TP-002
+  category: identity
+  assertion: feature_id is identical across contract, registry entry, and candidate
+    IR
+- test_id: TLC-FC-01-DISCIPLE-006-TP-003
+  category: traceability
+  assertion: source provenance includes maths/01-disciple.md
+- test_id: TLC-FC-01-DISCIPLE-006-TP-004
+  category: reservation
+  assertion: unresolved scientific semantics remain explicit and are not converted
+    into executable behavior
+- test_id: TLC-FC-01-DISCIPLE-006-TP-005
+  category: non_invention
+  assertion: no new equation, type, dimension, alias, or numerical method is introduced
+    by the registry wrapper
+- test_id: TLC-FC-01-DISCIPLE-006-TP-006
+  category: determinism
+  assertion: parsing and validation of the structured artifacts is deterministic
+execution_readiness: not_an_executable_scientific_oracle
+next_stage: extend_after_scientific_selection_of_contract_and_ir

--- a/registry/test-plans/TLC-FC-01-DISCIPLE-007/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-01-DISCIPLE-007/test-plan.yaml
@@ -1,0 +1,33 @@
+schema_version: '1.0'
+test_plan_id: TLC-TP-TLC-FC-01-DISCIPLE-007
+feature_id: TLC-FC-01-DISCIPLE-007
+domain: disciple
+test_plan_status: structural_candidate
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-007/contract.yaml
+ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-007/ir.yaml
+ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-007/ir.candidate.json
+scope: artifact_conformance_and_reservation_preservation
+tests:
+- test_id: TLC-FC-01-DISCIPLE-007-TP-001
+  category: presence
+  assertion: contract, IR registry entry, and candidate IR paths exist
+- test_id: TLC-FC-01-DISCIPLE-007-TP-002
+  category: identity
+  assertion: feature_id is identical across contract, registry entry, and candidate
+    IR
+- test_id: TLC-FC-01-DISCIPLE-007-TP-003
+  category: traceability
+  assertion: source provenance includes maths/01-disciple.md
+- test_id: TLC-FC-01-DISCIPLE-007-TP-004
+  category: reservation
+  assertion: unresolved scientific semantics remain explicit and are not converted
+    into executable behavior
+- test_id: TLC-FC-01-DISCIPLE-007-TP-005
+  category: non_invention
+  assertion: no new equation, type, dimension, alias, or numerical method is introduced
+    by the registry wrapper
+- test_id: TLC-FC-01-DISCIPLE-007-TP-006
+  category: determinism
+  assertion: parsing and validation of the structured artifacts is deterministic
+execution_readiness: not_an_executable_scientific_oracle
+next_stage: extend_after_scientific_selection_of_contract_and_ir

--- a/registry/test-plans/TLC-FC-01-DISCIPLE-008/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-01-DISCIPLE-008/test-plan.yaml
@@ -1,0 +1,33 @@
+schema_version: '1.0'
+test_plan_id: TLC-TP-TLC-FC-01-DISCIPLE-008
+feature_id: TLC-FC-01-DISCIPLE-008
+domain: disciple
+test_plan_status: structural_candidate
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-008/contract.yaml
+ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-008/ir.yaml
+ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-008/ir.candidate.json
+scope: artifact_conformance_and_reservation_preservation
+tests:
+- test_id: TLC-FC-01-DISCIPLE-008-TP-001
+  category: presence
+  assertion: contract, IR registry entry, and candidate IR paths exist
+- test_id: TLC-FC-01-DISCIPLE-008-TP-002
+  category: identity
+  assertion: feature_id is identical across contract, registry entry, and candidate
+    IR
+- test_id: TLC-FC-01-DISCIPLE-008-TP-003
+  category: traceability
+  assertion: source provenance includes maths/01-disciple.md
+- test_id: TLC-FC-01-DISCIPLE-008-TP-004
+  category: reservation
+  assertion: unresolved scientific semantics remain explicit and are not converted
+    into executable behavior
+- test_id: TLC-FC-01-DISCIPLE-008-TP-005
+  category: non_invention
+  assertion: no new equation, type, dimension, alias, or numerical method is introduced
+    by the registry wrapper
+- test_id: TLC-FC-01-DISCIPLE-008-TP-006
+  category: determinism
+  assertion: parsing and validation of the structured artifacts is deterministic
+execution_readiness: not_an_executable_scientific_oracle
+next_stage: extend_after_scientific_selection_of_contract_and_ir

--- a/registry/test-plans/TLC-FC-01-DISCIPLE-009/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-01-DISCIPLE-009/test-plan.yaml
@@ -1,0 +1,33 @@
+schema_version: '1.0'
+test_plan_id: TLC-TP-TLC-FC-01-DISCIPLE-009
+feature_id: TLC-FC-01-DISCIPLE-009
+domain: disciple
+test_plan_status: structural_candidate
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-009/contract.yaml
+ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-009/ir.yaml
+ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-009/ir.candidate.json
+scope: artifact_conformance_and_reservation_preservation
+tests:
+- test_id: TLC-FC-01-DISCIPLE-009-TP-001
+  category: presence
+  assertion: contract, IR registry entry, and candidate IR paths exist
+- test_id: TLC-FC-01-DISCIPLE-009-TP-002
+  category: identity
+  assertion: feature_id is identical across contract, registry entry, and candidate
+    IR
+- test_id: TLC-FC-01-DISCIPLE-009-TP-003
+  category: traceability
+  assertion: source provenance includes maths/01-disciple.md
+- test_id: TLC-FC-01-DISCIPLE-009-TP-004
+  category: reservation
+  assertion: unresolved scientific semantics remain explicit and are not converted
+    into executable behavior
+- test_id: TLC-FC-01-DISCIPLE-009-TP-005
+  category: non_invention
+  assertion: no new equation, type, dimension, alias, or numerical method is introduced
+    by the registry wrapper
+- test_id: TLC-FC-01-DISCIPLE-009-TP-006
+  category: determinism
+  assertion: parsing and validation of the structured artifacts is deterministic
+execution_readiness: not_an_executable_scientific_oracle
+next_stage: extend_after_scientific_selection_of_contract_and_ir

--- a/registry/test-plans/TLC-FC-01-DISCIPLE-010/test-plan.yaml
+++ b/registry/test-plans/TLC-FC-01-DISCIPLE-010/test-plan.yaml
@@ -1,0 +1,33 @@
+schema_version: '1.0'
+test_plan_id: TLC-TP-TLC-FC-01-DISCIPLE-010
+feature_id: TLC-FC-01-DISCIPLE-010
+domain: disciple
+test_plan_status: structural_candidate
+contract_ref: registry/math-contracts/TLC-FC-01-DISCIPLE-010/contract.yaml
+ir_registry_ref: registry/ir/TLC-FC-01-DISCIPLE-010/ir.yaml
+ir_candidate_ref: ir/TLC-FC-01-DISCIPLE-010/ir.candidate.json
+scope: artifact_conformance_and_reservation_preservation
+tests:
+- test_id: TLC-FC-01-DISCIPLE-010-TP-001
+  category: presence
+  assertion: contract, IR registry entry, and candidate IR paths exist
+- test_id: TLC-FC-01-DISCIPLE-010-TP-002
+  category: identity
+  assertion: feature_id is identical across contract, registry entry, and candidate
+    IR
+- test_id: TLC-FC-01-DISCIPLE-010-TP-003
+  category: traceability
+  assertion: source provenance includes maths/01-disciple.md
+- test_id: TLC-FC-01-DISCIPLE-010-TP-004
+  category: reservation
+  assertion: unresolved scientific semantics remain explicit and are not converted
+    into executable behavior
+- test_id: TLC-FC-01-DISCIPLE-010-TP-005
+  category: non_invention
+  assertion: no new equation, type, dimension, alias, or numerical method is introduced
+    by the registry wrapper
+- test_id: TLC-FC-01-DISCIPLE-010-TP-006
+  category: determinism
+  assertion: parsing and validation of the structured artifacts is deterministic
+execution_readiness: not_an_executable_scientific_oracle
+next_stage: extend_after_scientific_selection_of_contract_and_ir

--- a/reports/domain-completions/disciple-domain-completion-001/completion-report.md
+++ b/reports/domain-completions/disciple-domain-completion-001/completion-report.md
@@ -1,0 +1,11 @@
+# Disciple domain completion
+
+- Source: `maths/01-disciple.md`
+- Active software features: **10**
+- Existing owner contracts: **10**
+- Candidate IR registry entries added: **10**
+- Structural candidate test plans added: **10**
+- Canonical IR selection performed: **no**
+- Code-generation readiness asserted: **no**
+
+This completion aligns the domain with the repository's contract/IR/test-plan structure while preserving all scientific reservations and existing candidate variants.

--- a/scripts/validate_disciple_domain_completion.py
+++ b/scripts/validate_disciple_domain_completion.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys, yaml, json
+
+FEATURE_IDS = ['TLC-FC-01-DISCIPLE-001', 'TLC-FC-01-DISCIPLE-002', 'TLC-FC-01-DISCIPLE-003', 'TLC-FC-01-DISCIPLE-004', 'TLC-FC-01-DISCIPLE-005', 'TLC-FC-01-DISCIPLE-006', 'TLC-FC-01-DISCIPLE-007', 'TLC-FC-01-DISCIPLE-008', 'TLC-FC-01-DISCIPLE-009', 'TLC-FC-01-DISCIPLE-010']
+errors = []
+for fid in FEATURE_IDS:
+    paths = [
+        Path(f"registry/math-contracts/{fid}/contract.yaml"),
+        Path(f"registry/ir/{fid}/ir.yaml"),
+        Path(f"registry/test-plans/{fid}/test-plan.yaml"),
+        Path(f"ir/{fid}/ir.candidate.json"),
+    ]
+    for path in paths:
+        if not path.is_file():
+            errors.append(f"missing: {path}")
+            continue
+        try:
+            if path.suffix == ".json":
+                data = json.loads(path.read_text(encoding="utf-8-sig"))
+            else:
+                data = yaml.safe_load(path.read_text(encoding="utf-8-sig"))
+            if isinstance(data, dict) and data.get("feature_id") != fid:
+                errors.append(f"feature_id mismatch: {path}")
+        except Exception as exc:
+            errors.append(f"parse error {path}: {exc}")
+
+if errors:
+    print("\n".join(errors))
+    sys.exit(1)
+print("DISCIPLE DOMAIN COMPLETION VALIDATION PASSED features=10")
+print("canonical_selection=false code_generation_ready=false")


### PR DESCRIPTION
Adds registry-owned candidate IR entries, structural test plans, batch manifests, completion report, and validator. Preserves existing contracts, candidate variants, unresolved semantics, and maths sources. Performs no canonical executable IR selection.

## Summary by Sourcery

Add registry-owned candidate IR entries, manifests, structural test plans, and validation script to complete the disciple domain at the candidate structural level without selecting a canonical executable IR.

New Features:
- Introduce IR and math-contract batch manifests for disciple domain completion covering 10 features.
- Register 10 disciple candidate IR entries with preservation-focused metadata and provenance to the maths/01-disciple.md source.
- Add 10 structural candidate test plans to verify alignment and non-invention across contracts, registry IR, and candidate IR artifacts.
- Add a validation script to check existence, parseability, and feature_id consistency for all disciple domain artifacts.
- Publish a disciple domain completion report summarizing feature coverage and structural alignment.

Tests:
- Define structural candidate test plans for each disciple feature to enforce artifact presence, identity, traceability, reservation preservation, non-invention, and deterministic parsing.

Chores:
- Record disciple domain completion status and constraints in a human-readable report for repository tracking.