### PR TITLE
feat(handoff): establish Feature Handoff Package v1.0 foundation

### DIFF
--- a/.github/workflows/handoff.yml
+++ b/.github/workflows/handoff.yml
@@ -34,8 +34,18 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install validator dependency
-        run: python -m pip install --disable-pip-version-check jsonschema
+        run: python -m pip install --disable-pip-version-check --quiet jsonschema
       - name: Validate packages and schemas
-        run: python tools/handoff/validate_handoff.py
+        shell: bash
+        run: |
+          set -o pipefail
+          python tools/handoff/validate_handoff.py 2>&1 | tee handoff-validation.log
+      - name: Upload validation diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: handoff-validation-diagnostics
+          path: handoff-validation.log
+          if-no-files-found: error
       - name: Resolve pilot bundle without writing artifacts
         run: python tools/handoff/export_bundle.py TLC-FC-00-MASTER-005 --check

--- a/.github/workflows/handoff.yml
+++ b/.github/workflows/handoff.yml
@@ -36,15 +36,23 @@ jobs:
       - name: Install validator dependency
         run: python -m pip install --disable-pip-version-check --quiet jsonschema
       - name: Validate packages and schemas
+        id: validate
         shell: bash
         run: |
-          set -o pipefail
-          python tools/handoff/validate_handoff.py 2>&1 | tee handoff-validation.log
+          set +e
+          output="$(python tools/handoff/validate_handoff.py 2>&1)"
+          status=$?
+          printf '%s\n' "$output" | tee handoff-validation.log
+          if [ "$status" -ne 0 ]; then
+            diagnostic="$(printf '%s\n' "$output" | tail -n 1 | tr -cs '[:alnum:]_.-' '-' | cut -c1-120)"
+            printf 'diagnostic=%s\n' "$diagnostic" >> "$GITHUB_OUTPUT"
+            exit "$status"
+          fi
       - name: Upload validation diagnostics
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: handoff-validation-diagnostics
+          name: handoff-validation-${{ steps.validate.outputs.diagnostic }}
           path: handoff-validation.log
           if-no-files-found: error
       - name: Resolve pilot bundle without writing artifacts

--- a/.github/workflows/handoff.yml
+++ b/.github/workflows/handoff.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
       - name: Install validator dependency
         run: python -m pip install --disable-pip-version-check jsonschema
       - name: Validate packages and schemas

--- a/.github/workflows/handoff.yml
+++ b/.github/workflows/handoff.yml
@@ -1,0 +1,42 @@
+name: Feature handoff validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'handoff/**'
+      - 'tools/handoff/**'
+      - 'reports/handoff/**'
+      - 'README.md'
+      - '.github/workflows/handoff.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'handoff/**'
+      - 'tools/handoff/**'
+      - 'reports/handoff/**'
+      - 'README.md'
+      - '.github/workflows/handoff.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate handoff v1.0
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install validator dependency
+        run: python -m pip install --disable-pip-version-check jsonschema
+      - name: Validate packages and schemas
+        run: python tools/handoff/validate_handoff.py
+      - name: Resolve pilot bundle without writing artifacts
+        run: python tools/handoff/export_bundle.py TLC-FC-00-MASTER-005 --check

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Domains](https://img.shields.io/badge/domains-16-7c3aed)](registry/global-finalization/domain-status.yaml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-64748b)](LICENSE)
 
-[Overview](#overview) · [Architecture](#specification-architecture) · [Governance](#engineering-governance) · [Domains](#domains) · [Repository map](#repository-map) · [Feature chain](#working-with-a-feature) · [Validation](#validation) · [Contributing](#contributing)
+[Overview](#overview) · [Handoff](#feature-handoff-package) · [Architecture](#specification-architecture) · [Governance](#engineering-governance) · [Domains](#domains) · [Repository map](#repository-map) · [Feature chain](#working-with-a-feature) · [Validation](#validation) · [Contributing](#contributing)
 
 </div>
 
@@ -38,6 +38,14 @@ The current integrated specification covers:
 | Acceptance oracles | **166** |
 
 The global package is marked [`integrated_structural_specification_finalized`](registry/global-finalization/manifest.yaml). This means the **structural engineering specification is finalized and ready for downstream handoff**. It does not mean that runtime implementation exists here, or that every preserved equation, proof, metric, transition, or evaluator is scientifically executable.
+
+## Feature Handoff Package
+
+[`handoff/`](handoff/) is the language-independent final output intended for downstream programmers. It compiles observable behavior, acceptance tests, shared structural contracts, traceability, and explicit implementation freedoms into autonomous Markdown and JSON packages.
+
+The foundation currently includes the pilot package [`TLC-FC-00-MASTER-005`](handoff/features/TLC-FC-00-MASTER-005/) and eight shared contracts. It does **not** claim that all 166 final feature packages have been generated.
+
+For normal implementation work, a programmer should be able to use the resolved handoff package without reading the intermediate mathematical contracts, IRs, algorithm specifications, test plans, or scientific source text.
 
 ## Why this repository exists
 

--- a/handoff/README.md
+++ b/handoff/README.md
@@ -35,4 +35,4 @@ The handoff compiles observable obligations conservatively. It preserves unresol
 
 ## Current scope
 
-Version 1.0 establishes eight shared contracts and the pilot package `TLC-FC-00-MASTER-005`. The complete catalogue of 166 feature packages is not yet finalized.
+Version 1.0 establishes eight shared contracts and the pilot package `TLC-FC-00-MASTER-005`. The complete catalog of 166 feature packages is not yet finalized.

--- a/handoff/README.md
+++ b/handoff/README.md
@@ -1,0 +1,38 @@
+# Feature Handoff Package v1.0
+
+The `handoff/` tree is the final, language-independent output of the `tllib-specs` specification pipeline. It is intended for implementers who should not need to read mathematical contracts, intermediate representations, algorithm YAML, or scientific source prose during ordinary implementation work.
+
+## Authority order
+
+When two package files appear to differ, apply this order from highest to lowest authority:
+
+1. `contract.json`
+2. `acceptance.json`
+3. referenced shared contracts
+4. `manifest.json`
+5. `README.md`
+6. `examples.json`
+7. `traceability.json`
+
+A README or example cannot create an obligation absent from the normative JSON files.
+
+## Package model
+
+- `schemas/` defines the machine-validatable v1.0 structures.
+- `shared/` contains reusable, versioned structural contracts.
+- `features/` contains autonomous feature packages.
+- `catalog.json` indexes the packages currently compiled into this output.
+
+Markdown is the human interface. JSON is the normative machine interface. JSON Schema validates structure. YAML remains an upstream pipeline format and is not part of the handoff interface.
+
+## Scientific boundary
+
+The handoff compiles observable obligations conservatively. It preserves unresolved or opaque scientific material explicitly, does not select an implementation language, and does not prescribe internal algorithms, storage, ownership models, serialization formats, performance bounds, or concurrency policies unless an authoritative source makes them observable requirements.
+
+## Validation and export
+
+`tools/handoff/validate_handoff.py` validates package structure, cross-file coherence, dependency resolution, traceability, and the pilot package. `tools/handoff/export_bundle.py` resolves one feature with all required shared contracts and emits a directory bundle plus `bundle-lock.json`; generated archives are not committed.
+
+## Current scope
+
+Version 1.0 establishes eight shared contracts and the pilot package `TLC-FC-00-MASTER-005`. The complete catalogue of 166 feature packages is not yet finalized.

--- a/handoff/catalog.json
+++ b/handoff/catalog.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "1.0",
+  "model_version": "1.0.0",
+  "catalog_status": "foundation_pilot_only",
+  "complete_166_feature_catalog_finalized": false,
+  "shared_contracts": [
+    {"shared_contract_id": "TLC-HC-FEATURE-ID", "version": "1.0.0", "path": "handoff/shared/TLC-HC-FEATURE-ID", "status": "validated"},
+    {"shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE", "version": "1.0.0", "path": "handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE", "status": "validated"},
+    {"shared_contract_id": "TLC-HC-REFERENCE-COLLECTION", "version": "1.0.0", "path": "handoff/shared/TLC-HC-REFERENCE-COLLECTION", "status": "validated"},
+    {"shared_contract_id": "TLC-HC-UNRESOLVED-ITEM", "version": "1.0.0", "path": "handoff/shared/TLC-HC-UNRESOLVED-ITEM", "status": "validated"},
+    {"shared_contract_id": "TLC-HC-OPAQUE-VALUE", "version": "1.0.0", "path": "handoff/shared/TLC-HC-OPAQUE-VALUE", "status": "validated"},
+    {"shared_contract_id": "TLC-HC-STRUCTURED-ERROR", "version": "1.0.0", "path": "handoff/shared/TLC-HC-STRUCTURED-ERROR", "status": "validated"},
+    {"shared_contract_id": "TLC-HC-TRACEABILITY", "version": "1.0.0", "path": "handoff/shared/TLC-HC-TRACEABILITY", "status": "validated"},
+    {"shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE", "version": "1.0.0", "path": "handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE", "status": "validated"}
+  ],
+  "features": [
+    {
+      "feature_id": "TLC-FC-00-MASTER-005",
+      "package_version": "1.0.0",
+      "path": "handoff/features/TLC-FC-00-MASTER-005",
+      "status": "pilot",
+      "source_fingerprints": [
+        {"path": "maths/00-master.md", "algorithm": "git_blob_sha1", "value": "fe0a408035b07bad720062e98755dd32eaefc6f0"},
+        {"path": "registry/math-contracts/TLC-FC-00-MASTER-005/contract.yaml", "algorithm": "git_blob_sha1", "value": "11b5880dd2cdd8e6e091ec5a76f208c5ab36aa53"},
+        {"path": "registry/ir/TLC-FC-00-MASTER-005/ir.yaml", "algorithm": "git_blob_sha1", "value": "da8496d476208e8efa8a4925ab2261b7e2109a30"},
+        {"path": "ir/TLC-FC-00-MASTER-005/ir.candidate.json", "algorithm": "git_blob_sha1", "value": "98a9371c338b70d44ffd117676ad65aefc7a342f"},
+        {"path": "registry/test-plans/TLC-FC-00-MASTER-005/test-plan.yaml", "algorithm": "git_blob_sha1", "value": "dfa7625d721c4017ca71687fec778b94acda0498"},
+        {"path": "registry/optimized-ir/master/TLC-FC-00-MASTER-005/ir.yaml", "algorithm": "git_blob_sha1", "value": "6169258d4f2ae242dc08c7e820aa60b6b2a3b4fd"},
+        {"path": "registry/algorithms/master/TLC-FC-00-MASTER-005/algorithm.yaml", "algorithm": "git_blob_sha1", "value": "f314ffccb865897958ffd67dc56b304384f4953e"},
+        {"path": "registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml", "algorithm": "git_blob_sha1", "value": "274a1cb4a3dee851aa9d02824f734dc745b71f6b"}
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-005/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-005/README.md
@@ -1,0 +1,15 @@
+# TLC-FC-00-MASTER-005 — Master seven-tuple definition
+
+This pilot package defines the observable structural behavior for describing the Master's seven-tuple declaration.
+
+A conforming implementation accepts the exact feature identity, the exact scientific object reference `TLC-SO-MASTER-008`, the five exact relation references `TLC-SR-MASTER-007` through `TLC-SR-MASTER-011` in source order, and an empty unresolved collection. It emits an immutable declaration descriptor with complete provenance.
+
+The package does not evaluate the seven-tuple, assign component runtime types, select a memory layout, invent dimensions or values, merge component identities, or require the total step sequence printed in the upstream algorithm artifact. Only the partial-order obligations in `contract.json` are normative.
+
+## Authority
+
+Apply the repository handoff authority order. `contract.json` and `acceptance.json` are normative. This README and `examples.json` add no obligations.
+
+## Implementation freedom
+
+Public naming, programming-language type design, storage, allocation, ownership mechanism, error transport, serialization, concurrency strategy, and internal validation decomposition remain free unless they affect a stated observable obligation.

--- a/handoff/features/TLC-FC-00-MASTER-005/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-005/acceptance.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-005",
+  "tests": [
+    {
+      "test_id": "MASTER-005-A01",
+      "applies_to": "DESCRIBE-MASTER-SEVEN-TUPLE",
+      "category": "valid_input",
+      "given": {"feature_id": "TLC-FC-00-MASTER-005", "scientific_object_refs": ["TLC-SO-MASTER-008"], "relation_refs": ["TLC-SR-MASTER-007", "TLC-SR-MASTER-008", "TLC-SR-MASTER-009", "TLC-SR-MASTER-010", "TLC-SR-MASTER-011"], "unresolved_refs": []},
+      "when": "The structural descriptor operation is requested.",
+      "expect": {"accepted": true},
+      "source_basis": ["registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml"]
+    },
+    {
+      "test_id": "MASTER-005-A02",
+      "applies_to": "DESCRIBE-MASTER-SEVEN-TUPLE",
+      "category": "output_contract",
+      "given": {"valid_reference_bundle": true},
+      "when": "The operation succeeds.",
+      "expect": {"immutable": true, "feature_id": "TLC-FC-00-MASTER-005", "representation": "declaration", "required_fields": ["feature_id", "representation", "references", "unresolved", "dependencies", "provenance", "status"]},
+      "source_basis": ["registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml", "registry/optimized-ir/master/TLC-FC-00-MASTER-005/ir.yaml"]
+    },
+    {
+      "test_id": "MASTER-005-A03",
+      "applies_to": "DESCRIBE-MASTER-SEVEN-TUPLE",
+      "category": "error",
+      "given": {"relation_refs": ["TLC-SR-MASTER-007", "TLC-SR-MASTER-008", "TLC-SR-MASTER-009", "TLC-SR-MASTER-010"]},
+      "when": "One required relation is omitted.",
+      "expect": {"error_code": "MASTER_REFERENCE_SET_MISMATCH", "partial_result": false},
+      "source_basis": ["registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml"]
+    },
+    {
+      "test_id": "MASTER-005-A04",
+      "applies_to": "DESCRIBE-MASTER-SEVEN-TUPLE",
+      "category": "invariant",
+      "given": {"valid_reference_bundle": true},
+      "when": "The descriptor is emitted.",
+      "expect": {"relation_refs_distinct": true, "relation_order": ["TLC-SR-MASTER-007", "TLC-SR-MASTER-008", "TLC-SR-MASTER-009", "TLC-SR-MASTER-010", "TLC-SR-MASTER-011"]},
+      "source_basis": ["registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml", "maths/00-master.md"]
+    },
+    {
+      "test_id": "MASTER-005-A05",
+      "applies_to": "DESCRIBE-MASTER-SEVEN-TUPLE",
+      "category": "determinism",
+      "given": {"same_valid_input_repeated": true},
+      "when": "The operation is invoked more than once.",
+      "expect": {"semantic_output_identical": true, "field_presence_identical": true, "relation_order_identical": true},
+      "source_basis": ["registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml"]
+    },
+    {
+      "test_id": "MASTER-005-A06",
+      "applies_to": "DESCRIBE-MASTER-SEVEN-TUPLE",
+      "category": "preservation",
+      "given": {"valid_reference_bundle": true},
+      "when": "The descriptor is inspected.",
+      "expect": {"invented_runtime_type": false, "invented_layout": false, "invented_dimension": false, "invented_alias": false, "invented_scientific_value": false},
+      "source_basis": ["registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml", "registry/math-contracts/TLC-FC-00-MASTER-005/contract.yaml"]
+    },
+    {
+      "test_id": "MASTER-005-A07",
+      "applies_to": "scientific-evaluation",
+      "category": "unsupported_operation",
+      "given": {"request": "calculate the seven-tuple"},
+      "when": "An executable scientific result is requested.",
+      "expect": {"error_code": "MASTER_UNSUPPORTED_EXECUTION_MODE", "partial_result": false},
+      "source_basis": ["registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml"]
+    },
+    {
+      "test_id": "MASTER-005-A08",
+      "applies_to": "package integrity",
+      "category": "preservation",
+      "given": {"upstream_artifact_paths": ["maths/00-master.md", "registry/math-contracts/TLC-FC-00-MASTER-005/contract.yaml", "registry/ir/TLC-FC-00-MASTER-005/ir.yaml", "ir/TLC-FC-00-MASTER-005/ir.candidate.json", "registry/test-plans/TLC-FC-00-MASTER-005/test-plan.yaml", "registry/optimized-ir/master/TLC-FC-00-MASTER-005/ir.yaml", "registry/algorithms/master/TLC-FC-00-MASTER-005/algorithm.yaml", "registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml"]},
+      "when": "The handoff is validated.",
+      "expect": {"upstream_artifacts_unmodified_by_handoff": true},
+      "source_basis": ["registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml"]
+    },
+    {
+      "test_id": "MASTER-005-A09",
+      "applies_to": "DESCRIBE-MASTER-SEVEN-TUPLE",
+      "category": "invalid_input",
+      "given": {"feature_id": "TLC-FC-00-MASTER-006"},
+      "when": "The feature identity differs.",
+      "expect": {"error_code": "MASTER_INVALID_FEATURE_ID", "partial_result": false},
+      "source_basis": ["registry/optimized-ir/master/TLC-FC-00-MASTER-005/ir.yaml"]
+    },
+    {
+      "test_id": "MASTER-005-A10",
+      "applies_to": "DESCRIBE-MASTER-SEVEN-TUPLE",
+      "category": "preservation",
+      "given": {"accepted_input": true},
+      "when": "Any required identity, distinction, order, opacity, or provenance cannot be preserved.",
+      "expect": {"error_code": "MASTER_PRESERVATION_VIOLATION", "partial_result": false},
+      "source_basis": ["registry/optimized-ir/master/TLC-FC-00-MASTER-005/ir.yaml", "registry/domain-finalization/master/module-specification.yaml"]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-005/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-005/contract.json
@@ -1,0 +1,171 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-005",
+    "title": "Master seven-tuple definition",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact scientific references for the Master's seven-tuple declaration and emit an immutable, traceable declaration descriptor without executing or completing its scientific semantics.",
+  "scope": {
+    "required": [
+      {"id": "M005-REQ-001", "statement": "Accept only the exact feature identity TLC-FC-00-MASTER-005.", "basis": ["registry/optimized-ir/master/TLC-FC-00-MASTER-005/ir.yaml"]},
+      {"id": "M005-REQ-002", "statement": "Accept exactly scientific object reference TLC-SO-MASTER-008 and no additional object reference.", "basis": ["registry/math-contracts/TLC-FC-00-MASTER-005/contract.yaml", "registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml"]},
+      {"id": "M005-REQ-003", "statement": "Accept exactly relation references TLC-SR-MASTER-007, TLC-SR-MASTER-008, TLC-SR-MASTER-009, TLC-SR-MASTER-010, and TLC-SR-MASTER-011 in that source order.", "basis": ["registry/math-contracts/TLC-FC-00-MASTER-005/contract.yaml", "maths/00-master.md", "registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml"]},
+      {"id": "M005-REQ-004", "statement": "Emit an immutable descriptor whose observable fields are feature_id, representation, references, unresolved, dependencies, provenance, and status.", "basis": ["registry/optimized-ir/master/TLC-FC-00-MASTER-005/ir.yaml", "registry/domain-finalization/master/module-specification.yaml"]},
+      {"id": "M005-REQ-005", "statement": "Preserve every accepted reference as distinct and fully traceable.", "basis": ["registry/math-contracts/TLC-FC-00-MASTER-005/contract.yaml", "registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml"]}
+    ],
+    "forbidden": [
+      {"id": "M005-FOR-001", "statement": "Scientific evaluation, calculation, simulation, or completion of the seven-tuple is forbidden."},
+      {"id": "M005-FOR-002", "statement": "Do not invent component runtime types, dimensions, storage, layout, aliases, values, equations, tolerances, or numerical methods."},
+      {"id": "M005-FOR-003", "statement": "Do not merge the seven components or their five relation references because they share a carrier representation."},
+      {"id": "M005-FOR-004", "statement": "Do not expose a successful partial descriptor after any validation or preservation failure."}
+    ],
+    "deferred": [
+      {"id": "M005-DEF-001", "statement": "Executable scientific behavior for the seven-tuple remains undefined and outside this package."},
+      {"id": "M005-DEF-002", "statement": "Concrete component representations and all low-level storage decisions remain implementation-defined."}
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "DESCRIBE-MASTER-SEVEN-TUPLE",
+      "purpose": "Produce the structural declaration descriptor for the exact source reference bundle.",
+      "inputs": [
+        {
+          "name": "reference_bundle",
+          "semantic_role": "exact feature, object, relation, unresolved, and provenance references",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {"name": "feature_id", "required": true, "semantic_role": "exact feature identity", "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0", "constant": "TLC-FC-00-MASTER-005"},
+            {"name": "scientific_object_refs", "required": true, "semantic_role": "exact object reference set", "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0", "allowed_values": ["TLC-SO-MASTER-008"]},
+            {"name": "relation_refs", "required": true, "semantic_role": "exact ordered relation reference set", "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0", "allowed_values": ["TLC-SR-MASTER-007", "TLC-SR-MASTER-008", "TLC-SR-MASTER-009", "TLC-SR-MASTER-010", "TLC-SR-MASTER-011"]},
+            {"name": "unresolved_refs", "required": true, "semantic_role": "exact unresolved collection", "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0", "allowed_values": []},
+            {"name": "source_provenance", "required": true, "semantic_role": "source provenance", "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"}
+          ],
+          "collection": {"kind": "scalar", "membership": "exact", "members": [], "cardinality": {"minimum": 1, "maximum": 1}, "ordering": "not_applicable", "duplicates": "not_applicable", "key_contract": null, "value_contract": {"shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"}},
+          "constraints": [
+            {"id": "M005-IN-001", "statement": "scientific_object_refs is a set with exactly one member: TLC-SO-MASTER-008."},
+            {"id": "M005-IN-002", "statement": "relation_refs is an ordered_set with exactly the five declared relation identities in source order."},
+            {"id": "M005-IN-003", "statement": "unresolved_refs is an empty set for this package version."}
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "descriptor",
+          "semantic_role": "immutable Master seven-tuple declaration descriptor",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {"name": "feature_id", "required": true, "semantic_role": "exact feature identity", "constant": "TLC-FC-00-MASTER-005"},
+            {"name": "representation", "required": true, "semantic_role": "declaration representation", "constant": "declaration"},
+            {"name": "references", "required": true, "semantic_role": "exact accepted reference bundle", "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"},
+            {"name": "unresolved", "required": true, "semantic_role": "preserved unresolved items", "allowed_values": []},
+            {"name": "dependencies", "required": true, "semantic_role": "runtime scientific dependencies", "allowed_values": []},
+            {"name": "provenance", "required": true, "semantic_role": "complete upstream traceability", "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"},
+            {"name": "status", "required": true, "semantic_role": "candidate scientific and structural-only execution status"}
+          ],
+          "collection": {"kind": "scalar", "membership": "exact", "members": [], "cardinality": {"minimum": 1, "maximum": 1}, "ordering": "not_applicable", "duplicates": "not_applicable", "key_contract": null, "value_contract": {"shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0"}},
+          "constraints": [
+            {"id": "M005-OUT-001", "statement": "The descriptor is observable as immutable."},
+            {"id": "M005-OUT-002", "statement": "The five relation references remain distinct and in source order."}
+          ]
+        }
+      ],
+      "preconditions": [
+        {"id": "M005-PRE-001", "statement": "feature_id equals TLC-FC-00-MASTER-005 exactly."},
+        {"id": "M005-PRE-002", "statement": "The object and relation reference collections equal the required collections exactly."},
+        {"id": "M005-PRE-003", "statement": "The unresolved collection is empty."}
+      ],
+      "postconditions": [
+        {"id": "M005-POST-001", "statement": "A successful result is an immutable declaration descriptor with all required fields present."},
+        {"id": "M005-POST-002", "statement": "The descriptor remains candidate, structural-only, and traceable to every cited artifact."},
+        {"id": "M005-POST-003", "statement": "No scientific component representation or value has been added."}
+      ],
+      "invariants": [
+        {"id": "M005-INV-001", "statement": "The seven-tuple components remain distinct."},
+        {"id": "M005-INV-002", "statement": "The five relation identities remain distinct and ordered."},
+        {"id": "M005-INV-003", "statement": "Scientific state and external domain state are never mutated."}
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": ["validate feature identity", "validate exact reference collections", "construct provenance", "construct declaration descriptor", "verify preservation obligations", "publish success or stable error"],
+        "partial_order": [
+          {"before": "validate feature identity", "after": "publish success or stable error"},
+          {"before": "validate exact reference collections", "after": "publish success or stable error"},
+          {"before": "verify preservation obligations", "after": "publish success or stable error"},
+          {"before": "construct declaration descriptor", "after": "publish success or stable error"}
+        ],
+        "prescription_basis": ["Only validation-before-success and preservation-before-success are observable. The upstream total step list is not adopted as a unique algorithm."]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {"code": "MASTER_INVALID_FEATURE_ID", "category": "invalid_input", "condition": "The requested feature identity is not exactly TLC-FC-00-MASTER-005.", "recoverability": "recoverable", "public_result": "no_partial_result", "failure_atomicity": "no_observable_partial_result", "transport": "implementation_defined"},
+        {"code": "MASTER_REFERENCE_SET_MISMATCH", "category": "invalid_input", "condition": "The supplied object or relation collection differs in identity, membership, cardinality, or required order.", "recoverability": "recoverable", "public_result": "no_partial_result", "failure_atomicity": "no_observable_partial_result", "transport": "implementation_defined"},
+        {"code": "MASTER_PRESERVATION_VIOLATION", "category": "preservation", "condition": "A required identity, distinction, order, opacity, or provenance obligation cannot be preserved.", "recoverability": "non_retryable", "public_result": "no_partial_result", "failure_atomicity": "no_observable_partial_result", "transport": "implementation_defined"},
+        {"code": "MASTER_UNSUPPORTED_EXECUTION_MODE", "category": "unsupported_operation", "condition": "Scientific calculation, concrete layout, or another invented execution mode is requested.", "recoverability": "non_retryable", "public_result": "no_partial_result", "failure_atomicity": "no_observable_partial_result", "transport": "implementation_defined"}
+      ],
+      "resource_contract": {
+        "time_complexity": {"status": "not_specified", "value": null},
+        "auxiliary_memory": {"status": "not_specified", "value": null},
+        "allocations": {"status": "implementation_defined", "value": null},
+        "maximum_input_size": {"status": "not_constrained", "value": null}
+      }
+    }
+  ],
+  "implementation_modes": [
+    {"mode_id": "structural-descriptor", "status": "required", "statement": "Expose the structural declaration behavior and stable errors defined by this package."},
+    {"mode_id": "scientific-evaluation", "status": "forbidden", "statement": "Do not calculate, simulate, complete, or interpret the seven-tuple."},
+    {"mode_id": "concrete-component-layout", "status": "forbidden", "statement": "Do not claim this package prescribes component runtime types, dimensions, layout, or storage."},
+    {"mode_id": "alternative-internal-architecture", "status": "allowed", "statement": "Any internal design is allowed when all observable obligations and acceptance tests remain satisfied."}
+  ],
+  "global_invariants": [
+    {"id": "M005-GINV-001", "statement": "No implementation behavior may weaken exact identity, reference, order, opacity, immutability, or provenance requirements."},
+    {"id": "M005-GINV-002", "statement": "Absence of scientific definition remains absence; it never becomes a default."}
+  ],
+  "dependencies": [
+    {"shared_contract_id": "TLC-HC-FEATURE-ID", "version": "1.0.0", "purpose": "Exact feature identity."},
+    {"shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE", "version": "1.0.0", "purpose": "Lossless source references."},
+    {"shared_contract_id": "TLC-HC-REFERENCE-COLLECTION", "version": "1.0.0", "purpose": "Exact set and ordered-set semantics."},
+    {"shared_contract_id": "TLC-HC-UNRESOLVED-ITEM", "version": "1.0.0", "purpose": "Explicit unresolved preservation vocabulary."},
+    {"shared_contract_id": "TLC-HC-OPAQUE-VALUE", "version": "1.0.0", "purpose": "Non-interpretation of component details."},
+    {"shared_contract_id": "TLC-HC-STRUCTURED-ERROR", "version": "1.0.0", "purpose": "Transport-neutral stable errors."},
+    {"shared_contract_id": "TLC-HC-TRACEABILITY", "version": "1.0.0", "purpose": "Resolvable provenance."},
+    {"shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE", "version": "1.0.0", "purpose": "Immutable descriptor result shape."}
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": ["Conformance is behavioral and does not require a particular public function name or internal algorithm."]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-005/examples.json
+++ b/handoff/features/TLC-FC-00-MASTER-005/examples.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-005",
+  "examples": [
+    {
+      "example_id": "MASTER-005-EX-001",
+      "kind": "normative_fixture",
+      "description": "Exact valid reference fixture supplied by the acceptance oracle.",
+      "input": {
+        "feature_id": "TLC-FC-00-MASTER-005",
+        "scientific_object_refs": ["TLC-SO-MASTER-008"],
+        "relation_refs": ["TLC-SR-MASTER-007", "TLC-SR-MASTER-008", "TLC-SR-MASTER-009", "TLC-SR-MASTER-010", "TLC-SR-MASTER-011"],
+        "unresolved_refs": []
+      },
+      "expected": {
+        "success": true,
+        "feature_id": "TLC-FC-00-MASTER-005",
+        "representation": "declaration",
+        "immutable": true,
+        "references_preserved": true,
+        "scientific_evaluation_performed": false
+      },
+      "source_basis": ["registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml"]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-005/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-005/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-005",
+  "title": "Master seven-tuple definition",
+  "domain": "master",
+  "statuses": {"package": "pilot", "scientific": "partially_defined", "execution": "structural_only"},
+  "files": ["README.md", "manifest.json", "contract.json", "acceptance.json", "examples.json", "traceability.json"],
+  "shared_dependencies": [
+    {"shared_contract_id": "TLC-HC-FEATURE-ID", "version": "1.0.0"},
+    {"shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE", "version": "1.0.0"},
+    {"shared_contract_id": "TLC-HC-REFERENCE-COLLECTION", "version": "1.0.0"},
+    {"shared_contract_id": "TLC-HC-UNRESOLVED-ITEM", "version": "1.0.0"},
+    {"shared_contract_id": "TLC-HC-OPAQUE-VALUE", "version": "1.0.0"},
+    {"shared_contract_id": "TLC-HC-STRUCTURED-ERROR", "version": "1.0.0"},
+    {"shared_contract_id": "TLC-HC-TRACEABILITY", "version": "1.0.0"},
+    {"shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE", "version": "1.0.0"}
+  ],
+  "examples": {"present": true, "file": "examples.json"},
+  "reference_integrity": {"repository_relative_paths_only": true, "all_declared_files_required": true, "dependency_resolution_required": true}
+}

--- a/handoff/features/TLC-FC-00-MASTER-005/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-005/traceability.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-005",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative seven-tuple declaration.",
+      "title": "3. Structure interne du Maître (7-uplet)",
+      "section": "3. Structure interne du Maître (7-uplet)",
+      "subsection": null,
+      "line_range": {"start": 41, "end": 47},
+      "artifact_id": "TLC-SO-MASTER-008",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "fe0a408035b07bad720062e98755dd32eaefc6f0"}
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-005/contract.yaml",
+      "role": "Defines the candidate declaration, exact object and relation identities, distinctness invariant, and non-invention constraint.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-005",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "11b5880dd2cdd8e6e091ec5a76f208c5ab36aa53"}
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-005/ir.yaml",
+      "role": "Active source IR registry entry preserving non-canonical candidate status.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-005",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "da8496d476208e8efa8a4925ab2261b7e2109a30"}
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-005/ir.candidate.json",
+      "role": "Structural declaration candidate with no executable operations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-005",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "98a9371c338b70d44ffd117676ad65aefc7a342f"}
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-005/ir.yaml",
+      "role": "Selects the immutable descriptor envelope, exact reference validation, stable errors, opacity, and preservation obligations.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-005",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "6169258d4f2ae242dc08c7e820aa60b6b2a3b4fd"}
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-005/algorithm.yaml",
+      "role": "Provides applicable validation branches and preservation steps; its total listed sequence is not automatically normative.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-005",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "f314ffccb865897958ffd67dc56b304384f4953e"}
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-005/test-plan.yaml",
+      "role": "Requires identity, traceability, reservation preservation, non-invention, and deterministic parsing and validation.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-005",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "dfa7625d721c4017ca71687fec778b94acda0498"}
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-005/oracle.yaml",
+      "role": "Supplies the exact valid fixture and eight authoritative structural and preservation acceptance conditions.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-005",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "274a1cb4a3dee851aa9d02824f734dc745b71f6b"}
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines ScientificReferenceBundle, MasterDescriptor, common error conditions, immutable registry behavior, and the public structural interface.",
+      "artifact_id": "TLC-MODULE-MASTER-001",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "53a79429609367b5e80abdfba302510bc98cde0b"}
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Identifies the seven-tuple definition descriptor deliverable and its shared structural prerequisites.",
+      "artifact_id": "TLC-MASTER-IMPL-005",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "2219f7f2b68c0bee9a9926693ac21ce6a01d4d2c"}
+    },
+    {
+      "path": "registry/global-finalization/shared-types.yaml",
+      "role": "Confirms the shared structural carrier boundary and identity/representation separation.",
+      "fingerprint": {"algorithm": "git_blob_sha1", "value": "aef9616c4572c87a38209f9d58e00e1cf646f8ed"}
+    }
+  ]
+}

--- a/handoff/schemas/acceptance.schema.json
+++ b/handoff/schemas/acceptance.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tradition-learning-community.github.io/tllib-specs/handoff/schemas/acceptance.schema.json",
+  "title": "Feature Handoff Acceptance v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "package_version", "applies_to", "tests"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "package_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "applies_to": {"type": "string", "pattern": "^TLC-(FC-[0-9]{2}-[A-Z][A-Z0-9-]*-[0-9]{3}|HC-[A-Z0-9-]+)$"},
+    "tests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["test_id", "applies_to", "category", "given", "when", "expect"],
+        "properties": {
+          "test_id": {"type": "string", "pattern": "^[A-Z0-9][A-Z0-9-]*$"},
+          "applies_to": {"type": "string", "minLength": 1},
+          "category": {"enum": ["valid_input", "invalid_input", "output_contract", "invariant", "preservation", "determinism", "error", "resource", "concurrency", "serialization", "unsupported_operation"]},
+          "given": {"type": ["object", "array", "string", "number", "boolean", "null"]},
+          "when": {"type": ["object", "array", "string", "number", "boolean", "null"]},
+          "expect": {"type": ["object", "array", "string", "number", "boolean", "null"]},
+          "source_basis": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    }
+  }
+}

--- a/handoff/schemas/contract.schema.json
+++ b/handoff/schemas/contract.schema.json
@@ -139,7 +139,7 @@
       "properties": {
         "mutability": {"enum": ["immutable", "mutable", "not_constrained", "implementation_defined", "not_applicable"]},
         "result_ownership": {"enum": ["owned_result", "borrowed_result", "shared_result", "not_constrained", "implementation_defined", "not_applicable"]},
-        "input_retention": {"enum": ["forbidden", "allowed", "required", "not_constrained", "implementation_defined", "not_applicable"]},
+        "input_retention": {"enum": ["forbidden", "allowed", "required", "not_required", "not_constrained", "implementation_defined", "not_applicable"]},
         "input_change_visibility": {"enum": ["visible", "not_visible", "not_constrained", "implementation_defined", "not_applicable"]},
         "lifetime": {"enum": ["operation_only", "result_lifetime", "caller_managed", "not_constrained", "implementation_defined", "not_applicable"]},
         "aliasing": {"enum": ["forbidden", "allowed", "not_constrained", "implementation_defined", "not_applicable"]},

--- a/handoff/schemas/contract.schema.json
+++ b/handoff/schemas/contract.schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tradition-learning-community.github.io/tllib-specs/handoff/schemas/contract.schema.json",
+  "title": "Feature Handoff Contract v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "package_version", "feature", "purpose", "scope", "operations", "implementation_modes", "global_invariants", "dependencies", "conformance"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "package_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "feature": {"$ref": "#/$defs/feature"},
+    "purpose": {"type": "string", "minLength": 1},
+    "scope": {"$ref": "#/$defs/scope"},
+    "operations": {"type": "array", "items": {"$ref": "#/$defs/operation"}},
+    "implementation_modes": {"type": "array", "items": {"$ref": "#/$defs/implementationMode"}},
+    "global_invariants": {"type": "array", "items": {"$ref": "#/$defs/obligation"}},
+    "dependencies": {"type": "array", "items": {"$ref": "#/$defs/dependency"}},
+    "conformance": {"$ref": "#/$defs/conformance"}
+  },
+  "$defs": {
+    "feature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["feature_id", "title", "domain"],
+      "properties": {
+        "feature_id": {"type": "string", "pattern": "^TLC-FC-[0-9]{2}-[A-Z][A-Z0-9-]*-[0-9]{3}$"},
+        "title": {"type": "string", "minLength": 1},
+        "domain": {"type": "string", "minLength": 1}
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "forbidden", "deferred"],
+      "properties": {
+        "required": {"type": "array", "items": {"$ref": "#/$defs/obligation"}},
+        "forbidden": {"type": "array", "items": {"$ref": "#/$defs/obligation"}},
+        "deferred": {"type": "array", "items": {"$ref": "#/$defs/obligation"}}
+      }
+    },
+    "obligation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "statement"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "statement": {"type": "string", "minLength": 1},
+        "basis": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation_id", "purpose", "inputs", "outputs", "preconditions", "postconditions", "invariants", "strategy_contract", "runtime_contract", "determinism", "error_contract", "resource_contract"],
+      "properties": {
+        "operation_id": {"type": "string", "pattern": "^[A-Z0-9][A-Z0-9-]*$"},
+        "purpose": {"type": "string", "minLength": 1},
+        "inputs": {"type": "array", "items": {"$ref": "#/$defs/valueContract"}},
+        "outputs": {"type": "array", "items": {"$ref": "#/$defs/valueContract"}},
+        "preconditions": {"type": "array", "items": {"$ref": "#/$defs/obligation"}},
+        "postconditions": {"type": "array", "items": {"$ref": "#/$defs/obligation"}},
+        "invariants": {"type": "array", "items": {"$ref": "#/$defs/obligation"}},
+        "strategy_contract": {"$ref": "#/$defs/strategyContract"},
+        "runtime_contract": {"$ref": "#/$defs/runtimeContract"},
+        "determinism": {"$ref": "#/$defs/determinism"},
+        "error_contract": {"type": "array", "items": {"$ref": "#/$defs/errorContract"}},
+        "resource_contract": {"$ref": "#/$defs/resourceContract"}
+      }
+    },
+    "valueContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "semantic_role", "collection"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "semantic_role": {"type": "string", "minLength": 1},
+        "shared_contract_ref": {"type": "string", "pattern": "^TLC-HC-[A-Z0-9-]+@[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "fields": {"type": "array", "items": {"$ref": "#/$defs/fieldContract"}},
+        "collection": {"$ref": "#/$defs/collectionContract"},
+        "constraints": {"type": "array", "items": {"$ref": "#/$defs/obligation"}}
+      }
+    },
+    "fieldContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "required", "semantic_role"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "required": {"type": "boolean"},
+        "semantic_role": {"type": "string", "minLength": 1},
+        "shared_contract_ref": {"type": "string", "pattern": "^TLC-HC-[A-Z0-9-]+@[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "constant": {},
+        "allowed_values": {"type": "array"}
+      }
+    },
+    "collectionContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "membership", "cardinality", "ordering", "duplicates", "key_contract", "value_contract"],
+      "properties": {
+        "kind": {"enum": ["scalar", "optional", "sequence", "set", "ordered_set", "multiset", "map", "ordered_map"]},
+        "membership": {"enum": ["exact", "constrained", "open", "not_applicable"]},
+        "members": {"type": "array"},
+        "cardinality": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["minimum", "maximum"],
+          "properties": {"minimum": {"type": ["integer", "null"], "minimum": 0}, "maximum": {"type": ["integer", "null"], "minimum": 0}}
+        },
+        "ordering": {"enum": ["required", "preserved", "implementation_defined", "not_constrained", "not_applicable"]},
+        "duplicates": {"enum": ["forbidden", "allowed", "significant", "implementation_defined", "not_applicable"]},
+        "key_contract": {"type": ["object", "null"]},
+        "value_contract": {"type": ["object", "null"]}
+      }
+    },
+    "strategyContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "steps", "partial_order", "prescription_basis"],
+      "properties": {
+        "mode": {"enum": ["open", "partially_constrained", "prescribed"]},
+        "steps": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "partial_order": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["before", "after"],
+            "properties": {"before": {"type": "string", "minLength": 1}, "after": {"type": "string", "minLength": 1}}
+          }
+        },
+        "prescription_basis": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "runtimeContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mutability", "result_ownership", "input_retention", "input_change_visibility", "lifetime", "aliasing", "layout", "contiguity", "alignment", "address_stability", "copy_semantics", "move_semantics", "allocation", "zero_copy", "thread_safety", "reentrancy", "failure_atomicity"],
+      "properties": {
+        "mutability": {"enum": ["immutable", "mutable", "not_constrained", "implementation_defined", "not_applicable"]},
+        "result_ownership": {"enum": ["owned_result", "borrowed_result", "shared_result", "not_constrained", "implementation_defined", "not_applicable"]},
+        "input_retention": {"enum": ["forbidden", "allowed", "required", "not_constrained", "implementation_defined", "not_applicable"]},
+        "input_change_visibility": {"enum": ["visible", "not_visible", "not_constrained", "implementation_defined", "not_applicable"]},
+        "lifetime": {"enum": ["operation_only", "result_lifetime", "caller_managed", "not_constrained", "implementation_defined", "not_applicable"]},
+        "aliasing": {"enum": ["forbidden", "allowed", "not_constrained", "implementation_defined", "not_applicable"]},
+        "layout": {"enum": ["prescribed", "not_constrained", "implementation_defined", "not_applicable"]},
+        "contiguity": {"enum": ["required", "not_required", "not_constrained", "implementation_defined", "not_applicable"]},
+        "alignment": {"enum": ["required", "not_required", "not_constrained", "implementation_defined", "not_applicable"]},
+        "address_stability": {"enum": ["required", "not_required", "not_constrained", "implementation_defined", "not_applicable"]},
+        "copy_semantics": {"enum": ["required", "allowed", "forbidden", "not_constrained", "implementation_defined", "not_applicable"]},
+        "move_semantics": {"enum": ["required", "allowed", "forbidden", "not_constrained", "implementation_defined", "not_applicable"]},
+        "allocation": {"enum": ["forbidden", "allowed", "required", "not_constrained", "implementation_defined", "not_applicable"]},
+        "zero_copy": {"enum": ["required", "not_required", "not_constrained", "implementation_defined", "not_applicable"]},
+        "thread_safety": {"enum": ["required", "not_required", "not_constrained", "implementation_defined", "not_applicable"]},
+        "reentrancy": {"enum": ["required", "not_required", "not_constrained", "implementation_defined", "not_applicable"]},
+        "failure_atomicity": {"enum": ["no_observable_partial_result", "basic", "not_constrained", "implementation_defined", "not_applicable"]}
+      }
+    },
+    "determinism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["semantic_output", "field_presence", "collection_order", "canonical_serialization", "binary_layout", "memory_address", "allocation_pattern", "concurrent_scheduling", "floating_point", "randomness"],
+      "properties": {
+        "semantic_output": {"$ref": "#/$defs/determinismValue"},
+        "field_presence": {"$ref": "#/$defs/determinismValue"},
+        "collection_order": {"$ref": "#/$defs/determinismValue"},
+        "canonical_serialization": {"$ref": "#/$defs/determinismValue"},
+        "binary_layout": {"$ref": "#/$defs/determinismValue"},
+        "memory_address": {"$ref": "#/$defs/determinismValue"},
+        "allocation_pattern": {"$ref": "#/$defs/determinismValue"},
+        "concurrent_scheduling": {"$ref": "#/$defs/determinismValue"},
+        "floating_point": {"$ref": "#/$defs/determinismValue"},
+        "randomness": {"$ref": "#/$defs/determinismValue"}
+      }
+    },
+    "determinismValue": {"enum": ["required", "forbidden", "not_required", "not_constrained", "not_specified", "implementation_defined", "not_applicable"]},
+    "errorContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "category", "condition", "recoverability", "public_result", "failure_atomicity", "transport"],
+      "properties": {
+        "code": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]+$"},
+        "category": {"type": "string", "minLength": 1},
+        "condition": {"type": "string", "minLength": 1},
+        "recoverability": {"enum": ["recoverable", "retryable", "non_retryable", "implementation_defined", "not_applicable"]},
+        "public_result": {"enum": ["error_only", "no_partial_result", "partial_result_allowed", "implementation_defined"]},
+        "failure_atomicity": {"enum": ["no_observable_partial_result", "basic", "not_constrained", "implementation_defined", "not_applicable"]},
+        "transport": {"const": "implementation_defined"}
+      }
+    },
+    "resourceContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["time_complexity", "auxiliary_memory", "allocations", "maximum_input_size"],
+      "properties": {
+        "time_complexity": {"$ref": "#/$defs/resourceConstraint"},
+        "auxiliary_memory": {"$ref": "#/$defs/resourceConstraint"},
+        "allocations": {"$ref": "#/$defs/resourceConstraint"},
+        "maximum_input_size": {"$ref": "#/$defs/resourceConstraint"}
+      }
+    },
+    "resourceConstraint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "value"],
+      "properties": {
+        "status": {"enum": ["required", "informative", "not_constrained", "not_specified", "implementation_defined"]},
+        "value": {"type": ["string", "number", "integer", "null"]}
+      }
+    },
+    "implementationMode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode_id", "status", "statement"],
+      "properties": {
+        "mode_id": {"type": "string", "minLength": 1},
+        "status": {"enum": ["required", "preferred", "allowed", "experimental", "forbidden"]},
+        "statement": {"type": "string", "minLength": 1}
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["shared_contract_id", "version", "purpose"],
+      "properties": {
+        "shared_contract_id": {"type": "string", "pattern": "^TLC-HC-[A-Z0-9-]+$"},
+        "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "purpose": {"type": "string", "minLength": 1}
+      }
+    },
+    "conformance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["acceptance_required", "all_required_tests_must_pass", "forbidden_behavior_is_nonconforming"],
+      "properties": {
+        "acceptance_required": {"const": true},
+        "all_required_tests_must_pass": {"const": true},
+        "forbidden_behavior_is_nonconforming": {"const": true},
+        "notes": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    }
+  }
+}

--- a/handoff/schemas/examples.schema.json
+++ b/handoff/schemas/examples.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tradition-learning-community.github.io/tllib-specs/handoff/schemas/examples.schema.json",
+  "title": "Feature Handoff Examples v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "package_version", "applies_to", "examples"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "package_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "applies_to": {"type": "string", "pattern": "^TLC-(FC-[0-9]{2}-[A-Z][A-Z0-9-]*-[0-9]{3}|HC-[A-Z0-9-]+)$"},
+    "examples": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["example_id", "kind", "description", "input", "expected"],
+        "properties": {
+          "example_id": {"type": "string", "pattern": "^[A-Z0-9][A-Z0-9-]*$"},
+          "kind": {"enum": ["normative_fixture", "illustrative"]},
+          "description": {"type": "string", "minLength": 1},
+          "input": {},
+          "expected": {},
+          "source_basis": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    }
+  }
+}

--- a/handoff/schemas/manifest.schema.json
+++ b/handoff/schemas/manifest.schema.json
@@ -67,9 +67,33 @@
   ],
   "allOf": [
     {
-      "if": {"properties": {"examples": {"properties": {"present": {"const": true}}}}},
-      "then": {"properties": {"examples": {"properties": {"file": {"const": "examples.json"}}}},
-      "else": {"properties": {"examples": {"properties": {"file": {"type": "null"}}}}
+      "if": {
+        "properties": {
+          "examples": {
+            "properties": {
+              "present": {"const": true}
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "examples": {
+            "properties": {
+              "file": {"const": "examples.json"}
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "examples": {
+            "properties": {
+              "file": {"type": "null"}
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/handoff/schemas/manifest.schema.json
+++ b/handoff/schemas/manifest.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tradition-learning-community.github.io/tllib-specs/handoff/schemas/manifest.schema.json",
+  "title": "Feature Handoff Manifest v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "package_version", "title", "statuses", "files", "shared_dependencies", "examples", "reference_integrity"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "package_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "feature_id": {"type": "string", "pattern": "^TLC-FC-[0-9]{2}-[A-Z][A-Z0-9-]*-[0-9]{3}$"},
+    "shared_contract_id": {"type": "string", "pattern": "^TLC-HC-[A-Z0-9-]+$"},
+    "title": {"type": "string", "minLength": 1},
+    "domain": {"type": "string", "minLength": 1},
+    "statuses": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["package", "scientific", "execution"],
+      "properties": {
+        "package": {"enum": ["draft", "pilot", "validated", "finalized", "deprecated", "superseded"]},
+        "scientific": {"enum": ["defined", "partially_defined", "preserved_unresolved", "external_provider_required", "not_applicable"]},
+        "execution": {"enum": ["structural_only", "executable", "conditionally_executable", "unsupported"]}
+      }
+    },
+    "files": {
+      "type": "array",
+      "minItems": 4,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^(README\\.md|manifest\\.json|contract\\.json|acceptance\\.json|examples\\.json|traceability\\.json)$"}
+    },
+    "shared_dependencies": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["shared_contract_id", "version"],
+        "properties": {
+          "shared_contract_id": {"type": "string", "pattern": "^TLC-HC-[A-Z0-9-]+$"},
+          "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"}
+        }
+      }
+    },
+    "examples": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["present", "file"],
+      "properties": {
+        "present": {"type": "boolean"},
+        "file": {"type": ["string", "null"], "enum": ["examples.json", null]}
+      }
+    },
+    "reference_integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository_relative_paths_only", "all_declared_files_required", "dependency_resolution_required"],
+      "properties": {
+        "repository_relative_paths_only": {"const": true},
+        "all_declared_files_required": {"const": true},
+        "dependency_resolution_required": {"const": true}
+      }
+    }
+  },
+  "oneOf": [
+    {"required": ["feature_id", "domain"], "not": {"required": ["shared_contract_id"]}},
+    {"required": ["shared_contract_id"], "not": {"anyOf": [{"required": ["feature_id"]}, {"required": ["domain"]}]}}
+  ],
+  "allOf": [
+    {
+      "if": {"properties": {"examples": {"properties": {"present": {"const": true}}}}},
+      "then": {"properties": {"examples": {"properties": {"file": {"const": "examples.json"}}}},
+      "else": {"properties": {"examples": {"properties": {"file": {"type": "null"}}}}
+    }
+  ]
+}

--- a/handoff/schemas/shared-contract.schema.json
+++ b/handoff/schemas/shared-contract.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tradition-learning-community.github.io/tllib-specs/handoff/schemas/shared-contract.schema.json",
+  "title": "Shared Handoff Contract v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "package_version", "shared_contract", "purpose", "scope", "data_contract", "global_invariants", "conformance"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "package_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "shared_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["shared_contract_id", "title"],
+      "properties": {
+        "shared_contract_id": {"type": "string", "pattern": "^TLC-HC-[A-Z0-9-]+$"},
+        "title": {"type": "string", "minLength": 1}
+      }
+    },
+    "purpose": {"type": "string", "minLength": 1},
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "forbidden", "deferred"],
+      "properties": {
+        "required": {"type": "array", "items": {"$ref": "#/$defs/obligation"}},
+        "forbidden": {"type": "array", "items": {"$ref": "#/$defs/obligation"}},
+        "deferred": {"type": "array", "items": {"$ref": "#/$defs/obligation"}}
+      }
+    },
+    "data_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["shape", "fields", "collection", "runtime"],
+      "properties": {
+        "shape": {"enum": ["opaque_scalar", "record", "collection", "envelope"]},
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "required", "semantic_role"],
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "required": {"type": "boolean"},
+              "semantic_role": {"type": "string", "minLength": 1},
+              "value_kind": {"enum": ["string", "boolean", "integer", "number", "object", "array", "opaque", "repository_path", "identifier", "enum"]},
+              "allowed_values": {"type": "array"},
+              "shared_contract_ref": {"type": "string", "pattern": "^TLC-HC-[A-Z0-9-]+@[0-9]+\\.[0-9]+\\.[0-9]+$"}
+            }
+          }
+        },
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["supported_kinds", "membership", "cardinality", "ordering", "duplicates", "key_contract", "value_contract"],
+          "properties": {
+            "supported_kinds": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {"enum": ["scalar", "optional", "sequence", "set", "ordered_set", "multiset", "map", "ordered_map"]}
+            },
+            "membership": {"enum": ["exact", "constrained", "open", "not_applicable"]},
+            "cardinality": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["minimum", "maximum"],
+              "properties": {"minimum": {"type": ["integer", "null"], "minimum": 0}, "maximum": {"type": ["integer", "null"], "minimum": 0}}
+            },
+            "ordering": {"enum": ["required", "preserved", "implementation_defined", "not_constrained", "not_applicable"]},
+            "duplicates": {"enum": ["forbidden", "allowed", "significant", "implementation_defined", "not_applicable"]},
+            "key_contract": {"type": ["object", "null"]},
+            "value_contract": {"type": ["object", "null"]}
+          }
+        },
+        "runtime": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mutability", "layout", "ownership", "lifetime", "allocation", "thread_safety"],
+          "properties": {
+            "mutability": {"enum": ["immutable", "mutable", "not_constrained", "implementation_defined", "not_applicable"]},
+            "layout": {"enum": ["not_constrained", "implementation_defined", "not_applicable"]},
+            "ownership": {"enum": ["owned", "borrowed", "shared", "not_constrained", "implementation_defined", "not_applicable"]},
+            "lifetime": {"enum": ["operation_only", "result_lifetime", "caller_managed", "not_constrained", "implementation_defined", "not_applicable"]},
+            "allocation": {"enum": ["forbidden", "allowed", "required", "not_constrained", "implementation_defined", "not_applicable"]},
+            "thread_safety": {"enum": ["required", "not_required", "not_constrained", "implementation_defined", "not_applicable"]}
+          }
+        }
+      }
+    },
+    "global_invariants": {"type": "array", "items": {"$ref": "#/$defs/obligation"}},
+    "conformance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["acceptance_required", "lossless_preservation_required"],
+      "properties": {
+        "acceptance_required": {"const": true},
+        "lossless_preservation_required": {"type": "boolean"},
+        "notes": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    }
+  },
+  "$defs": {
+    "obligation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "statement"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "statement": {"type": "string", "minLength": 1},
+        "basis": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    }
+  }
+}

--- a/handoff/schemas/traceability.schema.json
+++ b/handoff/schemas/traceability.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tradition-learning-community.github.io/tllib-specs/handoff/schemas/traceability.schema.json",
+  "title": "Feature Handoff Traceability v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "package_version", "applies_to", "scientific_sources", "mathematical_contracts", "source_irs", "finalized_irs", "algorithm_specifications", "test_plans", "acceptance_oracles", "scientific_decisions"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "package_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "applies_to": {"type": "string", "pattern": "^TLC-(FC-[0-9]{2}-[A-Z][A-Z0-9-]*-[0-9]{3}|HC-[A-Z0-9-]+)$"},
+    "scientific_sources": {"$ref": "#/$defs/references"},
+    "mathematical_contracts": {"$ref": "#/$defs/references"},
+    "source_irs": {"$ref": "#/$defs/references"},
+    "finalized_irs": {"$ref": "#/$defs/references"},
+    "algorithm_specifications": {"$ref": "#/$defs/references"},
+    "test_plans": {"$ref": "#/$defs/references"},
+    "acceptance_oracles": {"$ref": "#/$defs/references"},
+    "scientific_decisions": {"$ref": "#/$defs/references"}
+  },
+  "$defs": {
+    "references": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "role"],
+        "properties": {
+          "path": {"type": "string", "minLength": 1},
+          "role": {"type": "string", "minLength": 1},
+          "title": {"type": "string", "minLength": 1},
+          "section": {"type": ["string", "null"]},
+          "subsection": {"type": ["string", "null"]},
+          "line_range": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "required": ["start", "end"],
+            "properties": {"start": {"type": "integer", "minimum": 1}, "end": {"type": "integer", "minimum": 1}}
+          },
+          "artifact_id": {"type": ["string", "null"]},
+          "fingerprint": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "required": ["algorithm", "value"],
+            "properties": {"algorithm": {"enum": ["git_blob_sha1", "sha256"]}, "value": {"type": "string", "minLength": 1}}
+          },
+          "notes": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE/README.md
+++ b/handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE/README.md
@@ -1,0 +1,5 @@
+# TLC-HC-DESCRIPTOR-ENVELOPE
+
+Defines the common structural envelope used by declaration and descriptor features. It preserves feature identity, representation label, references, unresolved items, dependencies, provenance, and status while leaving domain-specific fields and runtime storage unconstrained.
+
+The envelope is immutable as an observable result. It does not prescribe a programming-language type, memory layout, allocation policy, or serialization format.

--- a/handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE/acceptance.json
+++ b/handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE/acceptance.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-DESCRIPTOR-ENVELOPE",
+  "tests": [
+    {"test_id": "HC-ENV-001", "applies_to": "required fields", "category": "output_contract", "given": {"feature_id": "TLC-FC-00-MASTER-005", "representation": "declaration", "references": {}, "unresolved": [], "dependencies": [], "provenance": {}, "status": {}}, "when": "The envelope is validated.", "expect": {"accepted": true}},
+    {"test_id": "HC-ENV-002", "applies_to": "immutability", "category": "invariant", "given": {"emitted": true}, "when": "A caller attempts to alter an observable field through the public result contract.", "expect": {"observable_mutation_supported": false}},
+    {"test_id": "HC-ENV-003", "applies_to": "representation neutrality", "category": "preservation", "given": {"two_distinct_scientific_references": true}, "when": "Both use the same internal carrier.", "expect": {"semantic_identity_merged": false}}
+  ]
+}

--- a/handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE/contract.json
+++ b/handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE/contract.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract": {"shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE", "title": "Descriptor Envelope"},
+  "purpose": "Provide a common immutable descriptor carrier without constraining domain-specific semantics or runtime representation.",
+  "scope": {
+    "required": [
+      {"id": "ENV-REQ-001", "statement": "The envelope preserves feature_id, representation, references, unresolved, dependencies, provenance, and status."},
+      {"id": "ENV-REQ-002", "statement": "The emitted envelope is immutable as an observable result."}
+    ],
+    "forbidden": [
+      {"id": "ENV-FOR-001", "statement": "The envelope must not interpret scientific references or opaque values."},
+      {"id": "ENV-FOR-002", "statement": "The envelope must not imply a unique programming-language type, memory layout, or serialization format."}
+    ],
+    "deferred": [{"id": "ENV-DEF-001", "statement": "Domain-specific fields and all internal storage strategies are defined by consuming feature packages or implementations."}]
+  },
+  "data_contract": {
+    "shape": "envelope",
+    "fields": [
+      {"name": "feature_id", "required": true, "semantic_role": "feature identity", "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0"},
+      {"name": "representation", "required": true, "semantic_role": "structural representation label", "value_kind": "string"},
+      {"name": "references", "required": true, "semantic_role": "scientific reference collections", "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"},
+      {"name": "unresolved", "required": true, "semantic_role": "preserved unresolved items", "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0"},
+      {"name": "dependencies", "required": true, "semantic_role": "declared package dependencies", "value_kind": "array"},
+      {"name": "provenance", "required": true, "semantic_role": "resolvable provenance", "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"},
+      {"name": "status", "required": true, "semantic_role": "descriptor scientific and execution state", "value_kind": "object"}
+    ],
+    "collection": {"supported_kinds": ["scalar"], "membership": "exact", "cardinality": {"minimum": 1, "maximum": 1}, "ordering": "not_applicable", "duplicates": "not_applicable", "key_contract": null, "value_contract": null},
+    "runtime": {"mutability": "immutable", "layout": "not_constrained", "ownership": "implementation_defined", "lifetime": "implementation_defined", "allocation": "implementation_defined", "thread_safety": "implementation_defined"}
+  },
+  "global_invariants": [
+    {"id": "ENV-INV-001", "statement": "No envelope transformation changes semantic identity or provenance."},
+    {"id": "ENV-INV-002", "statement": "Distinct scientific references remain distinct unless an authoritative alias is declared."}
+  ],
+  "conformance": {"acceptance_required": true, "lossless_preservation_required": true, "notes": []}
+}

--- a/handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE/manifest.json
+++ b/handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE/manifest.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+  "title": "Descriptor Envelope",
+  "statuses": {"package": "validated", "scientific": "not_applicable", "execution": "structural_only"},
+  "files": ["README.md", "manifest.json", "contract.json", "acceptance.json", "traceability.json"],
+  "shared_dependencies": [
+    {"shared_contract_id": "TLC-HC-FEATURE-ID", "version": "1.0.0"},
+    {"shared_contract_id": "TLC-HC-REFERENCE-COLLECTION", "version": "1.0.0"},
+    {"shared_contract_id": "TLC-HC-UNRESOLVED-ITEM", "version": "1.0.0"},
+    {"shared_contract_id": "TLC-HC-TRACEABILITY", "version": "1.0.0"}
+  ],
+  "examples": {"present": false, "file": null},
+  "reference_integrity": {"repository_relative_paths_only": true, "all_declared_files_required": true, "dependency_resolution_required": true}
+}

--- a/handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE/traceability.json
+++ b/handoff/shared/TLC-HC-DESCRIPTOR-ENVELOPE/traceability.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-DESCRIPTOR-ENVELOPE",
+  "scientific_sources": [],
+  "mathematical_contracts": [],
+  "source_irs": [],
+  "finalized_irs": [],
+  "algorithm_specifications": [],
+  "test_plans": [],
+  "acceptance_oracles": [],
+  "scientific_decisions": [
+    {"path": "registry/global-finalization/shared-types.yaml", "role": "Confirms identity, reference, unresolved, traceability, opaque-value, and structured-error carriers without creating scientific types.", "fingerprint": {"algorithm": "git_blob_sha1", "value": "aef9616c4572c87a38209f9d58e00e1cf646f8ed"}},
+    {"path": "registry/domain-finalization/master/module-specification.yaml", "role": "Defines MasterDescriptor fields and immutable reference bundle behavior.", "artifact_id": "MasterDescriptor", "fingerprint": {"algorithm": "git_blob_sha1", "value": "53a79429609367b5e80abdfba302510bc98cde0b"}}
+  ]
+}

--- a/handoff/shared/TLC-HC-FEATURE-ID/README.md
+++ b/handoff/shared/TLC-HC-FEATURE-ID/README.md
@@ -1,0 +1,7 @@
+# TLC-HC-FEATURE-ID
+
+Defines the stable, opaque identifier carried by a handoff feature package.
+
+The identifier is compared exactly. Implementations must not trim, case-fold, translate, decompose into scientific meaning, or treat a shared representation as evidence of aliasing. Storage, interning, binary layout, and allocation are implementation choices.
+
+Normative behavior is defined by `contract.json` and `acceptance.json`.

--- a/handoff/shared/TLC-HC-FEATURE-ID/acceptance.json
+++ b/handoff/shared/TLC-HC-FEATURE-ID/acceptance.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-FEATURE-ID",
+  "tests": [
+    {"test_id": "HC-FID-001", "applies_to": "identifier validation", "category": "valid_input", "given": {"value": "TLC-FC-00-MASTER-005"}, "when": "The identifier is validated.", "expect": {"accepted": true, "preserved_value": "TLC-FC-00-MASTER-005"}},
+    {"test_id": "HC-FID-002", "applies_to": "exact identity", "category": "invalid_input", "given": {"value": "tlc-fc-00-master-005"}, "when": "The identifier is validated.", "expect": {"accepted": false}},
+    {"test_id": "HC-FID-003", "applies_to": "round trip", "category": "preservation", "given": {"value": "TLC-FC-00-MASTER-005"}, "when": "The identifier crosses a conforming transport boundary and returns.", "expect": {"exactly_equal": true}}
+  ]
+}

--- a/handoff/shared/TLC-HC-FEATURE-ID/contract.json
+++ b/handoff/shared/TLC-HC-FEATURE-ID/contract.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract": {"shared_contract_id": "TLC-HC-FEATURE-ID", "title": "Feature Identifier"},
+  "purpose": "Preserve an exact stable feature identity without assigning scientific semantics to its representation.",
+  "scope": {
+    "required": [
+      {"id": "FID-REQ-001", "statement": "The identifier is preserved and compared exactly."},
+      {"id": "FID-REQ-002", "statement": "A valid feature identifier matches the closed TLC feature identifier syntax."}
+    ],
+    "forbidden": [
+      {"id": "FID-FOR-001", "statement": "Case folding, whitespace normalization, translation, or inferred aliasing is forbidden."},
+      {"id": "FID-FOR-002", "statement": "A shared carrier representation must not be treated as scientific equivalence."}
+    ],
+    "deferred": [
+      {"id": "FID-DEF-001", "statement": "Storage, interning, binary layout, and allocation strategy are implementation-defined."}
+    ]
+  },
+  "data_contract": {
+    "shape": "opaque_scalar",
+    "fields": [
+      {"name": "value", "required": true, "semantic_role": "exact stable identifier", "value_kind": "identifier"}
+    ],
+    "collection": {"supported_kinds": ["scalar"], "membership": "exact", "cardinality": {"minimum": 1, "maximum": 1}, "ordering": "not_applicable", "duplicates": "not_applicable", "key_contract": null, "value_contract": null},
+    "runtime": {"mutability": "immutable", "layout": "not_constrained", "ownership": "implementation_defined", "lifetime": "implementation_defined", "allocation": "implementation_defined", "thread_safety": "implementation_defined"}
+  },
+  "global_invariants": [
+    {"id": "FID-INV-001", "statement": "Round-trip transport preserves every identifier character exactly."}
+  ],
+  "conformance": {"acceptance_required": true, "lossless_preservation_required": true, "notes": ["The syntax rule does not assign meaning to identifier segments."]}
+}

--- a/handoff/shared/TLC-HC-FEATURE-ID/manifest.json
+++ b/handoff/shared/TLC-HC-FEATURE-ID/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract_id": "TLC-HC-FEATURE-ID",
+  "title": "Feature Identifier",
+  "statuses": {"package": "validated", "scientific": "not_applicable", "execution": "structural_only"},
+  "files": ["README.md", "manifest.json", "contract.json", "acceptance.json", "traceability.json"],
+  "shared_dependencies": [],
+  "examples": {"present": false, "file": null},
+  "reference_integrity": {"repository_relative_paths_only": true, "all_declared_files_required": true, "dependency_resolution_required": true}
+}

--- a/handoff/shared/TLC-HC-FEATURE-ID/traceability.json
+++ b/handoff/shared/TLC-HC-FEATURE-ID/traceability.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-FEATURE-ID",
+  "scientific_sources": [],
+  "mathematical_contracts": [],
+  "source_irs": [],
+  "finalized_irs": [],
+  "algorithm_specifications": [],
+  "test_plans": [],
+  "acceptance_oracles": [],
+  "scientific_decisions": [
+    {"path": "registry/global-finalization/shared-types.yaml", "role": "Confirms the opaque stable feature identifier and exact preservation obligation.", "artifact_id": "TLC-SHARED-TYPE-FEATURE-ID", "fingerprint": {"algorithm": "git_blob_sha1", "value": "aef9616c4572c87a38209f9d58e00e1cf646f8ed"}}
+  ]
+}

--- a/handoff/shared/TLC-HC-OPAQUE-VALUE/README.md
+++ b/handoff/shared/TLC-HC-OPAQUE-VALUE/README.md
@@ -1,0 +1,5 @@
+# TLC-HC-OPAQUE-VALUE
+
+Defines a carrier for scientific payloads whose internal semantics are unavailable to or intentionally outside the consuming package. The payload and semantic type identity are transported losslessly and are never coerced, evaluated, normalized, or reinterpreted by the wrapper.
+
+Normative behavior is defined by `contract.json` and `acceptance.json`.

--- a/handoff/shared/TLC-HC-OPAQUE-VALUE/acceptance.json
+++ b/handoff/shared/TLC-HC-OPAQUE-VALUE/acceptance.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-OPAQUE-VALUE",
+  "tests": [
+    {"test_id": "HC-OPA-001", "applies_to": "lossless transport", "category": "preservation", "given": {"semantic_type_id": "TLC-SO-MASTER-008", "payload": {"opaque": true}}, "when": "The value is round-tripped.", "expect": {"payload_exactly_equal": true, "semantic_type_id_exactly_equal": true}},
+    {"test_id": "HC-OPA-002", "applies_to": "non-interpretation", "category": "invariant", "given": {"payload": {"unknown_field": "preserve"}}, "when": "The wrapper processes the carrier.", "expect": {"unknown_field_preserved": true, "scientific_evaluation_performed": false}},
+    {"test_id": "HC-OPA-003", "applies_to": "semantic identity", "category": "invalid_input", "given": {"payload": {}, "source_reference": {"source_path": "maths/00-master.md"}}, "when": "The value lacks semantic_type_id.", "expect": {"accepted": false}}
+  ]
+}

--- a/handoff/shared/TLC-HC-OPAQUE-VALUE/contract.json
+++ b/handoff/shared/TLC-HC-OPAQUE-VALUE/contract.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract": {"shared_contract_id": "TLC-HC-OPAQUE-VALUE", "title": "Opaque Value"},
+  "purpose": "Transport an uninterpreted scientific payload with exact semantic identity and provenance.",
+  "scope": {
+    "required": [
+      {"id": "OPA-REQ-001", "statement": "The semantic type identifier, payload, and source reference are preserved losslessly."},
+      {"id": "OPA-REQ-002", "statement": "Consumers treat payload bytes or structured content as uninterpreted."}
+    ],
+    "forbidden": [
+      {"id": "OPA-FOR-001", "statement": "Coercion, evaluation, normalization, unit conversion, alias inference, and value synthesis are forbidden."},
+      {"id": "OPA-FOR-002", "statement": "A shared storage representation must not erase semantic type identity."}
+    ],
+    "deferred": [{"id": "OPA-DEF-001", "statement": "Payload encoding, storage, ownership, and provider implementation are implementation-defined unless a consuming package constrains them."}]
+  },
+  "data_contract": {
+    "shape": "record",
+    "fields": [
+      {"name": "semantic_type_id", "required": true, "semantic_role": "preserved semantic identity", "value_kind": "identifier"},
+      {"name": "payload", "required": true, "semantic_role": "uninterpreted value carrier", "value_kind": "opaque"},
+      {"name": "source_reference", "required": true, "semantic_role": "payload provenance", "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"},
+      {"name": "encoding", "required": false, "semantic_role": "transport encoding label", "value_kind": "string"}
+    ],
+    "collection": {"supported_kinds": ["scalar", "optional", "sequence", "set", "ordered_set", "multiset", "map", "ordered_map"], "membership": "open", "cardinality": {"minimum": 0, "maximum": null}, "ordering": "not_constrained", "duplicates": "implementation_defined", "key_contract": {}, "value_contract": {"shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"}},
+    "runtime": {"mutability": "not_constrained", "layout": "not_constrained", "ownership": "implementation_defined", "lifetime": "implementation_defined", "allocation": "implementation_defined", "thread_safety": "implementation_defined"}
+  },
+  "global_invariants": [{"id": "OPA-INV-001", "statement": "A round trip preserves payload, semantic type identity, and provenance exactly."}],
+  "conformance": {"acceptance_required": true, "lossless_preservation_required": true, "notes": []}
+}

--- a/handoff/shared/TLC-HC-OPAQUE-VALUE/manifest.json
+++ b/handoff/shared/TLC-HC-OPAQUE-VALUE/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+  "title": "Opaque Value",
+  "statuses": {"package": "validated", "scientific": "external_provider_required", "execution": "structural_only"},
+  "files": ["README.md", "manifest.json", "contract.json", "acceptance.json", "traceability.json"],
+  "shared_dependencies": [{"shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE", "version": "1.0.0"}],
+  "examples": {"present": false, "file": null},
+  "reference_integrity": {"repository_relative_paths_only": true, "all_declared_files_required": true, "dependency_resolution_required": true}
+}

--- a/handoff/shared/TLC-HC-OPAQUE-VALUE/traceability.json
+++ b/handoff/shared/TLC-HC-OPAQUE-VALUE/traceability.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-OPAQUE-VALUE",
+  "scientific_sources": [],
+  "mathematical_contracts": [],
+  "source_irs": [],
+  "finalized_irs": [],
+  "algorithm_specifications": [],
+  "test_plans": [],
+  "acceptance_oracles": [],
+  "scientific_decisions": [
+    {"path": "registry/global-finalization/shared-types.yaml", "role": "Confirms opaque scientific value transport, semantic identity preservation, no coercion, no evaluation, and lossless round trip.", "artifact_id": "TLC-SHARED-TYPE-OPAQUE-SCIENTIFIC-VALUE", "fingerprint": {"algorithm": "git_blob_sha1", "value": "aef9616c4572c87a38209f9d58e00e1cf646f8ed"}}
+  ]
+}

--- a/handoff/shared/TLC-HC-REFERENCE-COLLECTION/README.md
+++ b/handoff/shared/TLC-HC-REFERENCE-COLLECTION/README.md
@@ -1,0 +1,5 @@
+# TLC-HC-REFERENCE-COLLECTION
+
+Defines collection semantics for scientific references. The supported kinds are exactly `scalar`, `optional`, `sequence`, `set`, `ordered_set`, `multiset`, `map`, and `ordered_map`.
+
+A package must state membership, cardinality, ordering, duplicate, key, and value obligations explicitly. Unspecified implementation containers remain free choices.

--- a/handoff/shared/TLC-HC-REFERENCE-COLLECTION/acceptance.json
+++ b/handoff/shared/TLC-HC-REFERENCE-COLLECTION/acceptance.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-REFERENCE-COLLECTION",
+  "tests": [
+    {"test_id": "HC-RCOL-001", "applies_to": "closed collection kinds", "category": "valid_input", "given": {"kind": "ordered_set"}, "when": "The kind is validated.", "expect": {"accepted": true}},
+    {"test_id": "HC-RCOL-002", "applies_to": "closed collection kinds", "category": "invalid_input", "given": {"kind": "vector"}, "when": "The kind is validated.", "expect": {"accepted": false}},
+    {"test_id": "HC-RCOL-003", "applies_to": "observable ordering", "category": "preservation", "given": {"kind": "ordered_set", "members": ["TLC-SR-MASTER-007", "TLC-SR-MASTER-008"]}, "when": "The collection is represented and returned.", "expect": {"order_preserved": true, "duplicates_absent": true}}
+  ]
+}

--- a/handoff/shared/TLC-HC-REFERENCE-COLLECTION/contract.json
+++ b/handoff/shared/TLC-HC-REFERENCE-COLLECTION/contract.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract": {"shared_contract_id": "TLC-HC-REFERENCE-COLLECTION", "title": "Reference Collection"},
+  "purpose": "Express observable reference collection semantics without selecting a programming-language container.",
+  "scope": {
+    "required": [
+      {"id": "RCOL-REQ-001", "statement": "The collection kind is one of the eight closed kinds."},
+      {"id": "RCOL-REQ-002", "statement": "Membership, minimum and maximum cardinality, ordering, duplicates, key contract, and value contract are explicit."}
+    ],
+    "forbidden": [
+      {"id": "RCOL-FOR-001", "statement": "A sequence must not be substituted for a set, multiset, or ordered set when observable semantics differ."},
+      {"id": "RCOL-FOR-002", "statement": "An implementation container must not create ordering or duplicate guarantees absent from the package."}
+    ],
+    "deferred": [{"id": "RCOL-DEF-001", "statement": "Container type, layout, hashing, comparison, and allocation strategy are implementation-defined."}]
+  },
+  "data_contract": {
+    "shape": "collection",
+    "fields": [],
+    "collection": {
+      "supported_kinds": ["scalar", "optional", "sequence", "set", "ordered_set", "multiset", "map", "ordered_map"],
+      "membership": "open",
+      "cardinality": {"minimum": 0, "maximum": null},
+      "ordering": "not_constrained",
+      "duplicates": "implementation_defined",
+      "key_contract": {},
+      "value_contract": {"shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"}
+    },
+    "runtime": {"mutability": "not_constrained", "layout": "not_constrained", "ownership": "implementation_defined", "lifetime": "implementation_defined", "allocation": "implementation_defined", "thread_safety": "implementation_defined"}
+  },
+  "global_invariants": [{"id": "RCOL-INV-001", "statement": "A conforming representation preserves every collection semantic declared by the consuming package."}],
+  "conformance": {"acceptance_required": true, "lossless_preservation_required": true, "notes": ["This shared contract defines the vocabulary; consuming packages select concrete semantics."]}
+}

--- a/handoff/shared/TLC-HC-REFERENCE-COLLECTION/manifest.json
+++ b/handoff/shared/TLC-HC-REFERENCE-COLLECTION/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+  "title": "Reference Collection",
+  "statuses": {"package": "validated", "scientific": "not_applicable", "execution": "structural_only"},
+  "files": ["README.md", "manifest.json", "contract.json", "acceptance.json", "traceability.json"],
+  "shared_dependencies": [{"shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE", "version": "1.0.0"}],
+  "examples": {"present": false, "file": null},
+  "reference_integrity": {"repository_relative_paths_only": true, "all_declared_files_required": true, "dependency_resolution_required": true}
+}

--- a/handoff/shared/TLC-HC-REFERENCE-COLLECTION/traceability.json
+++ b/handoff/shared/TLC-HC-REFERENCE-COLLECTION/traceability.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-REFERENCE-COLLECTION",
+  "scientific_sources": [],
+  "mathematical_contracts": [],
+  "source_irs": [],
+  "finalized_irs": [],
+  "algorithm_specifications": [],
+  "test_plans": [],
+  "acceptance_oracles": [],
+  "scientific_decisions": [
+    {"path": "registry/global-finalization/shared-types.yaml", "role": "Confirms reusable reference carriers while preserving semantic identity and forbidding inferred equivalence.", "fingerprint": {"algorithm": "git_blob_sha1", "value": "aef9616c4572c87a38209f9d58e00e1cf646f8ed"}}
+  ]
+}

--- a/handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE/README.md
+++ b/handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE/README.md
@@ -1,0 +1,5 @@
+# TLC-HC-SCIENTIFIC-REFERENCE
+
+Defines a lossless repository-relative reference to an authoritative scientific or specification artifact. Optional object, section, subsection, line-range, and source-commit fields refine provenance without interpreting the referenced science.
+
+Normative behavior is defined by `contract.json` and `acceptance.json`.

--- a/handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE/acceptance.json
+++ b/handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE/acceptance.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-SCIENTIFIC-REFERENCE",
+  "tests": [
+    {"test_id": "HC-SREF-001", "applies_to": "reference validation", "category": "valid_input", "given": {"source_path": "maths/00-master.md", "section": "3. Structure interne du Maître (7-uplet)", "line_range": {"start": 41, "end": 47}}, "when": "The reference is validated.", "expect": {"accepted": true}},
+    {"test_id": "HC-SREF-002", "applies_to": "path safety", "category": "invalid_input", "given": {"source_path": "../outside.md"}, "when": "The reference is validated.", "expect": {"accepted": false}},
+    {"test_id": "HC-SREF-003", "applies_to": "provenance preservation", "category": "preservation", "given": {"source_path": "maths/00-master.md", "object_id": "TLC-SO-MASTER-008"}, "when": "The reference is round-tripped.", "expect": {"all_supplied_fields_exactly_equal": true}}
+  ]
+}

--- a/handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE/contract.json
+++ b/handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE/contract.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract": {"shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE", "title": "Scientific Reference"},
+  "purpose": "Preserve provenance to a repository artifact without inferring the artifact's scientific semantics.",
+  "scope": {
+    "required": [
+      {"id": "SREF-REQ-001", "statement": "source_path is repository-relative and preserved exactly."},
+      {"id": "SREF-REQ-002", "statement": "Any supplied object, section, subsection, line range, or source commit is preserved exactly."}
+    ],
+    "forbidden": [
+      {"id": "SREF-FOR-001", "statement": "Path traversal, absolute paths, and silent provenance rewriting are forbidden."},
+      {"id": "SREF-FOR-002", "statement": "A reference must not be interpreted as a scientific definition or alias declaration."}
+    ],
+    "deferred": [{"id": "SREF-DEF-001", "statement": "Repository access and transport mechanisms are implementation-defined."}]
+  },
+  "data_contract": {
+    "shape": "record",
+    "fields": [
+      {"name": "source_path", "required": true, "semantic_role": "repository-relative provenance path", "value_kind": "repository_path"},
+      {"name": "object_id", "required": false, "semantic_role": "opaque referenced object identity", "value_kind": "identifier"},
+      {"name": "section", "required": false, "semantic_role": "source section label", "value_kind": "string"},
+      {"name": "subsection", "required": false, "semantic_role": "source subsection label", "value_kind": "string"},
+      {"name": "line_range", "required": false, "semantic_role": "inclusive source line range", "value_kind": "object"},
+      {"name": "source_commit", "required": false, "semantic_role": "source revision fingerprint", "value_kind": "string"}
+    ],
+    "collection": {"supported_kinds": ["scalar"], "membership": "exact", "cardinality": {"minimum": 1, "maximum": 1}, "ordering": "not_applicable", "duplicates": "not_applicable", "key_contract": null, "value_contract": null},
+    "runtime": {"mutability": "immutable", "layout": "not_constrained", "ownership": "implementation_defined", "lifetime": "implementation_defined", "allocation": "implementation_defined", "thread_safety": "implementation_defined"}
+  },
+  "global_invariants": [{"id": "SREF-INV-001", "statement": "A conforming round trip does not change provenance fields."}],
+  "conformance": {"acceptance_required": true, "lossless_preservation_required": true, "notes": []}
+}

--- a/handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE/manifest.json
+++ b/handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+  "title": "Scientific Reference",
+  "statuses": {"package": "validated", "scientific": "not_applicable", "execution": "structural_only"},
+  "files": ["README.md", "manifest.json", "contract.json", "acceptance.json", "traceability.json"],
+  "shared_dependencies": [],
+  "examples": {"present": false, "file": null},
+  "reference_integrity": {"repository_relative_paths_only": true, "all_declared_files_required": true, "dependency_resolution_required": true}
+}

--- a/handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE/traceability.json
+++ b/handoff/shared/TLC-HC-SCIENTIFIC-REFERENCE/traceability.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-SCIENTIFIC-REFERENCE",
+  "scientific_sources": [],
+  "mathematical_contracts": [],
+  "source_irs": [],
+  "finalized_irs": [],
+  "algorithm_specifications": [],
+  "test_plans": [],
+  "acceptance_oracles": [],
+  "scientific_decisions": [
+    {"path": "registry/global-finalization/shared-types.yaml", "role": "Confirms the source-reference carrier and its provenance-preservation obligation.", "artifact_id": "TLC-SHARED-TYPE-SOURCE-REFERENCE", "fingerprint": {"algorithm": "git_blob_sha1", "value": "aef9616c4572c87a38209f9d58e00e1cf646f8ed"}}
+  ]
+}

--- a/handoff/shared/TLC-HC-STRUCTURED-ERROR/README.md
+++ b/handoff/shared/TLC-HC-STRUCTURED-ERROR/README.md
@@ -1,0 +1,5 @@
+# TLC-HC-STRUCTURED-ERROR
+
+Defines a transport-neutral public error record. Error codes and observable conditions are stable; exceptions, status objects, return values, callbacks, protocol messages, and other delivery mechanisms remain implementation-defined.
+
+Normative behavior is defined by `contract.json` and `acceptance.json`.

--- a/handoff/shared/TLC-HC-STRUCTURED-ERROR/acceptance.json
+++ b/handoff/shared/TLC-HC-STRUCTURED-ERROR/acceptance.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-STRUCTURED-ERROR",
+  "tests": [
+    {"test_id": "HC-ERR-001", "applies_to": "stable code", "category": "determinism", "given": {"condition": "reference set mismatch"}, "when": "The same condition is detected repeatedly.", "expect": {"same_code_each_time": true}},
+    {"test_id": "HC-ERR-002", "applies_to": "transport neutrality", "category": "invariant", "given": {"code": "MASTER_REFERENCE_SET_MISMATCH", "transport": "implementation_defined"}, "when": "Any supported delivery mechanism is used.", "expect": {"code_preserved": true}},
+    {"test_id": "HC-ERR-003", "applies_to": "failure atomicity", "category": "error", "given": {"public_result": "no_partial_result", "failure_atomicity": "no_observable_partial_result"}, "when": "The operation fails.", "expect": {"partial_result_visible": false}}
+  ]
+}

--- a/handoff/shared/TLC-HC-STRUCTURED-ERROR/contract.json
+++ b/handoff/shared/TLC-HC-STRUCTURED-ERROR/contract.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract": {"shared_contract_id": "TLC-HC-STRUCTURED-ERROR", "title": "Structured Error"},
+  "purpose": "Expose stable error semantics independently of the mechanism used to transport an error.",
+  "scope": {
+    "required": [
+      {"id": "ERR-REQ-001", "statement": "The stable code, category, condition, recoverability, public result policy, failure atomicity, and context are observable."},
+      {"id": "ERR-REQ-002", "statement": "Error emission is deterministic for the same detected condition."}
+    ],
+    "forbidden": [
+      {"id": "ERR-FOR-001", "statement": "A conforming implementation must not return a partial scientific result when the consuming contract requires no partial result."},
+      {"id": "ERR-FOR-002", "statement": "The transport mechanism must not alter the stable error code."}
+    ],
+    "deferred": [{"id": "ERR-DEF-001", "statement": "Exception, return-value, callback, protocol, and logging mechanisms are implementation-defined."}]
+  },
+  "data_contract": {
+    "shape": "record",
+    "fields": [
+      {"name": "code", "required": true, "semantic_role": "stable public error identity", "value_kind": "identifier"},
+      {"name": "category", "required": true, "semantic_role": "error classification", "value_kind": "string"},
+      {"name": "condition", "required": true, "semantic_role": "observable triggering condition", "value_kind": "string"},
+      {"name": "feature_id", "required": false, "semantic_role": "feature scope", "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0"},
+      {"name": "recoverability", "required": true, "semantic_role": "caller recovery classification", "value_kind": "enum", "allowed_values": ["recoverable", "retryable", "non_retryable", "implementation_defined", "not_applicable"]},
+      {"name": "public_result", "required": true, "semantic_role": "result visibility on failure", "value_kind": "enum", "allowed_values": ["error_only", "no_partial_result", "partial_result_allowed", "implementation_defined"]},
+      {"name": "failure_atomicity", "required": true, "semantic_role": "observable state guarantee", "value_kind": "enum", "allowed_values": ["no_observable_partial_result", "basic", "not_constrained", "implementation_defined", "not_applicable"]},
+      {"name": "context", "required": true, "semantic_role": "non-scientific diagnostic fields", "value_kind": "object"},
+      {"name": "transport", "required": true, "semantic_role": "delivery mechanism policy", "value_kind": "enum", "allowed_values": ["implementation_defined"]}
+    ],
+    "collection": {"supported_kinds": ["scalar", "optional", "sequence"], "membership": "open", "cardinality": {"minimum": 0, "maximum": null}, "ordering": "not_constrained", "duplicates": "allowed", "key_contract": null, "value_contract": {"shared_contract_ref": "TLC-HC-STRUCTURED-ERROR@1.0.0"}},
+    "runtime": {"mutability": "immutable", "layout": "not_constrained", "ownership": "implementation_defined", "lifetime": "implementation_defined", "allocation": "implementation_defined", "thread_safety": "implementation_defined"}
+  },
+  "global_invariants": [{"id": "ERR-INV-001", "statement": "The same scoped error code denotes the same public condition throughout a package version."}],
+  "conformance": {"acceptance_required": true, "lossless_preservation_required": true, "notes": []}
+}

--- a/handoff/shared/TLC-HC-STRUCTURED-ERROR/manifest.json
+++ b/handoff/shared/TLC-HC-STRUCTURED-ERROR/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+  "title": "Structured Error",
+  "statuses": {"package": "validated", "scientific": "not_applicable", "execution": "structural_only"},
+  "files": ["README.md", "manifest.json", "contract.json", "acceptance.json", "traceability.json"],
+  "shared_dependencies": [{"shared_contract_id": "TLC-HC-FEATURE-ID", "version": "1.0.0"}],
+  "examples": {"present": false, "file": null},
+  "reference_integrity": {"repository_relative_paths_only": true, "all_declared_files_required": true, "dependency_resolution_required": true}
+}

--- a/handoff/shared/TLC-HC-STRUCTURED-ERROR/traceability.json
+++ b/handoff/shared/TLC-HC-STRUCTURED-ERROR/traceability.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-STRUCTURED-ERROR",
+  "scientific_sources": [],
+  "mathematical_contracts": [],
+  "source_irs": [],
+  "finalized_irs": [],
+  "algorithm_specifications": [],
+  "test_plans": [],
+  "acceptance_oracles": [],
+  "scientific_decisions": [
+    {"path": "registry/global-finalization/shared-types.yaml", "role": "Confirms stable structured errors, deterministic emission, and no partial scientific result.", "artifact_id": "TLC-SHARED-TYPE-STRUCTURED-ERROR", "fingerprint": {"algorithm": "git_blob_sha1", "value": "aef9616c4572c87a38209f9d58e00e1cf646f8ed"}},
+    {"path": "registry/domain-finalization/master/module-specification.yaml", "role": "Defines the Master error code set and observable conditions.", "fingerprint": {"algorithm": "git_blob_sha1", "value": "53a79429609367b5e80abdfba302510bc98cde0b"}}
+  ]
+}

--- a/handoff/shared/TLC-HC-TRACEABILITY/README.md
+++ b/handoff/shared/TLC-HC-TRACEABILITY/README.md
@@ -1,0 +1,5 @@
+# TLC-HC-TRACEABILITY
+
+Defines resolvable, repository-relative provenance lists for every handoff package. Each traceability category is a list so multiple artifacts can support one compiled obligation.
+
+Traceability records explain origin; they do not override the normative authority order or create scientific decisions.

--- a/handoff/shared/TLC-HC-TRACEABILITY/acceptance.json
+++ b/handoff/shared/TLC-HC-TRACEABILITY/acceptance.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-TRACEABILITY",
+  "tests": [
+    {"test_id": "HC-TRC-001", "applies_to": "list structure", "category": "valid_input", "given": {"scientific_sources": [], "mathematical_contracts": [], "source_irs": [], "finalized_irs": [], "algorithm_specifications": [], "test_plans": [], "acceptance_oracles": [], "scientific_decisions": []}, "when": "The traceability record is structurally validated.", "expect": {"accepted": true}},
+    {"test_id": "HC-TRC-002", "applies_to": "path safety", "category": "invalid_input", "given": {"path": "/absolute/source.yaml"}, "when": "A populated reference is validated.", "expect": {"accepted": false}},
+    {"test_id": "HC-TRC-003", "applies_to": "resolution", "category": "preservation", "given": {"path": "registry/math-contracts/TLC-FC-00-MASTER-005/contract.yaml"}, "when": "Repository integrity is checked.", "expect": {"resolves_inside_repository": true}}
+  ]
+}

--- a/handoff/shared/TLC-HC-TRACEABILITY/contract.json
+++ b/handoff/shared/TLC-HC-TRACEABILITY/contract.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract": {"shared_contract_id": "TLC-HC-TRACEABILITY", "title": "Traceability"},
+  "purpose": "Maintain resolvable provenance from a handoff package to every relevant upstream artifact category.",
+  "scope": {
+    "required": [
+      {"id": "TRC-REQ-001", "statement": "Scientific sources, mathematical contracts, source IRs, finalized IRs, algorithm specifications, test plans, acceptance oracles, and scientific decisions are represented as lists."},
+      {"id": "TRC-REQ-002", "statement": "Every populated reference uses a repository-relative path and preserves its role and optional fingerprint."}
+    ],
+    "forbidden": [
+      {"id": "TRC-FOR-001", "statement": "Absolute paths, parent-directory traversal, and empty required references are forbidden."},
+      {"id": "TRC-FOR-002", "statement": "Traceability metadata must not create or resolve a scientific obligation."}
+    ],
+    "deferred": [{"id": "TRC-DEF-001", "statement": "Remote provenance stores and external identifier schemes are outside v1.0."}]
+  },
+  "data_contract": {
+    "shape": "record",
+    "fields": [
+      {"name": "scientific_sources", "required": true, "semantic_role": "authoritative scientific source references", "value_kind": "array"},
+      {"name": "mathematical_contracts", "required": true, "semantic_role": "mathematical contract references", "value_kind": "array"},
+      {"name": "source_irs", "required": true, "semantic_role": "source IR references", "value_kind": "array"},
+      {"name": "finalized_irs", "required": true, "semantic_role": "finalized IR references", "value_kind": "array"},
+      {"name": "algorithm_specifications", "required": true, "semantic_role": "algorithm specification references", "value_kind": "array"},
+      {"name": "test_plans", "required": true, "semantic_role": "source test plan references", "value_kind": "array"},
+      {"name": "acceptance_oracles", "required": true, "semantic_role": "acceptance oracle references", "value_kind": "array"},
+      {"name": "scientific_decisions", "required": true, "semantic_role": "decision and governance references", "value_kind": "array"}
+    ],
+    "collection": {"supported_kinds": ["sequence"], "membership": "open", "cardinality": {"minimum": 0, "maximum": null}, "ordering": "preserved", "duplicates": "forbidden", "key_contract": null, "value_contract": {"shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"}},
+    "runtime": {"mutability": "immutable", "layout": "not_constrained", "ownership": "implementation_defined", "lifetime": "implementation_defined", "allocation": "implementation_defined", "thread_safety": "implementation_defined"}
+  },
+  "global_invariants": [{"id": "TRC-INV-001", "statement": "Every populated traceability path resolves inside the repository revision being validated."}],
+  "conformance": {"acceptance_required": true, "lossless_preservation_required": true, "notes": ["A consuming feature may require selected categories to be non-empty."]}
+}

--- a/handoff/shared/TLC-HC-TRACEABILITY/manifest.json
+++ b/handoff/shared/TLC-HC-TRACEABILITY/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract_id": "TLC-HC-TRACEABILITY",
+  "title": "Traceability",
+  "statuses": {"package": "validated", "scientific": "not_applicable", "execution": "structural_only"},
+  "files": ["README.md", "manifest.json", "contract.json", "acceptance.json", "traceability.json"],
+  "shared_dependencies": [{"shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE", "version": "1.0.0"}],
+  "examples": {"present": false, "file": null},
+  "reference_integrity": {"repository_relative_paths_only": true, "all_declared_files_required": true, "dependency_resolution_required": true}
+}

--- a/handoff/shared/TLC-HC-TRACEABILITY/traceability.json
+++ b/handoff/shared/TLC-HC-TRACEABILITY/traceability.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-TRACEABILITY",
+  "scientific_sources": [],
+  "mathematical_contracts": [],
+  "source_irs": [],
+  "finalized_irs": [],
+  "algorithm_specifications": [],
+  "test_plans": [],
+  "acceptance_oracles": [],
+  "scientific_decisions": [
+    {"path": "registry/global-finalization/shared-types.yaml", "role": "Confirms the resolvable traceability carrier and required artifact references.", "artifact_id": "TLC-SHARED-TYPE-TRACEABILITY", "fingerprint": {"algorithm": "git_blob_sha1", "value": "aef9616c4572c87a38209f9d58e00e1cf646f8ed"}}
+  ]
+}

--- a/handoff/shared/TLC-HC-UNRESOLVED-ITEM/README.md
+++ b/handoff/shared/TLC-HC-UNRESOLVED-ITEM/README.md
@@ -1,0 +1,5 @@
+# TLC-HC-UNRESOLVED-ITEM
+
+Defines an explicit carrier for scientific or specification material that remains unresolved. Unresolved items propagate monotonically and cannot be converted into defaults, inferred decisions, aliases, or executable semantics.
+
+Normative behavior is defined by `contract.json` and `acceptance.json`.

--- a/handoff/shared/TLC-HC-UNRESOLVED-ITEM/acceptance.json
+++ b/handoff/shared/TLC-HC-UNRESOLVED-ITEM/acceptance.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-UNRESOLVED-ITEM",
+  "tests": [
+    {"test_id": "HC-UNR-001", "applies_to": "unresolved propagation", "category": "preservation", "given": {"status": "preserved_unresolved"}, "when": "The item is copied into a descriptor.", "expect": {"status": "preserved_unresolved"}},
+    {"test_id": "HC-UNR-002", "applies_to": "non-invention", "category": "invalid_input", "given": {"status": "resolved_by_default"}, "when": "The item is validated.", "expect": {"accepted": false}},
+    {"test_id": "HC-UNR-003", "applies_to": "provenance", "category": "invariant", "given": {"source_reference": {"source_path": "registry/scientific-review/engineering-disposition.yaml"}}, "when": "The item is propagated.", "expect": {"source_reference_preserved": true}}
+  ]
+}

--- a/handoff/shared/TLC-HC-UNRESOLVED-ITEM/contract.json
+++ b/handoff/shared/TLC-HC-UNRESOLVED-ITEM/contract.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract": {"shared_contract_id": "TLC-HC-UNRESOLVED-ITEM", "title": "Unresolved Item"},
+  "purpose": "Preserve an unresolved item and its provenance without inventing a resolution.",
+  "scope": {
+    "required": [
+      {"id": "UNR-REQ-001", "statement": "The unresolved identifier, classification, source reference, blocking scope, and status are preserved."},
+      {"id": "UNR-REQ-002", "statement": "Propagation is monotone until an authoritative replacement explicitly resolves the item."}
+    ],
+    "forbidden": [
+      {"id": "UNR-FOR-001", "statement": "A missing definition must not become a default value or executable behavior."},
+      {"id": "UNR-FOR-002", "statement": "The handoff must not mark a scientific decision resolved."}
+    ],
+    "deferred": [{"id": "UNR-DEF-001", "statement": "Scientific adjudication remains outside this structural contract."}]
+  },
+  "data_contract": {
+    "shape": "record",
+    "fields": [
+      {"name": "unresolved_id", "required": true, "semantic_role": "stable unresolved item identity", "value_kind": "identifier"},
+      {"name": "classification", "required": true, "semantic_role": "preserved upstream classification", "value_kind": "string"},
+      {"name": "source_reference", "required": true, "semantic_role": "authoritative provenance", "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"},
+      {"name": "blocking_scope", "required": true, "semantic_role": "scope affected by missing semantics", "value_kind": "string"},
+      {"name": "status", "required": true, "semantic_role": "unresolved state", "value_kind": "enum", "allowed_values": ["preserved_unresolved", "external_provider_required"]}
+    ],
+    "collection": {"supported_kinds": ["scalar", "sequence", "set", "ordered_set"], "membership": "open", "cardinality": {"minimum": 0, "maximum": null}, "ordering": "not_constrained", "duplicates": "forbidden", "key_contract": null, "value_contract": {"shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0"}},
+    "runtime": {"mutability": "immutable", "layout": "not_constrained", "ownership": "implementation_defined", "lifetime": "implementation_defined", "allocation": "implementation_defined", "thread_safety": "implementation_defined"}
+  },
+  "global_invariants": [{"id": "UNR-INV-001", "statement": "Transport and composition preserve unresolved status unless an authoritative package revision changes it."}],
+  "conformance": {"acceptance_required": true, "lossless_preservation_required": true, "notes": []}
+}

--- a/handoff/shared/TLC-HC-UNRESOLVED-ITEM/manifest.json
+++ b/handoff/shared/TLC-HC-UNRESOLVED-ITEM/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+  "title": "Unresolved Item",
+  "statuses": {"package": "validated", "scientific": "preserved_unresolved", "execution": "structural_only"},
+  "files": ["README.md", "manifest.json", "contract.json", "acceptance.json", "traceability.json"],
+  "shared_dependencies": [{"shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE", "version": "1.0.0"}],
+  "examples": {"present": false, "file": null},
+  "reference_integrity": {"repository_relative_paths_only": true, "all_declared_files_required": true, "dependency_resolution_required": true}
+}

--- a/handoff/shared/TLC-HC-UNRESOLVED-ITEM/traceability.json
+++ b/handoff/shared/TLC-HC-UNRESOLVED-ITEM/traceability.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-HC-UNRESOLVED-ITEM",
+  "scientific_sources": [],
+  "mathematical_contracts": [],
+  "source_irs": [],
+  "finalized_irs": [],
+  "algorithm_specifications": [],
+  "test_plans": [],
+  "acceptance_oracles": [],
+  "scientific_decisions": [
+    {"path": "registry/global-finalization/shared-types.yaml", "role": "Confirms monotone unresolved propagation and prohibition of arbitrary resolution.", "artifact_id": "TLC-SHARED-TYPE-UNRESOLVED", "fingerprint": {"algorithm": "git_blob_sha1", "value": "aef9616c4572c87a38209f9d58e00e1cf646f8ed"}},
+    {"path": "registry/scientific-review/engineering-disposition.yaml", "role": "Preserves scientific questions as unresolved while allowing conservative structural handoff."}
+  ]
+}

--- a/reports/handoff/pilot-master-005-simulation.md
+++ b/reports/handoff/pilot-master-005-simulation.md
@@ -1,0 +1,108 @@
+# Pilot simulation: TLC-FC-00-MASTER-005 low-level work item
+
+## Purpose
+
+This document simulates downstream use of the Feature Handoff Package v1.0. C++ is used only as a verification lens for low-level concerns. No implementation source file is created, and this report does not make C++ normative.
+
+## Inputs available to the implementer
+
+The simulated implementer receives only:
+
+- `handoff/features/TLC-FC-00-MASTER-005/`;
+- the eight resolved shared contracts;
+- `bundle-lock.json` produced by the exporter.
+
+The mathematical contract, source IR, finalized IR, algorithm YAML, oracle YAML, and scientific prose are not needed during ordinary implementation.
+
+## Derivable public behavior
+
+A possible API can expose one descriptor-producing operation corresponding to `DESCRIBE-MASTER-SEVEN-TUPLE`. The public name and concrete type syntax are free. The input must carry:
+
+- exact feature identity `TLC-FC-00-MASTER-005`;
+- exact object-reference set containing only `TLC-SO-MASTER-008`;
+- exact ordered relation-reference set `TLC-SR-MASTER-007` through `TLC-SR-MASTER-011`;
+- an empty unresolved-reference set;
+- source provenance.
+
+Success returns an immutable descriptor with the seven required envelope fields. Requests for scientific calculation or concrete component layout fail with `MASTER_UNSUPPORTED_EXECUTION_MODE`.
+
+## C++ verification lens
+
+A C++ work item could choose a value-returning function, a result wrapper, or another error-aware interface. The handoff does not require exceptions, a particular expected/result utility, heap allocation, reference counting, templates, inheritance, or a specific standard-library container.
+
+The following conclusions are derivable:
+
+| Concern | Derivable requirement | Remaining freedom |
+|---|---|---|
+| Result ownership | The public result must remain valid according to the implementation's documented API and must not expose a partial success on failure. | Owned value, shared storage, arena-backed value, or another model may be used. |
+| Lifetime | No result lifetime duration is prescribed beyond the implementation's public contract. Inputs need not be retained. | Stack, heap, arena, static tables, and interning remain possible. |
+| Mutability | The observable descriptor is immutable after successful emission. | Internal construction may use mutation before publication. |
+| Aliasing | No aliasing model is prescribed. Aliasing must not permit observable mutation or identity merging. | Copying, sharing, views, or handles may be used. |
+| Layout | Component and descriptor layout are not constrained. | Field order in memory, padding, alignment, and binary ABI are implementation choices. |
+| Allocation | No allocation count or allocation prohibition is specified. | Zero, one, or multiple allocations may be used. |
+| Concurrency | Thread safety and reentrancy are implementation-defined. | Stateless, synchronized, thread-local, or externally synchronized designs are possible. |
+| Errors | Four stable codes and their triggering conditions are public. | Exceptions, return objects, status codes, callbacks, or protocol errors are possible. |
+| Failure atomicity | Failure exposes no successful partial descriptor and mutates no scientific or external domain state. | Internal temporary state and cleanup strategy are free. |
+
+## Strategy simulation
+
+The upstream algorithm lists a total sequence, but the handoff intentionally compiles only observable ordering constraints:
+
+1. feature identity validation must occur before successful publication;
+2. exact reference validation must occur before successful publication;
+3. preservation obligations must be verified before successful publication;
+4. a complete descriptor must exist before successful publication.
+
+Validation order relative to provenance construction, error-object construction, caching, and internal descriptor assembly is otherwise free. A low-level implementation may short-circuit, combine checks, precompute constants, use table-driven validation, or use generated metadata.
+
+## Error derivation
+
+The programmer can derive the following without upstream artifacts:
+
+- `MASTER_INVALID_FEATURE_ID` for any non-exact feature identity;
+- `MASTER_REFERENCE_SET_MISMATCH` for membership, cardinality, identity, or required-order mismatch;
+- `MASTER_PRESERVATION_VIOLATION` when identity, distinctness, order, opacity, or provenance cannot be preserved;
+- `MASTER_UNSUPPORTED_EXECUTION_MODE` for calculation, concrete layout, or another invented execution request.
+
+All four errors are transport-neutral and expose no partial successful result.
+
+## Test derivation
+
+The acceptance package supplies:
+
+- the exact valid fixture;
+- required descriptor fields and immutability;
+- missing-relation rejection;
+- relation distinctness and source order;
+- deterministic semantic output for identical input;
+- non-invention checks;
+- unsupported calculation rejection;
+- upstream source-integrity preservation;
+- invalid-feature rejection;
+- preservation-failure behavior.
+
+These tests can be translated into any low-level test framework without consulting the oracle YAML.
+
+## Ambiguities deliberately preserved
+
+The simulation identified real choices that remain unsupported by authoritative sources and therefore stay implementation-defined:
+
+- exact public function and type names;
+- result ownership model and lifetime duration;
+- copying, moving, borrowing, sharing, and aliasing mechanisms;
+- memory layout, alignment, contiguity, address stability, and ABI;
+- allocation strategy and maximum input size;
+- canonical serialization and binary encoding;
+- thread safety, reentrancy, and concurrent scheduling;
+- diagnostic context beyond the stable error code and condition;
+- scientific meaning, runtime representation, dimensions, values, and evaluation of each seven-tuple component.
+
+No model correction was required for these ambiguities because the handoff exposes them explicitly as unconstrained or implementation-defined.
+
+## Concrete model defect found and corrected
+
+The simulation showed that copying the upstream `execution_order` list as a prescribed algorithm would unnecessarily restrict low-level implementations. The feature contract therefore uses `partially_constrained` strategy semantics and records only validation-before-success, preservation-before-success, and descriptor-before-success dependency pairs.
+
+## Result
+
+The pilot is sufficient to create an autonomous low-level work item. A programmer can derive a possible API, observable immutability, stable errors, failure atomicity, test obligations, and architecture freedoms without reading the intermediate pipeline.

--- a/tools/handoff/export_bundle.py
+++ b/tools/handoff/export_bundle.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Resolve one handoff feature and export a standalone directory bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+HANDOFF = ROOT / "handoff"
+MODEL_VERSION = "1.0.0"
+
+
+class ExportFailure(RuntimeError):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ExportFailure(f"cannot read {path}: {exc}") from exc
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def hash_tree(path: Path, logical_root: str) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for file_path in sorted(item for item in path.rglob("*") if item.is_file()):
+        relative = file_path.relative_to(path).as_posix()
+        hashes[f"{logical_root}/{relative}"] = sha256_file(file_path)
+    return hashes
+
+
+def resolve(feature_id: str) -> tuple[Path, dict[str, Any], list[tuple[str, str, Path]], dict[str, str]]:
+    feature_dir = HANDOFF / "features" / feature_id
+    if not feature_dir.is_dir():
+        raise ExportFailure(f"unknown feature package: {feature_id}")
+    manifest = load_json(feature_dir / "manifest.json")
+    if manifest.get("feature_id") != feature_id:
+        raise ExportFailure("feature manifest identity mismatch")
+
+    dependencies: list[tuple[str, str, Path]] = []
+    for dependency in manifest["shared_dependencies"]:
+        contract_id = dependency["shared_contract_id"]
+        required_version = dependency["version"]
+        shared_dir = HANDOFF / "shared" / contract_id
+        if not shared_dir.is_dir():
+            raise ExportFailure(f"missing shared dependency: {contract_id}")
+        shared_manifest = load_json(shared_dir / "manifest.json")
+        actual_version = shared_manifest.get("package_version")
+        if actual_version != required_version:
+            raise ExportFailure(
+                f"shared dependency version mismatch for {contract_id}: required {required_version}, found {actual_version}"
+            )
+        dependencies.append((contract_id, actual_version, shared_dir))
+
+    hashes = hash_tree(feature_dir, "feature")
+    for contract_id, _, shared_dir in dependencies:
+        hashes.update(hash_tree(shared_dir, f"shared/{contract_id}"))
+    return feature_dir, manifest, dependencies, hashes
+
+
+def build_lock(feature_id: str, manifest: dict[str, Any], dependencies: list[tuple[str, str, Path]], hashes: dict[str, str]) -> dict[str, Any]:
+    return {
+        "model_version": MODEL_VERSION,
+        "feature_id": feature_id,
+        "package_version": manifest["package_version"],
+        "resolved_dependencies": [
+            {"shared_contract_id": contract_id, "version": version}
+            for contract_id, version, _ in dependencies
+        ],
+        "hash_algorithm": "sha256",
+        "hashes": dict(sorted(hashes.items())),
+    }
+
+
+def export(feature_id: str, output: Path, check_only: bool) -> dict[str, Any]:
+    feature_dir, manifest, dependencies, hashes = resolve(feature_id)
+    lock = build_lock(feature_id, manifest, dependencies, hashes)
+    if check_only:
+        return lock
+
+    if output.exists():
+        raise ExportFailure(f"output already exists: {output}")
+    output.mkdir(parents=True)
+    shutil.copytree(feature_dir, output / "feature")
+    shared_output = output / "shared"
+    shared_output.mkdir()
+    for contract_id, _, shared_dir in dependencies:
+        shutil.copytree(shared_dir, shared_output / contract_id)
+    (output / "bundle-lock.json").write_text(
+        json.dumps(lock, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return lock
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("feature_id", help="Feature package identifier to resolve")
+    parser.add_argument("output", nargs="?", type=Path, help="New output directory")
+    parser.add_argument("--check", action="store_true", help="Resolve and hash without writing a bundle")
+    args = parser.parse_args()
+    if not args.check and args.output is None:
+        parser.error("output is required unless --check is used")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        lock = export(args.feature_id, args.output, args.check)
+    except ExportFailure as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if args.check:
+        print(json.dumps(lock, indent=2, sort_keys=True))
+    else:
+        print(f"Exported {args.feature_id} to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/handoff/validate_handoff.py
+++ b/tools/handoff/validate_handoff.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -45,15 +46,14 @@ def fail(message: str) -> None:
     raise ValidationFailure(message)
 
 
+@lru_cache(maxsize=None)
 def load_json(path: Path) -> Any:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
-        fail(f"missing required file: {path.relative_to(ROOT)}")
-        raise exc
+        raise ValidationFailure(f"missing required file: {path.relative_to(ROOT)}") from exc
     except json.JSONDecodeError as exc:
-        fail(f"invalid JSON in {path.relative_to(ROOT)}: {exc}")
-        raise exc
+        raise ValidationFailure(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
 
 
 def validate_schema(instance: Any, schema: Any, path: Path) -> None:
@@ -76,16 +76,11 @@ def walk_strings(value: Any) -> Iterable[str]:
     if isinstance(value, str):
         yield value
     elif isinstance(value, dict):
-        for key, item in value.items():
-            yield str(key)
+        for item in value.values():
             yield from walk_strings(item)
     elif isinstance(value, list):
         for item in value:
             yield from walk_strings(item)
-
-
-def major(version: str) -> str:
-    return version.split(".", 1)[0]
 
 
 def package_files(package_dir: Path, manifest: dict[str, Any]) -> None:
@@ -106,6 +101,8 @@ def package_files(package_dir: Path, manifest: dict[str, Any]) -> None:
 
 def validate_trace_paths(trace: dict[str, Any], path: Path, require_nonempty: bool) -> None:
     for category in REQUIRED_TRACE_CATEGORIES:
+        if category not in trace:
+            fail(f"missing traceability category {category} in {path.relative_to(ROOT)}")
         refs = trace[category]
         if require_nonempty and not refs:
             fail(f"{category} must be non-empty in {path.relative_to(ROOT)}")
@@ -119,17 +116,18 @@ def validate_trace_paths(trace: dict[str, Any], path: Path, require_nonempty: bo
 
 def validate_no_normative_language_code(package_dir: Path) -> None:
     patterns = (
-        re.compile(r"```\s*(?:c\+\+|cpp|rust|ruby|python)\b", re.IGNORECASE),
-        re.compile(r"#include\s*[<\"]"),
-        re.compile(r"\bfn\s+main\s*\("),
-        re.compile(r"\bdef\s+[A-Za-z_]\w*\s*\("),
+        re.compile(r"```[ \t]*(?:c\+\+|cpp|rust|ruby|python)\b", re.IGNORECASE),
+        re.compile(r"(?m)^\s*#include\s*[<\"]"),
+        re.compile(r"(?m)^\s*(?:pub\s+)?fn\s+[A-Za-z_]\w*\s*\("),
+        re.compile(r"(?m)^\s*def\s+[A-Za-z_]\w*[!?=]?\s*(?:\(|$)"),
+        re.compile(r"\bstd::[A-Za-z_]\w*"),
     )
     for name in ("contract.json", "acceptance.json", "examples.json"):
         path = package_dir / name
         if not path.exists():
             continue
-        text = path.read_text(encoding="utf-8")
-        if any(pattern.search(text) for pattern in patterns):
+        document = load_json(path)
+        if any(pattern.search(text) for text in walk_strings(document) for pattern in patterns):
             fail(f"normative programming-language code found in {path.relative_to(ROOT)}")
 
 
@@ -250,7 +248,7 @@ def main() -> int:
             dep_id = dependency["shared_contract_id"]
             if dep_id not in shared_versions:
                 fail(f"unresolved shared dependency {dep_id} in {package_dir.relative_to(ROOT)}")
-            if dependency["version"] != shared_versions[dep_id] or major(dependency["version"]) != major(shared_versions[dep_id]):
+            if dependency["version"] != shared_versions[dep_id]:
                 fail(f"incompatible shared dependency {dep_id} in {package_dir.relative_to(ROOT)}")
 
     feature_dirs = sorted(path for path in (HANDOFF / "features").iterdir() if path.is_dir())

--- a/tools/handoff/validate_handoff.py
+++ b/tools/handoff/validate_handoff.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Validate the Feature Handoff Package v1.0 foundation."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[2]
+HANDOFF = ROOT / "handoff"
+SCHEMAS = HANDOFF / "schemas"
+EXPECTED_SHARED = {
+    "TLC-HC-FEATURE-ID",
+    "TLC-HC-SCIENTIFIC-REFERENCE",
+    "TLC-HC-REFERENCE-COLLECTION",
+    "TLC-HC-UNRESOLVED-ITEM",
+    "TLC-HC-OPAQUE-VALUE",
+    "TLC-HC-STRUCTURED-ERROR",
+    "TLC-HC-TRACEABILITY",
+    "TLC-HC-DESCRIPTOR-ENVELOPE",
+}
+PILOT_ID = "TLC-FC-00-MASTER-005"
+REQUIRED_TRACE_CATEGORIES = (
+    "scientific_sources",
+    "mathematical_contracts",
+    "source_irs",
+    "finalized_irs",
+    "algorithm_specifications",
+    "test_plans",
+    "acceptance_oracles",
+    "scientific_decisions",
+)
+
+
+class ValidationFailure(RuntimeError):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationFailure(message)
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        fail(f"missing required file: {path.relative_to(ROOT)}")
+        raise exc
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path.relative_to(ROOT)}: {exc}")
+        raise exc
+
+
+def validate_schema(instance: Any, schema: Any, path: Path) -> None:
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(instance), key=lambda item: list(item.absolute_path))
+    if errors:
+        details = "; ".join(
+            f"{'/'.join(str(part) for part in error.absolute_path) or '<root>'}: {error.message}"
+            for error in errors[:10]
+        )
+        fail(f"schema validation failed for {path.relative_to(ROOT)}: {details}")
+
+
+def safe_repo_path(value: str) -> bool:
+    path = Path(value)
+    return bool(value) and not path.is_absolute() and ".." not in path.parts and not value.startswith("~")
+
+
+def walk_strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            yield str(key)
+            yield from walk_strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from walk_strings(item)
+
+
+def major(version: str) -> str:
+    return version.split(".", 1)[0]
+
+
+def package_files(package_dir: Path, manifest: dict[str, Any]) -> None:
+    required = {"README.md", "manifest.json", "contract.json", "acceptance.json", "traceability.json"}
+    declared = set(manifest["files"])
+    if not required.issubset(declared):
+        fail(f"{package_dir.relative_to(ROOT)} does not declare every required file")
+    for filename in declared:
+        if not (package_dir / filename).is_file():
+            fail(f"declared file is missing: {(package_dir / filename).relative_to(ROOT)}")
+    examples = manifest["examples"]
+    exists = (package_dir / "examples.json").exists()
+    if examples["present"] != exists:
+        fail(f"examples declaration mismatch in {package_dir.relative_to(ROOT)}")
+    if exists and "examples.json" not in declared:
+        fail(f"examples.json exists but is not declared in {package_dir.relative_to(ROOT)}")
+
+
+def validate_trace_paths(trace: dict[str, Any], path: Path, require_nonempty: bool) -> None:
+    for category in REQUIRED_TRACE_CATEGORIES:
+        refs = trace[category]
+        if require_nonempty and not refs:
+            fail(f"{category} must be non-empty in {path.relative_to(ROOT)}")
+        for ref in refs:
+            value = ref["path"]
+            if not safe_repo_path(value):
+                fail(f"unsafe traceability path {value!r} in {path.relative_to(ROOT)}")
+            if not (ROOT / value).exists():
+                fail(f"unresolved traceability path {value!r} in {path.relative_to(ROOT)}")
+
+
+def validate_no_normative_language_code(package_dir: Path) -> None:
+    patterns = (
+        re.compile(r"```\s*(?:c\+\+|cpp|rust|ruby|python)\b", re.IGNORECASE),
+        re.compile(r"#include\s*[<\"]"),
+        re.compile(r"\bfn\s+main\s*\("),
+        re.compile(r"\bdef\s+[A-Za-z_]\w*\s*\("),
+    )
+    for name in ("contract.json", "acceptance.json", "examples.json"):
+        path = package_dir / name
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(pattern.search(text) for pattern in patterns):
+            fail(f"normative programming-language code found in {path.relative_to(ROOT)}")
+
+
+def validate_strategy(contract: dict[str, Any], trace: dict[str, Any], path: Path) -> None:
+    for operation in contract.get("operations", []):
+        strategy = operation["strategy_contract"]
+        steps = set(strategy["steps"])
+        for edge in strategy["partial_order"]:
+            if edge["before"] not in steps or edge["after"] not in steps:
+                fail(f"partial-order edge references an unknown step in {path.relative_to(ROOT)}")
+        if strategy["mode"] == "prescribed":
+            if not strategy["prescription_basis"]:
+                fail(f"prescribed strategy lacks an authoritative basis in {path.relative_to(ROOT)}")
+            if not trace["algorithm_specifications"]:
+                fail(f"prescribed strategy lacks algorithm traceability in {path.relative_to(ROOT)}")
+
+
+def validate_error_uniqueness(contract: dict[str, Any], path: Path) -> None:
+    for operation in contract.get("operations", []):
+        codes = [item["code"] for item in operation["error_contract"]]
+        if len(codes) != len(set(codes)):
+            fail(f"duplicate error code in operation {operation['operation_id']} at {path.relative_to(ROOT)}")
+
+
+def validate_acceptance_ids(acceptance: dict[str, Any], global_ids: set[str], path: Path) -> None:
+    local: set[str] = set()
+    for test in acceptance["tests"]:
+        test_id = test["test_id"]
+        if test_id in local or test_id in global_ids:
+            fail(f"duplicate test_id {test_id} in {path.relative_to(ROOT)}")
+        local.add(test_id)
+        global_ids.add(test_id)
+
+
+def validate_pilot(contract: dict[str, Any], acceptance: dict[str, Any], manifest: dict[str, Any]) -> None:
+    if contract["feature"]["feature_id"] != PILOT_ID:
+        fail("pilot contract feature_id mismatch")
+    if manifest["statuses"] != {"package": "pilot", "scientific": "partially_defined", "execution": "structural_only"}:
+        fail("pilot multidimensional status mismatch")
+    text = json.dumps(contract, sort_keys=True)
+    required_tokens = {
+        "TLC-SO-MASTER-008",
+        "TLC-SR-MASTER-007",
+        "TLC-SR-MASTER-008",
+        "TLC-SR-MASTER-009",
+        "TLC-SR-MASTER-010",
+        "TLC-SR-MASTER-011",
+        "MASTER_INVALID_FEATURE_ID",
+        "MASTER_REFERENCE_SET_MISMATCH",
+        "MASTER_PRESERVATION_VIOLATION",
+        "MASTER_UNSUPPORTED_EXECUTION_MODE",
+    }
+    missing = sorted(token for token in required_tokens if token not in text)
+    if missing:
+        fail(f"pilot contract is missing required source-backed tokens: {missing}")
+    if len(contract["operations"]) != 1:
+        fail("pilot must expose exactly one structural operation in v1.0")
+    strategy = contract["operations"][0]["strategy_contract"]
+    if strategy["mode"] != "partially_constrained":
+        fail("pilot must preserve internal strategy freedom with a partially constrained strategy")
+    test_ids = {test["test_id"] for test in acceptance["tests"]}
+    if not {f"MASTER-005-A{i:02d}" for i in range(1, 9)}.issubset(test_ids):
+        fail("pilot does not preserve all eight oracle acceptance identifiers")
+
+
+def main() -> int:
+    if not HANDOFF.is_dir():
+        fail("handoff directory is missing")
+
+    schema_names = {
+        "manifest": "manifest.schema.json",
+        "contract": "contract.schema.json",
+        "acceptance": "acceptance.schema.json",
+        "examples": "examples.schema.json",
+        "traceability": "traceability.schema.json",
+        "shared_contract": "shared-contract.schema.json",
+    }
+    schemas = {name: load_json(SCHEMAS / filename) for name, filename in schema_names.items()}
+    for name, schema in schemas.items():
+        try:
+            Draft202012Validator.check_schema(schema)
+        except Exception as exc:  # jsonschema exposes several schema exception types
+            fail(f"invalid {name} schema: {exc}")
+
+    for path in sorted(HANDOFF.rglob("*.json")):
+        load_json(path)
+
+    shared_dirs = sorted(path for path in (HANDOFF / "shared").iterdir() if path.is_dir())
+    shared_ids = {path.name for path in shared_dirs}
+    if shared_ids != EXPECTED_SHARED:
+        fail(f"shared contract population mismatch: expected {sorted(EXPECTED_SHARED)}, found {sorted(shared_ids)}")
+
+    shared_versions: dict[str, str] = {}
+    global_test_ids: set[str] = set()
+    for package_dir in shared_dirs:
+        manifest = load_json(package_dir / "manifest.json")
+        contract = load_json(package_dir / "contract.json")
+        acceptance = load_json(package_dir / "acceptance.json")
+        trace = load_json(package_dir / "traceability.json")
+        validate_schema(manifest, schemas["manifest"], package_dir / "manifest.json")
+        validate_schema(contract, schemas["shared_contract"], package_dir / "contract.json")
+        validate_schema(acceptance, schemas["acceptance"], package_dir / "acceptance.json")
+        validate_schema(trace, schemas["traceability"], package_dir / "traceability.json")
+        package_id = package_dir.name
+        if manifest["shared_contract_id"] != package_id or contract["shared_contract"]["shared_contract_id"] != package_id or acceptance["applies_to"] != package_id or trace["applies_to"] != package_id:
+            fail(f"shared_contract_id mismatch in {package_dir.relative_to(ROOT)}")
+        if manifest["package_version"] != contract["package_version"] or manifest["package_version"] != acceptance["package_version"] or manifest["package_version"] != trace["package_version"]:
+            fail(f"package version mismatch in {package_dir.relative_to(ROOT)}")
+        shared_versions[package_id] = manifest["package_version"]
+        package_files(package_dir, manifest)
+        validate_trace_paths(trace, package_dir / "traceability.json", require_nonempty=False)
+        validate_acceptance_ids(acceptance, global_test_ids, package_dir / "acceptance.json")
+        validate_no_normative_language_code(package_dir)
+
+    for package_dir in shared_dirs:
+        manifest = load_json(package_dir / "manifest.json")
+        for dependency in manifest["shared_dependencies"]:
+            dep_id = dependency["shared_contract_id"]
+            if dep_id not in shared_versions:
+                fail(f"unresolved shared dependency {dep_id} in {package_dir.relative_to(ROOT)}")
+            if dependency["version"] != shared_versions[dep_id] or major(dependency["version"]) != major(shared_versions[dep_id]):
+                fail(f"incompatible shared dependency {dep_id} in {package_dir.relative_to(ROOT)}")
+
+    feature_dirs = sorted(path for path in (HANDOFF / "features").iterdir() if path.is_dir())
+    if {path.name for path in feature_dirs} != {PILOT_ID}:
+        fail("v1.0 foundation must contain only the declared pilot feature")
+
+    for package_dir in feature_dirs:
+        manifest = load_json(package_dir / "manifest.json")
+        contract = load_json(package_dir / "contract.json")
+        acceptance = load_json(package_dir / "acceptance.json")
+        trace = load_json(package_dir / "traceability.json")
+        examples = load_json(package_dir / "examples.json") if (package_dir / "examples.json").exists() else None
+        validate_schema(manifest, schemas["manifest"], package_dir / "manifest.json")
+        validate_schema(contract, schemas["contract"], package_dir / "contract.json")
+        validate_schema(acceptance, schemas["acceptance"], package_dir / "acceptance.json")
+        validate_schema(trace, schemas["traceability"], package_dir / "traceability.json")
+        if examples is not None:
+            validate_schema(examples, schemas["examples"], package_dir / "examples.json")
+        feature_id = package_dir.name
+        if manifest["feature_id"] != feature_id or contract["feature"]["feature_id"] != feature_id or acceptance["applies_to"] != feature_id or trace["applies_to"] != feature_id or (examples and examples["applies_to"] != feature_id):
+            fail(f"feature_id mismatch in {package_dir.relative_to(ROOT)}")
+        versions = {manifest["package_version"], contract["package_version"], acceptance["package_version"], trace["package_version"]}
+        if examples:
+            versions.add(examples["package_version"])
+        if len(versions) != 1:
+            fail(f"package version mismatch in {package_dir.relative_to(ROOT)}")
+        package_files(package_dir, manifest)
+        validate_trace_paths(trace, package_dir / "traceability.json", require_nonempty=True)
+        validate_acceptance_ids(acceptance, global_test_ids, package_dir / "acceptance.json")
+        validate_error_uniqueness(contract, package_dir / "contract.json")
+        validate_strategy(contract, trace, package_dir / "contract.json")
+        validate_no_normative_language_code(package_dir)
+        manifest_deps = {(item["shared_contract_id"], item["version"]) for item in manifest["shared_dependencies"]}
+        contract_deps = {(item["shared_contract_id"], item["version"]) for item in contract["dependencies"]}
+        if manifest_deps != contract_deps:
+            fail(f"manifest and contract dependencies differ in {package_dir.relative_to(ROOT)}")
+        for dep_id, version in manifest_deps:
+            if shared_versions.get(dep_id) != version:
+                fail(f"unresolved or incompatible dependency {dep_id}@{version} in {package_dir.relative_to(ROOT)}")
+        validate_pilot(contract, acceptance, manifest)
+
+    catalog = load_json(HANDOFF / "catalog.json")
+    if catalog.get("model_version") != "1.0.0" or catalog.get("complete_166_feature_catalog_finalized") is not False:
+        fail("catalog foundation status is incorrect")
+    if {entry["shared_contract_id"] for entry in catalog["shared_contracts"]} != EXPECTED_SHARED:
+        fail("catalog shared contract population mismatch")
+    if {entry["feature_id"] for entry in catalog["features"]} != {PILOT_ID}:
+        fail("catalog pilot population mismatch")
+    for entry in catalog["shared_contracts"] + catalog["features"]:
+        if not safe_repo_path(entry["path"]) or not (ROOT / entry["path"]).is_dir():
+            fail(f"catalog path does not resolve: {entry['path']}")
+
+    print("Feature Handoff Package v1.0 validation passed.")
+    print(f"Validated {len(shared_dirs)} shared contracts and {len(feature_dirs)} feature package.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValidationFailure as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

Establishes the official Feature Handoff Package v1.0 foundation as the final, language-independent output of `tllib-specs`.

- adds six JSON Schemas and the authority model;
- adds eight versioned shared structural contracts;
- compiles the autonomous pilot package `TLC-FC-00-MASTER-005` from its authoritative source chain;
- preserves unresolved and opaque scientific material without invention;
- encodes partially constrained strategy semantics rather than copying a total algorithm sequence;
- adds validation, standalone bundle resolution, a dedicated GitHub Actions workflow, and the low-level simulation report;
- announces the handoff in the repository README without claiming all 166 packages are generated.

## Protected sources

No files under `maths/`, `registry/math-contracts/`, `registry/ir/`, `registry/test-plans/`, `registry/optimized-ir/`, `registry/algorithms/`, `registry/oracles/`, or `registry/global-reconciliation/` were modified.

## Validation

The dedicated workflow runs:

- `python tools/handoff/validate_handoff.py`
- `python tools/handoff/export_bundle.py TLC-FC-00-MASTER-005 --check`

## Merge

Squash merge only after all required checks pass.

## Summary by Sourcery

Establish the Feature Handoff Package v1.0 as the language-independent downstream output, including schemas, shared contracts, a pilot feature package, validation/export tools, and CI integration.

New Features:
- Introduce the handoff package tree with JSON Schemas, catalog, and language-independent feature artifacts for downstream implementers.
- Add the pilot feature package TLC-FC-00-MASTER-005 and eight reusable shared structural contracts.
- Document the handoff authority model and implementation freedoms in new README sections and reports.

Enhancements:
- Extend the main README with a Feature Handoff section linking the finalized structural specification to downstream packages.

CI:
- Add a GitHub Actions workflow to validate handoff schemas and packages and to resolve the pilot bundle on each change.

Tests:
- Add a low-level pilot simulation report to validate downstream implementability without prescribing a specific language implementation.

Chores:
- Add Python tooling to validate the handoff package foundation and export standalone feature bundles for consumers.