### PR TITLE
fix(handoff): support progressive domain package validation

### DIFF
--- a/.github/workflows/handoff.yml
+++ b/.github/workflows/handoff.yml
@@ -2,21 +2,31 @@ name: Feature handoff validation
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, handoff/integration-v1]
     paths:
-      - 'handoff/**'
+      - 'handoff/domains/**'
+      - 'handoff/schemas/**'
+      - 'handoff/features/**'
+      - 'handoff/shared/**'
+      - 'handoff/catalog.json'
+      - 'handoff/README.md'
       - 'tools/handoff/**'
-      - 'reports/handoff/**'
+      - 'reports/handoff/infrastructure/**'
       - 'README.md'
-      - '.github/workflows/handoff.yml'
+      - '.github/workflows/*handoff*'
   push:
-    branches: [main]
+    branches: [main, handoff/integration-v1]
     paths:
-      - 'handoff/**'
+      - 'handoff/domains/**'
+      - 'handoff/schemas/**'
+      - 'handoff/features/**'
+      - 'handoff/shared/**'
+      - 'handoff/catalog.json'
+      - 'handoff/README.md'
       - 'tools/handoff/**'
-      - 'reports/handoff/**'
+      - 'reports/handoff/infrastructure/**'
       - 'README.md'
-      - '.github/workflows/handoff.yml'
+      - '.github/workflows/*handoff*'
   workflow_dispatch:
 
 permissions:
@@ -33,9 +43,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install validator dependency
-        run: python -m pip install --disable-pip-version-check --quiet jsonschema
-      - name: Validate packages and schemas
+      - name: Install validator dependencies
+        run: python -m pip install --disable-pip-version-check --quiet jsonschema pyyaml
+      - name: Validate packages, schemas, and progressive populations
         id: validate
         shell: bash
         run: |
@@ -48,6 +58,8 @@ jobs:
             printf 'diagnostic=%s\n' "$diagnostic" >> "$GITHUB_OUTPUT"
             exit "$status"
           fi
+      - name: Run progressive validation logical scenarios
+        run: python tools/handoff/validate_handoff.py --self-test
       - name: Upload validation diagnostics
         if: failure()
         uses: actions/upload-artifact@v4

--- a/handoff/README.md
+++ b/handoff/README.md
@@ -21,9 +21,32 @@ A README or example cannot create an obligation absent from the normative JSON f
 - `schemas/` defines the machine-validatable v1.0 structures.
 - `shared/` contains reusable, versioned structural contracts.
 - `features/` contains autonomous feature packages.
-- `catalog.json` indexes the packages currently compiled into this output.
+- `domains/<domain-slug>/catalog.json` declares a complete domain population when that domain is compiled.
+- `catalog.json` remains the foundation-level catalog until global integration.
 
 Markdown is the human interface. JSON is the normative machine interface. JSON Schema validates structure. YAML remains an upstream pipeline format and is not part of the handoff interface.
+
+## Progressive domain validation
+
+The foundation pilot `TLC-FC-00-MASTER-005` is always required. Domain compilation is progressive: no domain catalog is required for the foundation alone, but every catalog that is present is authoritative for its complete local population.
+
+For each directory under `handoff/domains/`, `catalog.json` must conform to `schemas/domain-catalog.schema.json`. It must list every package for that domain in authoritative order, point to `handoff/features/<feature-id>`, declare the exact union of shared dependencies used by those packages, and reference `registry/domain-finalization/<domain-slug>/feature-status.yaml` as its authoritative inventory.
+
+The validator computes the expected feature population as:
+
+```text
+{TLC-FC-00-MASTER-005} union all feature IDs declared by present domain catalogs
+```
+
+That computed population must exactly equal the directories under `handoff/features/`. Therefore:
+
+- a complete Master catalog may coexist with no Disciple catalog;
+- a later Disciple catalog becomes mandatory only when Disciple is introduced;
+- a declared but missing package is rejected;
+- an undeclared package is rejected;
+- duplicate feature ownership across domains is rejected;
+- a partial domain catalog is rejected;
+- the pilot-specific identity, status, reference, error, strategy, and acceptance checks remain active.
 
 ## Scientific boundary
 
@@ -31,8 +54,8 @@ The handoff compiles observable obligations conservatively. It preserves unresol
 
 ## Validation and export
 
-`tools/handoff/validate_handoff.py` validates package structure, cross-file coherence, dependency resolution, traceability, and the pilot package. `tools/handoff/export_bundle.py` resolves one feature with all required shared contracts and emits a directory bundle plus `bundle-lock.json`; generated archives are not committed.
+`tools/handoff/validate_handoff.py` validates package structure, cross-file coherence, progressive population, authoritative domain inventories, dependency resolution, traceability, and the pilot package. Its `--self-test` mode exercises the logical foundation, completeness, orphan, collision, progressive-domain, and altered-pilot scenarios. `tools/handoff/export_bundle.py` resolves one feature with all required shared contracts and emits a directory bundle plus `bundle-lock.json`; generated archives are not committed.
 
 ## Current scope
 
-Version 1.0 establishes eight shared contracts and the pilot package `TLC-FC-00-MASTER-005`. The complete catalog of 166 feature packages is not yet finalized.
+Version 1.0 establishes eight shared contracts and the pilot package `TLC-FC-00-MASTER-005`. The complete catalog of 166 feature packages is not yet finalized, and domains may be integrated independently only as complete catalog-declared populations.

--- a/handoff/schemas/domain-catalog.schema.json
+++ b/handoff/schemas/domain-catalog.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tradition-learning-community.github.io/tllib-specs/handoff/schemas/domain-catalog.schema.json",
+  "title": "Feature Handoff Domain Catalog v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "package_model_version",
+    "domain",
+    "domain_index",
+    "expected_feature_count",
+    "ordered_feature_ids",
+    "feature_packages",
+    "statuses",
+    "shared_dependencies",
+    "metadata"
+  ],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "package_model_version": {"const": "1.0.0"},
+    "domain": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "domain_index": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 99
+    },
+    "expected_feature_count": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "ordered_feature_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^TLC-FC-[0-9]{2}-[A-Z][A-Z0-9-]*-[0-9]{3}$"
+      }
+    },
+    "feature_packages": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["feature_id", "path", "package_version", "status"],
+        "properties": {
+          "feature_id": {
+            "type": "string",
+            "pattern": "^TLC-FC-[0-9]{2}-[A-Z][A-Z0-9-]*-[0-9]{3}$"
+          },
+          "path": {
+            "type": "string",
+            "pattern": "^handoff/features/TLC-FC-[0-9]{2}-[A-Z][A-Z0-9-]*-[0-9]{3}$"
+          },
+          "package_version": {
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          },
+          "status": {
+            "enum": ["draft", "pilot", "validated", "finalized", "deprecated", "superseded"]
+          }
+        }
+      }
+    },
+    "statuses": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["population", "validation"],
+      "properties": {
+        "population": {"const": "complete"},
+        "validation": {"enum": ["pending", "validated"]}
+      }
+    },
+    "shared_dependencies": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["shared_contract_id", "version"],
+        "properties": {
+          "shared_contract_id": {
+            "type": "string",
+            "pattern": "^TLC-HC-[A-Z0-9-]+$"
+          },
+          "version": {
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          }
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authoritative_inventory", "generated_by", "validation_tool"],
+      "properties": {
+        "authoritative_inventory": {
+          "type": "string",
+          "pattern": "^registry/domain-finalization/[a-z0-9]+(?:-[a-z0-9]+)*/feature-status\\.yaml$"
+        },
+        "generated_by": {"type": "string", "minLength": 1},
+        "validation_tool": {"const": "tools/handoff/validate_handoff.py"},
+        "source_commit": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    }
+  }
+}

--- a/reports/handoff/infrastructure/progressive-validation.md
+++ b/reports/handoff/infrastructure/progressive-validation.md
@@ -1,0 +1,155 @@
+# Progressive Domain Validation Infrastructure
+
+## Initial blocker
+
+The Feature Handoff Package v1.0 foundation validator contained a foundation-only population assertion:
+
+```text
+handoff/features/ must contain exactly TLC-FC-00-MASTER-005
+```
+
+That assertion correctly protected the initial pilot, but it made every later domain compilation invalid by construction. A second foundation assumption called the pilot-specific validator for every discovered feature package, which would also reject any non-pilot package. Domain work was not permitted to modify the global validator, so the incompatibility required a dedicated infrastructure change before Master, Disciple, or any other domain could be integrated.
+
+The handoff workflow also listened only to pull requests targeting `main`. Domain pull requests target `handoff/integration-v1`, so they could not receive the dedicated handoff validation without a workflow update.
+
+## Removed rule
+
+The validator no longer enforces:
+
+```text
+v1.0 foundation must contain only the declared pilot feature
+```
+
+It also no longer applies `validate_pilot()` to every feature package. Pilot validation is invoked only for `TLC-FC-00-MASTER-005`, and the validator separately proves that this pilot remains present and validated.
+
+## Progressive population rule
+
+The expected feature population is now computed as:
+
+```text
+foundation pilot
+union
+all feature IDs declared by every currently present domain catalog
+```
+
+The computed set must exactly equal the directory names under `handoff/features/`.
+
+This gives progressive integration without weakening completeness:
+
+- no domain catalog is required for the foundation-only state;
+- a present domain catalog must declare its complete local population;
+- every declared feature must have exactly one package directory;
+- every package directory must be declared, except the foundation pilot before a Master catalog exists;
+- a feature may be owned by only one domain catalog;
+- package paths, versions, package statuses, and domain identities must agree with the catalog;
+- the exact union of package shared dependencies must agree with the catalog dependency summary.
+
+`handoff/catalog.json` remains a foundation catalog. It must remain syntactically coherent and preserve the pilot and the eight shared contracts, but it is not used as the progressive domain population authority.
+
+## Domain catalog contract
+
+A domain is declared by:
+
+```text
+handoff/domains/<domain-slug>/catalog.json
+```
+
+Every directory under `handoff/domains/` must contain a catalog. The catalog is validated against `handoff/schemas/domain-catalog.schema.json` and declares:
+
+- schema and package-model versions;
+- domain slug and numerical domain index;
+- expected feature count;
+- authoritative ordered feature IDs;
+- one package entry per feature, in the same order;
+- complete-population and validation statuses;
+- the exact shared dependency union;
+- the authoritative domain inventory and validation metadata.
+
+The validator rejects a catalog if its count, list, package entries, order, paths, versions, statuses, dependencies, domain index, or domain identity disagree.
+
+## Authoritative inventory validation
+
+The validator does not embed the 166 feature IDs in Python. Each catalog must reference:
+
+```text
+registry/domain-finalization/<domain-slug>/feature-status.yaml
+```
+
+The catalog's ordered feature population must exactly match the `features` list in that authoritative domain inventory. The inventory count and domain identity are also checked. For every authoritative feature, the finalized IR, algorithm specification, and acceptance oracle paths must exist under their established domain trees.
+
+This dependency is stable because domain finalization already defines the selected package population and because YAML parsing is read-only. The workflow installs `PyYAML` alongside `jsonschema`; no upstream YAML is modified or exposed as a handoff interface.
+
+## Pilot controls preserved
+
+`TLC-FC-00-MASTER-005` remains mandatory while model v1.0 declares it as the foundation pilot. The following checks remain active:
+
+- exact feature identity;
+- pilot, partially-defined, structural-only statuses;
+- required object and relation references;
+- required stable error codes;
+- exactly one structural operation;
+- partially constrained strategy mode;
+- all eight oracle acceptance identifiers.
+
+The logical self-test deliberately alters the pilot strategy and verifies that the pilot validator still rejects the package.
+
+## Individual package controls preserved
+
+Every discovered package still receives the existing checks:
+
+- JSON syntax and JSON Schema validation;
+- cross-file feature identity;
+- package-version consistency;
+- required and declared files;
+- `examples.json` presence consistency;
+- required non-empty traceability categories and resolvable repository-relative paths;
+- globally unique acceptance test IDs;
+- operation-scoped unique error codes;
+- valid partial-order strategy references and prescribed-strategy evidence;
+- exact manifest/contract shared dependency agreement and resolution;
+- absence of normative C++, Rust, Ruby, or Python code.
+
+## Logical scenarios
+
+The validator provides `--self-test`, and CI executes it after repository validation.
+
+### Accepted
+
+A. **Foundation only** — `MASTER-005` is present and no domain catalog exists.
+
+B. **Complete Master** — the Master catalog declares 16 IDs and all 16 package directories exist.
+
+E. **Progressive domain** — Master is complete while Disciple is absent and undeclared.
+
+F. **Two complete domains** — Master and Disciple are both complete and their feature populations are disjoint.
+
+### Rejected
+
+C. **Incomplete Master** — the catalog declares 16 features but only 15 package directories exist.
+
+D. **Orphan package** — a Disciple package exists without a Disciple catalog.
+
+G. **Collision** — two domains declare the same feature ID.
+
+H. **Altered pilot** — the foundation pilot no longer satisfies its specific strategy or other source-backed controls.
+
+The repository-level validator adds stronger checks beyond these set-based self-tests: authoritative inventory equality, package schemas, dependency summaries, path resolution, statuses, versions, traceability, and all preserved package-level controls.
+
+## Parallel domain integration
+
+Each domain pull request is validated from its own merged checkout against the current target branch content. After one domain merges, a second domain branch created from an older `handoff/integration-v1` head must be realigned before merge so its validation includes the already integrated catalog and packages.
+
+Recommended realignment instructions for domain task owners:
+
+1. Update the domain branch from the latest `handoff/integration-v1` using the project's normal GitHub branch-update or rebase workflow.
+2. Resolve Git conflicts without deleting or rewriting another domain's catalog or feature packages.
+3. Keep the domain's own complete catalog under `handoff/domains/<domain-slug>/catalog.json`.
+4. Ensure its feature IDs are disjoint from every catalog already present.
+5. Re-run the handoff workflow through the updated pull request.
+6. Do not edit `tools/handoff/validate_handoff.py`, handoff schemas, shared contracts, or another domain's packages from a domain compilation task.
+
+Automatic Git conflict resolution is intentionally out of scope. Population collision and incompleteness are rejected deterministically once the branch is evaluated.
+
+## Files and scientific boundary
+
+This infrastructure change modifies only the generic validator, the domain catalog schema, handoff documentation, the handoff workflow, and this report. It creates no feature package, scientific content, contract, IR, test plan, algorithm, oracle, or shared-contract change.

--- a/tools/handoff/validate_handoff.py
+++ b/tools/handoff/validate_handoff.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
-"""Validate the Feature Handoff Package v1.0 foundation."""
+"""Validate progressive Feature Handoff Package v1.0 populations."""
 
 from __future__ import annotations
 
+import copy
 import json
 import re
 import sys
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 from jsonschema import Draft202012Validator
+from yaml import YAMLError, safe_load
 
 ROOT = Path(__file__).resolve().parents[2]
 HANDOFF = ROOT / "handoff"
@@ -26,6 +28,7 @@ EXPECTED_SHARED = {
     "TLC-HC-DESCRIPTOR-ENVELOPE",
 }
 PILOT_ID = "TLC-FC-00-MASTER-005"
+FEATURE_ID_PATTERN = re.compile(r"^TLC-FC-(?P<index>[0-9]{2})-(?P<domain>[A-Z][A-Z0-9-]*)-[0-9]{3}$")
 REQUIRED_TRACE_CATEGORIES = (
     "scientific_sources",
     "mathematical_contracts",
@@ -54,6 +57,16 @@ def load_json(path: Path) -> Any:
         raise ValidationFailure(f"missing required file: {path.relative_to(ROOT)}") from exc
     except json.JSONDecodeError as exc:
         raise ValidationFailure(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+
+
+@lru_cache(maxsize=None)
+def load_yaml(path: Path) -> Any:
+    try:
+        return safe_load(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationFailure(f"missing authoritative inventory: {path.relative_to(ROOT)}") from exc
+    except YAMLError as exc:
+        raise ValidationFailure(f"invalid YAML in {path.relative_to(ROOT)}: {exc}") from exc
 
 
 def validate_schema(instance: Any, schema: Any, path: Path) -> None:
@@ -193,6 +206,144 @@ def validate_pilot(contract: dict[str, Any], acceptance: dict[str, Any], manifes
         fail("pilot does not preserve all eight oracle acceptance identifiers")
 
 
+def feature_identity(feature_id: str) -> tuple[int, str]:
+    match = FEATURE_ID_PATTERN.fullmatch(feature_id)
+    if match is None:
+        fail(f"invalid feature identifier: {feature_id}")
+    return int(match.group("index")), match.group("domain").lower()
+
+
+def register_feature_owner(owners: dict[str, str], feature_id: str, domain: str) -> None:
+    previous = owners.get(feature_id)
+    if previous is not None:
+        fail(f"feature {feature_id} is declared by both {previous} and {domain}")
+    owners[feature_id] = domain
+
+
+def validate_progressive_population(actual_feature_ids: set[str], declared_owners: dict[str, str]) -> None:
+    expected_feature_ids = set(declared_owners) | {PILOT_ID}
+    missing = sorted(expected_feature_ids - actual_feature_ids)
+    orphaned = sorted(actual_feature_ids - expected_feature_ids)
+    if missing or orphaned:
+        parts: list[str] = []
+        if missing:
+            parts.append(f"missing declared packages: {missing}")
+        if orphaned:
+            parts.append(f"orphan packages without a domain catalog: {orphaned}")
+        fail("progressive feature population mismatch: " + "; ".join(parts))
+
+
+def validate_authoritative_inventory(domain: str, catalog: dict[str, Any]) -> None:
+    inventory_value = catalog["metadata"]["authoritative_inventory"]
+    expected_value = f"registry/domain-finalization/{domain}/feature-status.yaml"
+    if inventory_value != expected_value:
+        fail(f"domain {domain} must use authoritative inventory {expected_value}")
+    if not safe_repo_path(inventory_value):
+        fail(f"unsafe authoritative inventory path for domain {domain}: {inventory_value}")
+
+    inventory = load_yaml(ROOT / inventory_value)
+    if not isinstance(inventory, dict):
+        fail(f"authoritative inventory is not an object for domain {domain}")
+    if inventory.get("domain") != domain:
+        fail(f"authoritative inventory domain mismatch for {domain}")
+    authoritative_features = inventory.get("features")
+    if not isinstance(authoritative_features, list):
+        fail(f"authoritative inventory has no feature list for domain {domain}")
+    authoritative_ids = [item.get("feature_id") for item in authoritative_features if isinstance(item, dict)]
+    if len(authoritative_ids) != len(authoritative_features) or any(not isinstance(item, str) for item in authoritative_ids):
+        fail(f"authoritative inventory contains an invalid feature entry for domain {domain}")
+    if inventory.get("feature_count") != len(authoritative_ids):
+        fail(f"authoritative inventory feature count mismatch for domain {domain}")
+    if catalog["ordered_feature_ids"] != authoritative_ids:
+        fail(f"domain catalog population or order differs from authoritative inventory for {domain}")
+
+    for feature_id in authoritative_ids:
+        required_artifacts = (
+            ROOT / "registry" / "optimized-ir" / domain / feature_id / "ir.yaml",
+            ROOT / "registry" / "algorithms" / domain / feature_id / "algorithm.yaml",
+            ROOT / "registry" / "oracles" / domain / feature_id / "oracle.yaml",
+        )
+        for artifact in required_artifacts:
+            if not artifact.is_file():
+                fail(f"authoritative feature artifact is missing: {artifact.relative_to(ROOT)}")
+
+
+def discover_domain_catalogs(
+    schema: dict[str, Any], shared_versions: dict[str, str]
+) -> tuple[dict[str, dict[str, Any]], dict[str, str], dict[str, dict[str, Any]]]:
+    domains_root = HANDOFF / "domains"
+    if not domains_root.exists():
+        return {}, {}, {}
+    if not domains_root.is_dir():
+        fail("handoff/domains must be a directory when present")
+
+    non_directories = sorted(path.name for path in domains_root.iterdir() if not path.is_dir())
+    if non_directories:
+        fail(f"handoff/domains contains non-directory entries: {non_directories}")
+
+    catalogs: dict[str, dict[str, Any]] = {}
+    owners: dict[str, str] = {}
+    package_entries: dict[str, dict[str, Any]] = {}
+    for domain_dir in sorted(path for path in domains_root.iterdir() if path.is_dir()):
+        catalog_path = domain_dir / "catalog.json"
+        if not catalog_path.is_file():
+            fail(f"domain directory lacks catalog.json: {domain_dir.relative_to(ROOT)}")
+        catalog = load_json(catalog_path)
+        validate_schema(catalog, schema, catalog_path)
+        domain = domain_dir.name
+        if catalog["domain"] != domain:
+            fail(f"domain catalog identity mismatch in {catalog_path.relative_to(ROOT)}")
+
+        ordered_ids = catalog["ordered_feature_ids"]
+        entries = catalog["feature_packages"]
+        if catalog["expected_feature_count"] != len(ordered_ids):
+            fail(f"expected_feature_count does not match ordered_feature_ids for domain {domain}")
+        if len(entries) != len(ordered_ids):
+            fail(f"feature_packages count does not match ordered_feature_ids for domain {domain}")
+        if [entry["feature_id"] for entry in entries] != ordered_ids:
+            fail(f"feature_packages must match ordered_feature_ids exactly and in order for domain {domain}")
+
+        for feature_id, entry in zip(ordered_ids, entries, strict=True):
+            domain_index, identifier_domain = feature_identity(feature_id)
+            if domain_index != catalog["domain_index"]:
+                fail(f"feature {feature_id} has the wrong domain index for catalog {domain}")
+            if identifier_domain != domain:
+                fail(f"feature {feature_id} is declared in the wrong domain catalog {domain}")
+            expected_path = f"handoff/features/{feature_id}"
+            if entry["path"] != expected_path:
+                fail(f"feature package path mismatch for {feature_id}: expected {expected_path}")
+            register_feature_owner(owners, feature_id, domain)
+            package_entries[feature_id] = entry
+
+        catalog_dependencies = {
+            (item["shared_contract_id"], item["version"]) for item in catalog["shared_dependencies"]
+        }
+        for dependency_id, version in catalog_dependencies:
+            if shared_versions.get(dependency_id) != version:
+                fail(f"unresolved or incompatible domain dependency {dependency_id}@{version} for {domain}")
+
+        validate_authoritative_inventory(domain, catalog)
+        catalogs[domain] = catalog
+
+    return catalogs, owners, package_entries
+
+
+def validate_global_foundation_catalog() -> None:
+    catalog = load_json(HANDOFF / "catalog.json")
+    if catalog.get("model_version") != "1.0.0" or catalog.get("complete_166_feature_catalog_finalized") is not False:
+        fail("catalog foundation status is incorrect")
+    if {entry["shared_contract_id"] for entry in catalog["shared_contracts"]} != EXPECTED_SHARED:
+        fail("catalog shared contract population mismatch")
+    feature_ids = [entry["feature_id"] for entry in catalog["features"]]
+    if len(feature_ids) != len(set(feature_ids)):
+        fail("catalog contains duplicate feature entries")
+    if PILOT_ID not in feature_ids:
+        fail("catalog does not preserve the foundation pilot")
+    for entry in catalog["shared_contracts"] + catalog["features"]:
+        if not safe_repo_path(entry["path"]) or not (ROOT / entry["path"]).is_dir():
+            fail(f"catalog path does not resolve: {entry['path']}")
+
+
 def main() -> int:
     if not HANDOFF.is_dir():
         fail("handoff directory is missing")
@@ -204,6 +355,7 @@ def main() -> int:
         "examples": "examples.schema.json",
         "traceability": "traceability.schema.json",
         "shared_contract": "shared-contract.schema.json",
+        "domain_catalog": "domain-catalog.schema.json",
     }
     schemas = {name: load_json(SCHEMAS / filename) for name, filename in schema_names.items()}
     for name, schema in schemas.items():
@@ -245,16 +397,28 @@ def main() -> int:
     for package_dir in shared_dirs:
         manifest = load_json(package_dir / "manifest.json")
         for dependency in manifest["shared_dependencies"]:
-            dep_id = dependency["shared_contract_id"]
-            if dep_id not in shared_versions:
-                fail(f"unresolved shared dependency {dep_id} in {package_dir.relative_to(ROOT)}")
-            if dependency["version"] != shared_versions[dep_id]:
-                fail(f"incompatible shared dependency {dep_id} in {package_dir.relative_to(ROOT)}")
+            dependency_id = dependency["shared_contract_id"]
+            if dependency_id not in shared_versions:
+                fail(f"unresolved shared dependency {dependency_id} in {package_dir.relative_to(ROOT)}")
+            if dependency["version"] != shared_versions[dependency_id]:
+                fail(f"incompatible shared dependency {dependency_id} in {package_dir.relative_to(ROOT)}")
 
-    feature_dirs = sorted(path for path in (HANDOFF / "features").iterdir() if path.is_dir())
-    if {path.name for path in feature_dirs} != {PILOT_ID}:
-        fail("v1.0 foundation must contain only the declared pilot feature")
+    catalogs, declared_owners, catalog_package_entries = discover_domain_catalogs(
+        schemas["domain_catalog"], shared_versions
+    )
 
+    features_root = HANDOFF / "features"
+    if not features_root.is_dir():
+        fail("handoff/features directory is missing")
+    non_feature_entries = sorted(path.name for path in features_root.iterdir() if not path.is_dir())
+    if non_feature_entries:
+        fail(f"handoff/features contains non-directory entries: {non_feature_entries}")
+    feature_dirs = sorted(path for path in features_root.iterdir() if path.is_dir())
+    actual_feature_ids = {path.name for path in feature_dirs}
+    validate_progressive_population(actual_feature_ids, declared_owners)
+
+    domain_dependency_unions: dict[str, set[tuple[str, str]]] = {domain: set() for domain in catalogs}
+    pilot_validated = False
     for package_dir in feature_dirs:
         manifest = load_json(package_dir / "manifest.json")
         contract = load_json(package_dir / "contract.json")
@@ -267,6 +431,7 @@ def main() -> int:
         validate_schema(trace, schemas["traceability"], package_dir / "traceability.json")
         if examples is not None:
             validate_schema(examples, schemas["examples"], package_dir / "examples.json")
+
         feature_id = package_dir.name
         if manifest["feature_id"] != feature_id or contract["feature"]["feature_id"] != feature_id or acceptance["applies_to"] != feature_id or trace["applies_to"] != feature_id or (examples and examples["applies_to"] != feature_id):
             fail(f"feature_id mismatch in {package_dir.relative_to(ROOT)}")
@@ -275,40 +440,117 @@ def main() -> int:
             versions.add(examples["package_version"])
         if len(versions) != 1:
             fail(f"package version mismatch in {package_dir.relative_to(ROOT)}")
+
+        owner = declared_owners.get(feature_id)
+        expected_domain = owner if owner is not None else "master"
+        if manifest["domain"] != expected_domain or contract["feature"]["domain"] != expected_domain:
+            fail(f"feature {feature_id} package domain does not match {expected_domain}")
+        if owner is not None:
+            catalog_entry = catalog_package_entries[feature_id]
+            if catalog_entry["package_version"] != manifest["package_version"]:
+                fail(f"domain catalog package version mismatch for {feature_id}")
+            if catalog_entry["status"] != manifest["statuses"]["package"]:
+                fail(f"domain catalog package status mismatch for {feature_id}")
+
         package_files(package_dir, manifest)
         validate_trace_paths(trace, package_dir / "traceability.json", require_nonempty=True)
         validate_acceptance_ids(acceptance, global_test_ids, package_dir / "acceptance.json")
         validate_error_uniqueness(contract, package_dir / "contract.json")
         validate_strategy(contract, trace, package_dir / "contract.json")
         validate_no_normative_language_code(package_dir)
-        manifest_deps = {(item["shared_contract_id"], item["version"]) for item in manifest["shared_dependencies"]}
-        contract_deps = {(item["shared_contract_id"], item["version"]) for item in contract["dependencies"]}
-        if manifest_deps != contract_deps:
+        manifest_dependencies = {(item["shared_contract_id"], item["version"]) for item in manifest["shared_dependencies"]}
+        contract_dependencies = {(item["shared_contract_id"], item["version"]) for item in contract["dependencies"]}
+        if manifest_dependencies != contract_dependencies:
             fail(f"manifest and contract dependencies differ in {package_dir.relative_to(ROOT)}")
-        for dep_id, version in manifest_deps:
-            if shared_versions.get(dep_id) != version:
-                fail(f"unresolved or incompatible dependency {dep_id}@{version} in {package_dir.relative_to(ROOT)}")
-        validate_pilot(contract, acceptance, manifest)
+        for dependency_id, version in manifest_dependencies:
+            if shared_versions.get(dependency_id) != version:
+                fail(f"unresolved or incompatible dependency {dependency_id}@{version} in {package_dir.relative_to(ROOT)}")
+        if owner is not None:
+            domain_dependency_unions[owner].update(manifest_dependencies)
 
-    catalog = load_json(HANDOFF / "catalog.json")
-    if catalog.get("model_version") != "1.0.0" or catalog.get("complete_166_feature_catalog_finalized") is not False:
-        fail("catalog foundation status is incorrect")
-    if {entry["shared_contract_id"] for entry in catalog["shared_contracts"]} != EXPECTED_SHARED:
-        fail("catalog shared contract population mismatch")
-    if {entry["feature_id"] for entry in catalog["features"]} != {PILOT_ID}:
-        fail("catalog pilot population mismatch")
-    for entry in catalog["shared_contracts"] + catalog["features"]:
-        if not safe_repo_path(entry["path"]) or not (ROOT / entry["path"]).is_dir():
-            fail(f"catalog path does not resolve: {entry['path']}")
+        if feature_id == PILOT_ID:
+            validate_pilot(contract, acceptance, manifest)
+            pilot_validated = True
 
-    print("Feature Handoff Package v1.0 validation passed.")
-    print(f"Validated {len(shared_dirs)} shared contracts and {len(feature_dirs)} feature package.")
+    if not pilot_validated:
+        fail("foundation pilot was not validated")
+
+    for domain, catalog in catalogs.items():
+        catalog_dependencies = {
+            (item["shared_contract_id"], item["version"]) for item in catalog["shared_dependencies"]
+        }
+        if catalog_dependencies != domain_dependency_unions[domain]:
+            fail(f"domain catalog shared dependencies do not exactly match package dependencies for {domain}")
+
+    validate_global_foundation_catalog()
+
+    print("Feature Handoff Package v1.0 progressive validation passed.")
+    print(
+        f"Validated {len(shared_dirs)} shared contracts, {len(feature_dirs)} feature packages, "
+        f"and {len(catalogs)} complete domain catalogs."
+    )
     return 0
+
+
+def expect_failure(action: Callable[[], None], scenario: str) -> None:
+    try:
+        action()
+    except ValidationFailure:
+        return
+    fail(f"logical self-test {scenario} did not reject invalid input")
+
+
+def run_progressive_self_tests() -> int:
+    master_ids = {f"TLC-FC-00-MASTER-{index:03d}" for index in range(1, 17)}
+    disciple_ids = {f"TLC-FC-01-DISCIPLE-{index:03d}" for index in range(1, 11)}
+    master_owners = {feature_id: "master" for feature_id in master_ids}
+    two_domain_owners = {**master_owners, **{feature_id: "disciple" for feature_id in disciple_ids}}
+
+    validate_progressive_population({PILOT_ID}, {})  # A: foundation only
+    validate_progressive_population(master_ids, master_owners)  # B: complete Master
+    expect_failure(
+        lambda: validate_progressive_population(set(sorted(master_ids)[:-1]), master_owners),
+        "C incomplete Master catalog",
+    )
+    expect_failure(
+        lambda: validate_progressive_population({PILOT_ID, "TLC-FC-01-DISCIPLE-001"}, {}),
+        "D orphan package",
+    )
+    validate_progressive_population(master_ids, master_owners)  # E: progressive Master only
+    validate_progressive_population(master_ids | disciple_ids, two_domain_owners)  # F: two domains
+
+    collision_owners: dict[str, str] = {}
+    register_feature_owner(collision_owners, PILOT_ID, "master")
+    expect_failure(lambda: register_feature_owner(collision_owners, PILOT_ID, "disciple"), "G collision")
+
+    pilot_dir = HANDOFF / "features" / PILOT_ID
+    pilot_contract = load_json(pilot_dir / "contract.json")
+    pilot_acceptance = load_json(pilot_dir / "acceptance.json")
+    pilot_manifest = load_json(pilot_dir / "manifest.json")
+    validate_pilot(pilot_contract, pilot_acceptance, pilot_manifest)
+    altered_contract = copy.deepcopy(pilot_contract)
+    altered_contract["operations"][0]["strategy_contract"]["mode"] = "open"
+    expect_failure(
+        lambda: validate_pilot(altered_contract, pilot_acceptance, pilot_manifest),
+        "H altered pilot",
+    )
+
+    print("Progressive validation logical self-tests A-H passed.")
+    return 0
+
+
+def entrypoint() -> int:
+    arguments = sys.argv[1:]
+    if not arguments:
+        return main()
+    if arguments == ["--self-test"]:
+        return run_progressive_self_tests()
+    fail(f"unsupported arguments: {arguments}")
 
 
 if __name__ == "__main__":
     try:
-        raise SystemExit(main())
+        raise SystemExit(entrypoint())
     except ValidationFailure as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         raise SystemExit(1)

--- a/tools/handoff/validate_handoff.py
+++ b/tools/handoff/validate_handoff.py
@@ -442,7 +442,12 @@ def main() -> int:
             fail(f"package version mismatch in {package_dir.relative_to(ROOT)}")
 
         owner = declared_owners.get(feature_id)
-        expected_domain = owner if owner is not None else "master"
+        if owner is None:
+            if feature_id != PILOT_ID:
+                fail(f"feature {feature_id} has no domain catalog owner")
+            _, expected_domain = feature_identity(PILOT_ID)
+        else:
+            expected_domain = owner
         if manifest["domain"] != expected_domain or contract["feature"]["domain"] != expected_domain:
             fail(f"feature {feature_id} package domain does not match {expected_domain}")
         if owner is not None:


### PR DESCRIPTION
## Problem

The foundation validator hard-coded `handoff/features/` to contain only `TLC-FC-00-MASTER-005`. It also applied the pilot-specific validator to every discovered feature package. Together, those assumptions blocked every complete domain compilation by construction. Domain tasks are not authorized to modify the validator or global model, so a generic infrastructure correction is required before Master, Disciple, and the remaining domains can resume.

The dedicated handoff workflow also listened only to pull requests targeting `main`, while domain integration pull requests target `handoff/integration-v1`.

## Generic progressive validation

This PR replaces the pilot-only population rule with a computed population:

- the foundation pilot is always required;
- domain catalogs are discovered under `handoff/domains/<domain-slug>/catalog.json`;
- the expected feature directories are exactly the pilot plus the union of IDs declared by all catalogs currently present;
- a present domain must be complete according to its own catalog;
- missing declared packages, undeclared orphan packages, duplicate ownership, wrong-domain declarations, incorrect counts, incorrect paths, version/status mismatches, and dependency-summary mismatches are rejected;
- absent domains are not required yet.

Domain catalogs are validated by a dedicated JSON Schema and must exactly match the authoritative `registry/domain-finalization/<domain-slug>/feature-status.yaml` population and order. The validator does not duplicate the 166 identifiers in Python.

## Controls preserved

The existing validation of all eight shared contracts remains unchanged. Every feature package still receives its JSON Schema, identity, version, file, examples, traceability, global test-ID, error-code, strategy, shared-dependency, path-safety, and no-normative-language-code checks.

`TLC-FC-00-MASTER-005` remains mandatory and retains all specific identity, multidimensional status, scientific-reference, error-code, single-operation, partially-constrained-strategy, and eight-acceptance-ID controls. Pilot-specific validation is now correctly scoped only to that pilot.

`handoff/catalog.json` remains the foundation catalog and is not made authoritative for progressive domain populations.

## CI and logical scenarios

The handoff workflow now runs for PRs targeting `handoff/integration-v1`, watches domain/schema/feature/shared/infrastructure paths, installs read-only YAML support, and executes:

- repository validation;
- logical self-tests A-H covering foundation-only, complete and incomplete Master, orphan packages, progressive Master-only, Master plus Disciple, cross-domain collision, and altered pilot rejection;
- pilot bundle resolution.

## Scientific boundary

No file under `handoff/features/`, `handoff/shared/`, `handoff/catalog.json`, `registry/`, or `maths/` is modified. This PR creates no feature package and changes no scientific source, contract, IR, test plan, algorithm, oracle, or shared contract.

## Merge

Squash merge into `handoff/integration-v1` only after all checks pass.

## Summary by Sourcery

Introduce progressive multi-domain validation for the Feature Handoff v1.0 foundation and extend CI and docs to support domain catalogs and logical self-tests.

Enhancements:
- Relax the foundation validator from a pilot-only population check to a progressive model driven by per-domain catalogs plus the mandatory pilot.
- Add discovery and validation of domain catalogs and their authoritative inventories, including strict feature ownership, counts, paths, versions, statuses, and shared dependency summaries.
- Preserve and scope pilot-specific checks to the foundation pilot while maintaining existing package- and shared-contract-level validations.
- Add built-in logical self-tests for progressive population scenarios and a dedicated entrypoint flag to run them.
- Validate the global handoff catalog for structural coherence without treating it as the domain population authority.

CI:
- Update the handoff GitHub Actions workflow to run on main and handoff/integration-v1 branches with refined path filters, install YAML support, execute the enhanced validator, and run progressive logical self-tests.

Documentation:
- Expand handoff README with an explanation of progressive domain validation, domain catalog responsibilities, and the validator’s self-test mode.
- Add an infrastructure report documenting the progressive domain validation design, scenarios, and integration guidance for domains.