### PR TITLE
feat(handoff): compile Master feature packages

### DIFF
--- a/handoff/domains/master/catalog.json
+++ b/handoff/domains/master/catalog.json
@@ -122,7 +122,7 @@
   ],
   "statuses": {
     "population": "complete",
-    "validation": "pending"
+    "validation": "validated"
   },
   "shared_dependencies": [
     {

--- a/handoff/domains/master/catalog.json
+++ b/handoff/domains/master/catalog.json
@@ -1,0 +1,167 @@
+{
+  "schema_version": "1.0",
+  "package_model_version": "1.0.0",
+  "domain": "master",
+  "domain_index": 0,
+  "expected_feature_count": 16,
+  "ordered_feature_ids": [
+    "TLC-FC-00-MASTER-001",
+    "TLC-FC-00-MASTER-002",
+    "TLC-FC-00-MASTER-003",
+    "TLC-FC-00-MASTER-004",
+    "TLC-FC-00-MASTER-005",
+    "TLC-FC-00-MASTER-006",
+    "TLC-FC-00-MASTER-007",
+    "TLC-FC-00-MASTER-008",
+    "TLC-FC-00-MASTER-009",
+    "TLC-FC-00-MASTER-010",
+    "TLC-FC-00-MASTER-011",
+    "TLC-FC-00-MASTER-012",
+    "TLC-FC-00-MASTER-013",
+    "TLC-FC-00-MASTER-014",
+    "TLC-FC-00-MASTER-015",
+    "TLC-FC-00-MASTER-016"
+  ],
+  "feature_packages": [
+    {
+      "feature_id": "TLC-FC-00-MASTER-001",
+      "path": "handoff/features/TLC-FC-00-MASTER-001",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-002",
+      "path": "handoff/features/TLC-FC-00-MASTER-002",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-003",
+      "path": "handoff/features/TLC-FC-00-MASTER-003",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-004",
+      "path": "handoff/features/TLC-FC-00-MASTER-004",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-005",
+      "path": "handoff/features/TLC-FC-00-MASTER-005",
+      "package_version": "1.0.0",
+      "status": "pilot"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-006",
+      "path": "handoff/features/TLC-FC-00-MASTER-006",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-007",
+      "path": "handoff/features/TLC-FC-00-MASTER-007",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-008",
+      "path": "handoff/features/TLC-FC-00-MASTER-008",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-009",
+      "path": "handoff/features/TLC-FC-00-MASTER-009",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-010",
+      "path": "handoff/features/TLC-FC-00-MASTER-010",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-011",
+      "path": "handoff/features/TLC-FC-00-MASTER-011",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-012",
+      "path": "handoff/features/TLC-FC-00-MASTER-012",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-013",
+      "path": "handoff/features/TLC-FC-00-MASTER-013",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-014",
+      "path": "handoff/features/TLC-FC-00-MASTER-014",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-015",
+      "path": "handoff/features/TLC-FC-00-MASTER-015",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-00-MASTER-016",
+      "path": "handoff/features/TLC-FC-00-MASTER-016",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    }
+  ],
+  "statuses": {
+    "population": "complete",
+    "validation": "pending"
+  },
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "metadata": {
+    "authoritative_inventory": "registry/domain-finalization/master/feature-status.yaml",
+    "generated_by": "Feature Handoff Package compiler",
+    "validation_tool": "tools/handoff/validate_handoff.py",
+    "source_commit": "b29ebf1c56c0191452b8055956331aba4d71083a"
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-001/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-001/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-001 — Empirical threshold configuration
+
+This package defines the final observable handoff for Empirical threshold configuration.
+
+## What must be implemented
+
+Implement one structural descriptor operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-040. Valid relation references: TLC-SR-MASTER-037. Required unresolved identifiers: none.
+
+The output is an immutable structural descriptor. No external domain dependency is required.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Scientific canonicalization remains outside this package.

--- a/handoff/features/TLC-FC-00-MASTER-001/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-001/acceptance.json
@@ -1,0 +1,157 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-001",
+  "tests": [
+    {
+      "test_id": "MASTER-001-A01",
+      "applies_to": "DESCRIBE-EMPIRICAL-THRESHOLD-CONFIGURATION",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-001",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-040"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-037"
+        ],
+        "unresolved_refs": []
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-001-A02",
+      "applies_to": "DESCRIBE-EMPIRICAL-THRESHOLD-CONFIGURATION",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-001-A03",
+      "applies_to": "DESCRIBE-EMPIRICAL-THRESHOLD-CONFIGURATION",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-001-A04",
+      "applies_to": "DESCRIBE-EMPIRICAL-THRESHOLD-CONFIGURATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-001-A05",
+      "applies_to": "DESCRIBE-EMPIRICAL-THRESHOLD-CONFIGURATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-001-A06",
+      "applies_to": "DESCRIBE-EMPIRICAL-THRESHOLD-CONFIGURATION",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-001-A07",
+      "applies_to": "DESCRIBE-EMPIRICAL-THRESHOLD-CONFIGURATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-001-A08",
+      "applies_to": "DESCRIBE-EMPIRICAL-THRESHOLD-CONFIGURATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-001-A09",
+      "applies_to": "DESCRIBE-EMPIRICAL-THRESHOLD-CONFIGURATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-001/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-001/contract.json
@@ -1,0 +1,431 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-001",
+    "title": "Empirical threshold configuration",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Empirical threshold configuration references and emit a structural descriptor without scientific completion.",
+  "scope": {
+    "required": [
+      {
+        "id": "M001-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-001.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-001/ir.yaml"
+        ]
+      },
+      {
+        "id": "M001-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-040], relation references [TLC-SR-MASTER-037], and unresolved identifiers [] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-001/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M001-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-001/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M001-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M001-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M001-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M001-DEF-001",
+        "statement": "Scientific canonicalization remains outside this package."
+      },
+      {
+        "id": "M001-DEF-002",
+        "statement": "Concrete runtime representation and all low-level storage decisions remain implementation-defined."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "DESCRIBE-EMPIRICAL-THRESHOLD-CONFIGURATION",
+      "purpose": "Emit the authoritative structural descriptor without inventing executable scientific semantics.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-001"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-040"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-037"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M001-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-040] exactly and in order."
+            },
+            {
+              "id": "M001-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-037] exactly and in order."
+            },
+            {
+              "id": "M001-IN-003",
+              "statement": "Unresolved identifiers equal [] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable structural descriptor",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-001"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "declaration_descriptor"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": []
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M001-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M001-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M001-POST-001",
+          "statement": "The result is an immutable, traceable structural descriptor."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M001-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M001-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "construct structural descriptor",
+          "verify preservation obligations",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct structural descriptor",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify preservation obligations",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNSUPPORTED_EXECUTION_MODE",
+          "category": "unsupported_operation",
+          "condition": "An invented or unsupported scientific execution mode was requested.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-descriptor",
+      "status": "required",
+      "statement": "Expose the structural descriptor and stable errors."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M001-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M001-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-001/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-001/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-001",
+  "title": "Empirical threshold configuration",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "partially_defined",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-001/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-001/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-001",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-001/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-001",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "920dd456999704d9b09619253c18c0f0efbefc67"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-001/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-001",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "de7a995e7d60fa5c2b378faedf76965e773678b1"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-001/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-001",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "2eac72de0d9529df490b58651e3ed44a499a4b1e"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-001/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-001",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "e7e8797d16e9229ab47bb280623552c6e69761b3"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-001/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-001",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "60715a8bfc975b0658d26ef97e935cfc5f0133d8"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-001/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-001",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "be866b42182901f5215c058d121f0803d7d4fbe5"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-001/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-001",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "63ffe007258e8a0cd01af32e34a3e74088ccc404"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-002/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-002/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-002 — Theoretical constant configuration
+
+This package defines the final observable handoff for Theoretical constant configuration.
+
+## What must be implemented
+
+Implement one structural descriptor operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-039. Valid relation references: TLC-SR-MASTER-036. Required unresolved identifiers: TLC-GU-00329, TLC-UT-MASTER-012.
+
+The output is an immutable structural descriptor. No external domain dependency is required.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-002/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-002/acceptance.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-002",
+  "tests": [
+    {
+      "test_id": "MASTER-002-A01",
+      "applies_to": "DESCRIBE-THEORETICAL-CONSTANT-CONFIGURATION",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-002",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-039"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-036"
+        ],
+        "unresolved_refs": [
+          "TLC-GU-00329",
+          "TLC-UT-MASTER-012"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-002-A02",
+      "applies_to": "DESCRIBE-THEORETICAL-CONSTANT-CONFIGURATION",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-002-A03",
+      "applies_to": "DESCRIBE-THEORETICAL-CONSTANT-CONFIGURATION",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-002-A04",
+      "applies_to": "DESCRIBE-THEORETICAL-CONSTANT-CONFIGURATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-002-A05",
+      "applies_to": "DESCRIBE-THEORETICAL-CONSTANT-CONFIGURATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-002-A06",
+      "applies_to": "DESCRIBE-THEORETICAL-CONSTANT-CONFIGURATION",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-002-A07",
+      "applies_to": "DESCRIBE-THEORETICAL-CONSTANT-CONFIGURATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-002-A08",
+      "applies_to": "DESCRIBE-THEORETICAL-CONSTANT-CONFIGURATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-002-A09",
+      "applies_to": "DESCRIBE-THEORETICAL-CONSTANT-CONFIGURATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-002/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-002/contract.json
@@ -1,0 +1,446 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-002",
+    "title": "Theoretical constant configuration",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Theoretical constant configuration references and emit a structural descriptor without scientific completion.",
+  "scope": {
+    "required": [
+      {
+        "id": "M002-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-002.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-002/ir.yaml"
+        ]
+      },
+      {
+        "id": "M002-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-039], relation references [TLC-SR-MASTER-036], and unresolved identifiers [TLC-GU-00329, TLC-UT-MASTER-012] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-002/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M002-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-002/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M002-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M002-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M002-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M002-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00329, TLC-UT-MASTER-012 remain preserved unresolved."
+      },
+      {
+        "id": "M002-DEF-002",
+        "statement": "Concrete runtime representation and all low-level storage decisions remain implementation-defined."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "DESCRIBE-THEORETICAL-CONSTANT-CONFIGURATION",
+      "purpose": "Emit the authoritative structural descriptor without inventing executable scientific semantics.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-002"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-039"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-036"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00329",
+                "TLC-UT-MASTER-012"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M002-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-039] exactly and in order."
+            },
+            {
+              "id": "M002-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-036] exactly and in order."
+            },
+            {
+              "id": "M002-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00329, TLC-UT-MASTER-012] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable structural descriptor",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-002"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "declaration_descriptor"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00329",
+                "TLC-UT-MASTER-012"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M002-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M002-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M002-POST-001",
+          "statement": "The result is an immutable, traceable structural descriptor."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M002-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M002-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "construct structural descriptor",
+          "verify preservation obligations",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct structural descriptor",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify preservation obligations",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNSUPPORTED_EXECUTION_MODE",
+          "category": "unsupported_operation",
+          "condition": "An invented or unsupported scientific execution mode was requested.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-descriptor",
+      "status": "required",
+      "statement": "Expose the structural descriptor and stable errors."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M002-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M002-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-002/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-002/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-002",
+  "title": "Theoretical constant configuration",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-002/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-002/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-002",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-002/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-002",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "3c7bbf3bd6d80eeedaa1581810237a72fe68b17e"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-002/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-002",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "5741719a22f84820a2a4416779c458464585a9cb"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-002/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-002",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "a5ec509a80a1b0d34961000159555a8c235759ed"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-002/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-002",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "d3eb80f50fca5cdf1a199534a898b38ff1dc4d62"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-002/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-002",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "d1b20f35a2cafb937d7eee05ad5a0124ec040508"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-002/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-002",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "ca6d32a091e2dd7f16cede666f25dba652e0dd64"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-002/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-002",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "af9cc0631f01706772cb8097bf121f4eecd6e30f"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-003/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-003/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-003 — Admissible Master constraints
+
+This package defines the final observable handoff for Admissible Master constraints.
+
+## What must be implemented
+
+Implement one conditional opaque-provider operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-007, TLC-SO-MASTER-032, TLC-SO-MASTER-033. Valid relation references: TLC-SR-MASTER-006, TLC-SR-MASTER-030. Required unresolved identifiers: none.
+
+The output is an immutable envelope with explicit evaluated or unresolved status; any provider payload remains opaque and unchanged. The community domain is required read-only only when evaluated mode is requested.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Scientific canonicalization remains outside this package.

--- a/handoff/features/TLC-FC-00-MASTER-003/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-003/acceptance.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-003",
+  "tests": [
+    {
+      "test_id": "MASTER-003-A01",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-CONSTRAINTS",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-003",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-007",
+          "TLC-SO-MASTER-032",
+          "TLC-SO-MASTER-033"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-006",
+          "TLC-SR-MASTER-030"
+        ],
+        "unresolved_refs": []
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-003-A02",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-CONSTRAINTS",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-003-A03",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-CONSTRAINTS",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-003-A04",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-CONSTRAINTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-003-A05",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-CONSTRAINTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-003-A06",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-CONSTRAINTS",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-003-A07",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-CONSTRAINTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-003-A08",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-CONSTRAINTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-003-A09",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-CONSTRAINTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-003/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-003/contract.json
@@ -1,0 +1,476 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-003",
+    "title": "Admissible Master constraints",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Admissible Master constraints references and expose conditional, provider-defined evaluation without interpreting scientific content.",
+  "scope": {
+    "required": [
+      {
+        "id": "M003-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-003.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-003/ir.yaml"
+        ]
+      },
+      {
+        "id": "M003-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-007, TLC-SO-MASTER-032, TLC-SO-MASTER-033], relation references [TLC-SR-MASTER-006, TLC-SR-MASTER-030], and unresolved identifiers [] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-003/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M003-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-003/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M003-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M003-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M003-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M003-DEF-001",
+        "statement": "Scientific canonicalization remains outside this package."
+      },
+      {
+        "id": "M003-DEF-002",
+        "statement": "Executable scientific semantics are supplied only by an external opaque provider."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "EVALUATE-ADMISSIBLE-MASTER-CONSTRAINTS",
+      "purpose": "Expose conditional evaluation through an injected opaque provider while preserving all scientific boundaries.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-003"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-007",
+                "TLC-SO-MASTER-032",
+                "TLC-SO-MASTER-033"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-006",
+                "TLC-SR-MASTER-030"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_inputs",
+              "required": false,
+              "semantic_role": "provider-defined uninterpreted input",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M003-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-007, TLC-SO-MASTER-032, TLC-SO-MASTER-033] exactly and in order."
+            },
+            {
+              "id": "M003-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-006, TLC-SR-MASTER-030] exactly and in order."
+            },
+            {
+              "id": "M003-IN-003",
+              "statement": "Unresolved identifiers equal [] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable opaque evaluation envelope",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-003"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "opaque_evaluation_result"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": []
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": [
+                "community"
+              ]
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            },
+            {
+              "name": "opaque_payload",
+              "required": false,
+              "semantic_role": "provider result preserved without interpretation",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M003-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M003-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M003-POST-001",
+          "statement": "The wrapper returns an explicit unresolved status or preserves the provider response without interpretation."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M003-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M003-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "determine requested evaluation mode",
+          "gate required external symbol",
+          "invoke provider without transforming opaque input",
+          "preserve provider response",
+          "publish success, unresolved status, or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "determine requested evaluation mode",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "gate required external symbol",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "invoke provider without transforming opaque input",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "preserve provider response",
+            "after": "publish success, unresolved status, or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "implementation_defined",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_EXTERNAL_DEPENDENCY_UNAVAILABLE",
+          "category": "dependency",
+          "condition": "A required read-only external symbol is unavailable for evaluation.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_REQUIRED",
+          "category": "dependency",
+          "condition": "Evaluation was requested without an opaque provider.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_FAILURE",
+          "category": "provider_failure",
+          "condition": "The opaque provider reported failure.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "opaque-provider-evaluation",
+      "status": "required",
+      "statement": "Support unresolved mode and conditional evaluation through an injected opaque provider."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M003-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M003-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-003/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-003/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-003",
+  "title": "Admissible Master constraints",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "external_provider_required",
+    "execution": "conditionally_executable"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-003/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-003/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-003",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-003/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-003",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "4e996e64a99b1aec4a5693e779efd9cd25ef8d18"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-003/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-003",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "afc0e6b2d05438d8c16b7dee5449f192f1325f39"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-003/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-003",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "e93f2689e35337dc6040df107363e13153f5b417"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-003/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-003",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "f80680b964d993191d40461b255cab0d5b4add93"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-003/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-003",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "32d038c49ff0ced1027e0b924eec8d78772f8134"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-003/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-003",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "b41f6dffe1cf7a21d6bcefd53fe95f62fb1a64ec"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-003/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-003",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "572dc138e631b64a408eba845991b0a992422ecc"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-004/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-004/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-004 — Reserved Master constraints
+
+This package defines the final observable handoff for Reserved Master constraints.
+
+## What must be implemented
+
+Implement one conditional opaque-provider operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-004, TLC-SO-MASTER-006, TLC-SO-MASTER-017, TLC-SO-MASTER-018, TLC-SO-MASTER-019, TLC-SO-MASTER-020, TLC-SO-MASTER-021, TLC-SO-MASTER-034. Valid relation references: TLC-SR-MASTER-003, TLC-SR-MASTER-005, TLC-SR-MASTER-016, TLC-SR-MASTER-017, TLC-SR-MASTER-018, TLC-SR-MASTER-019, TLC-SR-MASTER-020, TLC-SR-MASTER-031, TLC-SR-MASTER-036, TLC-SR-MASTER-037. Required unresolved identifiers: TLC-GU-00319, TLC-GU-00321, TLC-GU-00328, TLC-GU-00329, TLC-GU-00330, TLC-GU-00332, TLC-GU-00339, TLC-RELISS-MASTER-003, TLC-UT-MASTER-002, TLC-UT-MASTER-004, TLC-UT-MASTER-011, TLC-UT-MASTER-012, TLC-UT-MASTER-013, TLC-UT-MASTER-015, TLC-UT-MASTER-022.
+
+The output is an immutable envelope with explicit evaluated or unresolved status; any provider payload remains opaque and unchanged. The disciple domain is required read-only only when evaluated mode is requested.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-004/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-004/acceptance.json
@@ -1,0 +1,189 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-004",
+  "tests": [
+    {
+      "test_id": "MASTER-004-A01",
+      "applies_to": "EVALUATE-RESERVED-MASTER-CONSTRAINTS",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-004",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-004",
+          "TLC-SO-MASTER-006",
+          "TLC-SO-MASTER-017",
+          "TLC-SO-MASTER-018",
+          "TLC-SO-MASTER-019",
+          "TLC-SO-MASTER-020",
+          "TLC-SO-MASTER-021",
+          "TLC-SO-MASTER-034"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-003",
+          "TLC-SR-MASTER-005",
+          "TLC-SR-MASTER-016",
+          "TLC-SR-MASTER-017",
+          "TLC-SR-MASTER-018",
+          "TLC-SR-MASTER-019",
+          "TLC-SR-MASTER-020",
+          "TLC-SR-MASTER-031",
+          "TLC-SR-MASTER-036",
+          "TLC-SR-MASTER-037"
+        ],
+        "unresolved_refs": [
+          "TLC-GU-00319",
+          "TLC-GU-00321",
+          "TLC-GU-00328",
+          "TLC-GU-00329",
+          "TLC-GU-00330",
+          "TLC-GU-00332",
+          "TLC-GU-00339",
+          "TLC-RELISS-MASTER-003",
+          "TLC-UT-MASTER-002",
+          "TLC-UT-MASTER-004",
+          "TLC-UT-MASTER-011",
+          "TLC-UT-MASTER-012",
+          "TLC-UT-MASTER-013",
+          "TLC-UT-MASTER-015",
+          "TLC-UT-MASTER-022"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-004-A02",
+      "applies_to": "EVALUATE-RESERVED-MASTER-CONSTRAINTS",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-004-A03",
+      "applies_to": "EVALUATE-RESERVED-MASTER-CONSTRAINTS",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-004-A04",
+      "applies_to": "EVALUATE-RESERVED-MASTER-CONSTRAINTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-004-A05",
+      "applies_to": "EVALUATE-RESERVED-MASTER-CONSTRAINTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-004-A06",
+      "applies_to": "EVALUATE-RESERVED-MASTER-CONSTRAINTS",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-004-A07",
+      "applies_to": "EVALUATE-RESERVED-MASTER-CONSTRAINTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-004-A08",
+      "applies_to": "EVALUATE-RESERVED-MASTER-CONSTRAINTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-004-A09",
+      "applies_to": "EVALUATE-RESERVED-MASTER-CONSTRAINTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-004/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-004/contract.json
@@ -1,0 +1,530 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-004",
+    "title": "Reserved Master constraints",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Reserved Master constraints references and expose conditional, provider-defined evaluation without interpreting scientific content.",
+  "scope": {
+    "required": [
+      {
+        "id": "M004-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-004.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-004/ir.yaml"
+        ]
+      },
+      {
+        "id": "M004-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-004, TLC-SO-MASTER-006, TLC-SO-MASTER-017, TLC-SO-MASTER-018, TLC-SO-MASTER-019, TLC-SO-MASTER-020, TLC-SO-MASTER-021, TLC-SO-MASTER-034], relation references [TLC-SR-MASTER-003, TLC-SR-MASTER-005, TLC-SR-MASTER-016, TLC-SR-MASTER-017, TLC-SR-MASTER-018, TLC-SR-MASTER-019, TLC-SR-MASTER-020, TLC-SR-MASTER-031, TLC-SR-MASTER-036, TLC-SR-MASTER-037], and unresolved identifiers [TLC-GU-00319, TLC-GU-00321, TLC-GU-00328, TLC-GU-00329, TLC-GU-00330, TLC-GU-00332, TLC-GU-00339, TLC-RELISS-MASTER-003, TLC-UT-MASTER-002, TLC-UT-MASTER-004, TLC-UT-MASTER-011, TLC-UT-MASTER-012, TLC-UT-MASTER-013, TLC-UT-MASTER-015, TLC-UT-MASTER-022] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-004/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M004-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-004/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M004-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M004-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M004-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M004-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00319, TLC-GU-00321, TLC-GU-00328, TLC-GU-00329, TLC-GU-00330, TLC-GU-00332, TLC-GU-00339, TLC-RELISS-MASTER-003, TLC-UT-MASTER-002, TLC-UT-MASTER-004, TLC-UT-MASTER-011, TLC-UT-MASTER-012, TLC-UT-MASTER-013, TLC-UT-MASTER-015, TLC-UT-MASTER-022 remain preserved unresolved."
+      },
+      {
+        "id": "M004-DEF-002",
+        "statement": "Executable scientific semantics are supplied only by an external opaque provider."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "EVALUATE-RESERVED-MASTER-CONSTRAINTS",
+      "purpose": "Expose conditional evaluation through an injected opaque provider while preserving all scientific boundaries.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-004"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-004",
+                "TLC-SO-MASTER-006",
+                "TLC-SO-MASTER-017",
+                "TLC-SO-MASTER-018",
+                "TLC-SO-MASTER-019",
+                "TLC-SO-MASTER-020",
+                "TLC-SO-MASTER-021",
+                "TLC-SO-MASTER-034"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-003",
+                "TLC-SR-MASTER-005",
+                "TLC-SR-MASTER-016",
+                "TLC-SR-MASTER-017",
+                "TLC-SR-MASTER-018",
+                "TLC-SR-MASTER-019",
+                "TLC-SR-MASTER-020",
+                "TLC-SR-MASTER-031",
+                "TLC-SR-MASTER-036",
+                "TLC-SR-MASTER-037"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00319",
+                "TLC-GU-00321",
+                "TLC-GU-00328",
+                "TLC-GU-00329",
+                "TLC-GU-00330",
+                "TLC-GU-00332",
+                "TLC-GU-00339",
+                "TLC-RELISS-MASTER-003",
+                "TLC-UT-MASTER-002",
+                "TLC-UT-MASTER-004",
+                "TLC-UT-MASTER-011",
+                "TLC-UT-MASTER-012",
+                "TLC-UT-MASTER-013",
+                "TLC-UT-MASTER-015",
+                "TLC-UT-MASTER-022"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_inputs",
+              "required": false,
+              "semantic_role": "provider-defined uninterpreted input",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M004-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-004, TLC-SO-MASTER-006, TLC-SO-MASTER-017, TLC-SO-MASTER-018, TLC-SO-MASTER-019, TLC-SO-MASTER-020, TLC-SO-MASTER-021, TLC-SO-MASTER-034] exactly and in order."
+            },
+            {
+              "id": "M004-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-003, TLC-SR-MASTER-005, TLC-SR-MASTER-016, TLC-SR-MASTER-017, TLC-SR-MASTER-018, TLC-SR-MASTER-019, TLC-SR-MASTER-020, TLC-SR-MASTER-031, TLC-SR-MASTER-036, TLC-SR-MASTER-037] exactly and in order."
+            },
+            {
+              "id": "M004-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00319, TLC-GU-00321, TLC-GU-00328, TLC-GU-00329, TLC-GU-00330, TLC-GU-00332, TLC-GU-00339, TLC-RELISS-MASTER-003, TLC-UT-MASTER-002, TLC-UT-MASTER-004, TLC-UT-MASTER-011, TLC-UT-MASTER-012, TLC-UT-MASTER-013, TLC-UT-MASTER-015, TLC-UT-MASTER-022] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable opaque evaluation envelope",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-004"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "opaque_evaluation_result"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00319",
+                "TLC-GU-00321",
+                "TLC-GU-00328",
+                "TLC-GU-00329",
+                "TLC-GU-00330",
+                "TLC-GU-00332",
+                "TLC-GU-00339",
+                "TLC-RELISS-MASTER-003",
+                "TLC-UT-MASTER-002",
+                "TLC-UT-MASTER-004",
+                "TLC-UT-MASTER-011",
+                "TLC-UT-MASTER-012",
+                "TLC-UT-MASTER-013",
+                "TLC-UT-MASTER-015",
+                "TLC-UT-MASTER-022"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": [
+                "disciple"
+              ]
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            },
+            {
+              "name": "opaque_payload",
+              "required": false,
+              "semantic_role": "provider result preserved without interpretation",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M004-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M004-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M004-POST-001",
+          "statement": "The wrapper returns an explicit unresolved status or preserves the provider response without interpretation."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M004-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M004-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "determine requested evaluation mode",
+          "gate required external symbol",
+          "invoke provider without transforming opaque input",
+          "preserve provider response",
+          "publish success, unresolved status, or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "determine requested evaluation mode",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "gate required external symbol",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "invoke provider without transforming opaque input",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "preserve provider response",
+            "after": "publish success, unresolved status, or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "implementation_defined",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_EXTERNAL_DEPENDENCY_UNAVAILABLE",
+          "category": "dependency",
+          "condition": "A required read-only external symbol is unavailable for evaluation.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_REQUIRED",
+          "category": "dependency",
+          "condition": "Evaluation was requested without an opaque provider.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_FAILURE",
+          "category": "provider_failure",
+          "condition": "The opaque provider reported failure.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "opaque-provider-evaluation",
+      "status": "required",
+      "statement": "Support unresolved mode and conditional evaluation through an injected opaque provider."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M004-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M004-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-004/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-004/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-004",
+  "title": "Reserved Master constraints",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "conditionally_executable"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-004/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-004/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-004",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-004/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-004",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "4e1931cffe6606eeaed49391aa3b9d7a2a20899f"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-004/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-004",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "1d84a16fe0f0e22a4064287ce918d5b3c311ba5c"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-004/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-004",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "91d9665a6ee62e9185a6912eac323624ad09b284"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-004/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-004",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "f54173e89d442c270addff99112b05b25d9f1a27"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-004/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-004",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "6cbd80cdebd8b92ddea9012c6056f7b9dddc0812"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-004/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-004",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "0e5f4a330567f45aab3f035b6e21ecb8ac5e4b1e"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-004/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-004",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "9437325a9406913f9ef659f3b1f2927d9eb6415c"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-006/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-006/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-006 — Master conceptual definition
+
+This package defines the final observable handoff for Master conceptual definition.
+
+## What must be implemented
+
+Implement one structural descriptor operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-002. Valid relation references: TLC-SR-MASTER-001. Required unresolved identifiers: TLC-GU-00318, TLC-UT-MASTER-001.
+
+The output is an immutable structural descriptor. No external domain dependency is required.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-006/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-006/acceptance.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-006",
+  "tests": [
+    {
+      "test_id": "MASTER-006-A01",
+      "applies_to": "DESCRIBE-MASTER-CONCEPT",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-006",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-002"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-001"
+        ],
+        "unresolved_refs": [
+          "TLC-GU-00318",
+          "TLC-UT-MASTER-001"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-006-A02",
+      "applies_to": "DESCRIBE-MASTER-CONCEPT",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-006-A03",
+      "applies_to": "DESCRIBE-MASTER-CONCEPT",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-006-A04",
+      "applies_to": "DESCRIBE-MASTER-CONCEPT",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-006-A05",
+      "applies_to": "DESCRIBE-MASTER-CONCEPT",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-006-A06",
+      "applies_to": "DESCRIBE-MASTER-CONCEPT",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-006-A07",
+      "applies_to": "DESCRIBE-MASTER-CONCEPT",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-006-A08",
+      "applies_to": "DESCRIBE-MASTER-CONCEPT",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-006/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-006/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-006/contract.json
@@ -1,0 +1,446 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-006",
+    "title": "Master conceptual definition",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Master conceptual definition references and emit a structural descriptor without scientific completion.",
+  "scope": {
+    "required": [
+      {
+        "id": "M006-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-006.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-006/ir.yaml"
+        ]
+      },
+      {
+        "id": "M006-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-002], relation references [TLC-SR-MASTER-001], and unresolved identifiers [TLC-GU-00318, TLC-UT-MASTER-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-006/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-006/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M006-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-006/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M006-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M006-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M006-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M006-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00318, TLC-UT-MASTER-001 remain preserved unresolved."
+      },
+      {
+        "id": "M006-DEF-002",
+        "statement": "Concrete runtime representation and all low-level storage decisions remain implementation-defined."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "DESCRIBE-MASTER-CONCEPT",
+      "purpose": "Emit the authoritative structural descriptor without inventing executable scientific semantics.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-006"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-002"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-001"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00318",
+                "TLC-UT-MASTER-001"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M006-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-002] exactly and in order."
+            },
+            {
+              "id": "M006-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-001] exactly and in order."
+            },
+            {
+              "id": "M006-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00318, TLC-UT-MASTER-001] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable structural descriptor",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-006"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "declaration_descriptor"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00318",
+                "TLC-UT-MASTER-001"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M006-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M006-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M006-POST-001",
+          "statement": "The result is an immutable, traceable structural descriptor."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M006-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M006-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "construct structural descriptor",
+          "verify preservation obligations",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct structural descriptor",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify preservation obligations",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNSUPPORTED_EXECUTION_MODE",
+          "category": "unsupported_operation",
+          "condition": "An invented or unsupported scientific execution mode was requested.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-descriptor",
+      "status": "required",
+      "statement": "Expose the structural descriptor and stable errors."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M006-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M006-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-006/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-006/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-006",
+  "title": "Master conceptual definition",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-006/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-006/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-006",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-006/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-006",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "f19f49cb5d370857e8f2a4c252d77428e27cd64b"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-006/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-006",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "b49b6528772e8d1410a036ed7fec11488367b03a"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-006/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-006",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "925ed0d2b0556a670e6f44c34ce277828756d4c8"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-006/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-006",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "7a64c1916a78b4b98384d58cd01f95780c73c918"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-006/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-006",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "8fa8d89d2f73b9dfae908b39e50578c9f5c6dcf7"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-006/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-006",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "d35c6719e832ac9df3ebbbaf5f8ce35a0f2c0687"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-006/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-006",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "ee07d98904cbcacbe5fd8fe221c9c415be6c9932"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-007/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-007/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-007 — Admissible Master dynamics
+
+This package defines the final observable handoff for Admissible Master dynamics.
+
+## What must be implemented
+
+Implement one conditional opaque-provider operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-026, TLC-SO-MASTER-036. Valid relation references: TLC-SR-MASTER-026, TLC-SR-MASTER-033. Required unresolved identifiers: none.
+
+The output is an immutable envelope with explicit evaluated or unresolved status; any provider payload remains opaque and unchanged. No external domain dependency is required.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Scientific canonicalization remains outside this package.

--- a/handoff/features/TLC-FC-00-MASTER-007/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-007/acceptance.json
@@ -1,0 +1,143 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-007",
+  "tests": [
+    {
+      "test_id": "MASTER-007-A01",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-DYNAMICS",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-007",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-026",
+          "TLC-SO-MASTER-036"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-026",
+          "TLC-SR-MASTER-033"
+        ],
+        "unresolved_refs": []
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-007-A02",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-DYNAMICS",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-007-A03",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-DYNAMICS",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-007-A04",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-DYNAMICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-007-A05",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-DYNAMICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-007-A06",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-DYNAMICS",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-007-A07",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-DYNAMICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-007-A08",
+      "applies_to": "EVALUATE-ADMISSIBLE-MASTER-DYNAMICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-007/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-007/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-007/contract.json
@@ -1,0 +1,464 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-007",
+    "title": "Admissible Master dynamics",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Admissible Master dynamics references and expose conditional, provider-defined evaluation without interpreting scientific content.",
+  "scope": {
+    "required": [
+      {
+        "id": "M007-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-007.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-007/ir.yaml"
+        ]
+      },
+      {
+        "id": "M007-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-026, TLC-SO-MASTER-036], relation references [TLC-SR-MASTER-026, TLC-SR-MASTER-033], and unresolved identifiers [] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-007/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-007/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M007-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-007/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M007-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M007-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M007-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M007-DEF-001",
+        "statement": "Scientific canonicalization remains outside this package."
+      },
+      {
+        "id": "M007-DEF-002",
+        "statement": "Executable scientific semantics are supplied only by an external opaque provider."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "EVALUATE-ADMISSIBLE-MASTER-DYNAMICS",
+      "purpose": "Expose conditional evaluation through an injected opaque provider while preserving all scientific boundaries.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-007"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-026",
+                "TLC-SO-MASTER-036"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-026",
+                "TLC-SR-MASTER-033"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_inputs",
+              "required": false,
+              "semantic_role": "provider-defined uninterpreted input",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M007-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-026, TLC-SO-MASTER-036] exactly and in order."
+            },
+            {
+              "id": "M007-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-026, TLC-SR-MASTER-033] exactly and in order."
+            },
+            {
+              "id": "M007-IN-003",
+              "statement": "Unresolved identifiers equal [] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable opaque evaluation envelope",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-007"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "opaque_evaluation_result"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": []
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            },
+            {
+              "name": "opaque_payload",
+              "required": false,
+              "semantic_role": "provider result preserved without interpretation",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M007-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M007-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M007-POST-001",
+          "statement": "The wrapper returns an explicit unresolved status or preserves the provider response without interpretation."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M007-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M007-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "determine requested evaluation mode",
+          "gate required external symbol",
+          "invoke provider without transforming opaque input",
+          "preserve provider response",
+          "publish success, unresolved status, or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "determine requested evaluation mode",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "gate required external symbol",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "invoke provider without transforming opaque input",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "preserve provider response",
+            "after": "publish success, unresolved status, or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "implementation_defined",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_REQUIRED",
+          "category": "dependency",
+          "condition": "Evaluation was requested without an opaque provider.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_FAILURE",
+          "category": "provider_failure",
+          "condition": "The opaque provider reported failure.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "opaque-provider-evaluation",
+      "status": "required",
+      "statement": "Support unresolved mode and conditional evaluation through an injected opaque provider."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M007-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M007-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-007/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-007/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-007",
+  "title": "Admissible Master dynamics",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "external_provider_required",
+    "execution": "conditionally_executable"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-007/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-007/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-007",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-007/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-007",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "fba3ada00062b181596ddfb6910fdf17d1914fb7"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-007/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-007",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "38580e834994ee02b9b108ababd39c5c858a3142"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-007/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-007",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "9747a25e8267f5c951282be95cff5d25f89a2045"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-007/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-007",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "f212b8cfc708185579d52cc72d2b7b2daf9f7716"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-007/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-007",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "fba386aed8549a9a9ef0013b086d10611a5b3dc4"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-007/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-007",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "abd9407c25b0db7966c1324e961c6e0246d38390"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-007/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-007",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "00fdac52b5a5532b275ef624ba5307f7f8c12502"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-008/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-008/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-008 — Reserved Master dynamics
+
+This package defines the final observable handoff for Reserved Master dynamics.
+
+## What must be implemented
+
+Implement one conditional opaque-provider operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-025, TLC-SO-MASTER-027, TLC-SO-MASTER-028. Valid relation references: TLC-SR-MASTER-025, TLC-SR-MASTER-027, TLC-SR-MASTER-028. Required unresolved identifiers: TLC-GU-00333, TLC-GU-00334, TLC-GU-00335, TLC-UT-MASTER-016, TLC-UT-MASTER-017, TLC-UT-MASTER-018.
+
+The output is an immutable envelope with explicit evaluated or unresolved status; any provider payload remains opaque and unchanged. No external domain dependency is required.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-008/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-008/acceptance.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-008",
+  "tests": [
+    {
+      "test_id": "MASTER-008-A01",
+      "applies_to": "EVALUATE-RESERVED-MASTER-DYNAMICS",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-008",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-025",
+          "TLC-SO-MASTER-027",
+          "TLC-SO-MASTER-028"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-025",
+          "TLC-SR-MASTER-027",
+          "TLC-SR-MASTER-028"
+        ],
+        "unresolved_refs": [
+          "TLC-GU-00333",
+          "TLC-GU-00334",
+          "TLC-GU-00335",
+          "TLC-UT-MASTER-016",
+          "TLC-UT-MASTER-017",
+          "TLC-UT-MASTER-018"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-008-A02",
+      "applies_to": "EVALUATE-RESERVED-MASTER-DYNAMICS",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-008-A03",
+      "applies_to": "EVALUATE-RESERVED-MASTER-DYNAMICS",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-008-A04",
+      "applies_to": "EVALUATE-RESERVED-MASTER-DYNAMICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-008-A05",
+      "applies_to": "EVALUATE-RESERVED-MASTER-DYNAMICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-008-A06",
+      "applies_to": "EVALUATE-RESERVED-MASTER-DYNAMICS",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-008-A07",
+      "applies_to": "EVALUATE-RESERVED-MASTER-DYNAMICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-008-A08",
+      "applies_to": "EVALUATE-RESERVED-MASTER-DYNAMICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-008/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-008/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-008/contract.json
@@ -1,0 +1,489 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-008",
+    "title": "Reserved Master dynamics",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Reserved Master dynamics references and expose conditional, provider-defined evaluation without interpreting scientific content.",
+  "scope": {
+    "required": [
+      {
+        "id": "M008-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-008.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-008/ir.yaml"
+        ]
+      },
+      {
+        "id": "M008-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-025, TLC-SO-MASTER-027, TLC-SO-MASTER-028], relation references [TLC-SR-MASTER-025, TLC-SR-MASTER-027, TLC-SR-MASTER-028], and unresolved identifiers [TLC-GU-00333, TLC-GU-00334, TLC-GU-00335, TLC-UT-MASTER-016, TLC-UT-MASTER-017, TLC-UT-MASTER-018] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-008/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-008/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M008-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-008/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M008-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M008-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M008-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M008-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00333, TLC-GU-00334, TLC-GU-00335, TLC-UT-MASTER-016, TLC-UT-MASTER-017, TLC-UT-MASTER-018 remain preserved unresolved."
+      },
+      {
+        "id": "M008-DEF-002",
+        "statement": "Executable scientific semantics are supplied only by an external opaque provider."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "EVALUATE-RESERVED-MASTER-DYNAMICS",
+      "purpose": "Expose conditional evaluation through an injected opaque provider while preserving all scientific boundaries.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-008"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-025",
+                "TLC-SO-MASTER-027",
+                "TLC-SO-MASTER-028"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-025",
+                "TLC-SR-MASTER-027",
+                "TLC-SR-MASTER-028"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00333",
+                "TLC-GU-00334",
+                "TLC-GU-00335",
+                "TLC-UT-MASTER-016",
+                "TLC-UT-MASTER-017",
+                "TLC-UT-MASTER-018"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_inputs",
+              "required": false,
+              "semantic_role": "provider-defined uninterpreted input",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M008-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-025, TLC-SO-MASTER-027, TLC-SO-MASTER-028] exactly and in order."
+            },
+            {
+              "id": "M008-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-025, TLC-SR-MASTER-027, TLC-SR-MASTER-028] exactly and in order."
+            },
+            {
+              "id": "M008-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00333, TLC-GU-00334, TLC-GU-00335, TLC-UT-MASTER-016, TLC-UT-MASTER-017, TLC-UT-MASTER-018] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable opaque evaluation envelope",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-008"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "opaque_evaluation_result"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00333",
+                "TLC-GU-00334",
+                "TLC-GU-00335",
+                "TLC-UT-MASTER-016",
+                "TLC-UT-MASTER-017",
+                "TLC-UT-MASTER-018"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            },
+            {
+              "name": "opaque_payload",
+              "required": false,
+              "semantic_role": "provider result preserved without interpretation",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M008-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M008-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M008-POST-001",
+          "statement": "The wrapper returns an explicit unresolved status or preserves the provider response without interpretation."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M008-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M008-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "determine requested evaluation mode",
+          "gate required external symbol",
+          "invoke provider without transforming opaque input",
+          "preserve provider response",
+          "publish success, unresolved status, or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "determine requested evaluation mode",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "gate required external symbol",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "invoke provider without transforming opaque input",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "preserve provider response",
+            "after": "publish success, unresolved status, or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "implementation_defined",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_REQUIRED",
+          "category": "dependency",
+          "condition": "Evaluation was requested without an opaque provider.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_FAILURE",
+          "category": "provider_failure",
+          "condition": "The opaque provider reported failure.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "opaque-provider-evaluation",
+      "status": "required",
+      "statement": "Support unresolved mode and conditional evaluation through an injected opaque provider."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M008-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M008-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-008/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-008/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-008",
+  "title": "Reserved Master dynamics",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "conditionally_executable"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-008/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-008/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-008",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-008/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-008",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "91cc95badf411dfe194c97e5121f2cd74658a8f2"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-008/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-008",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "80d6bed051a6f2d0c626c5c02491ee10419070b9"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-008/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-008",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "87bfec76370a8112f837d9c7a0b0160568d2ea4c"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-008/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-008",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "cedbdf03f8c1ebdadbb00cd5725e16c5ee9fa6ea"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-008/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-008",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "a0662a948af65dd5d0a87ca729960638148eb40f"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-008/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-008",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "f64656b05ee84583db583d4114639eda2ca6869d"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-008/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-008",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "d134cbc8650ba0dfd8b813174c00e7992dbfada1"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-009/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-009/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-009 — Master rupture equation
+
+This package defines the final observable handoff for Master rupture equation.
+
+## What must be implemented
+
+Implement one conditional opaque-provider operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-031. Valid relation references: none. Required unresolved identifiers: TLC-GU-00338, TLC-UT-MASTER-021.
+
+The output is an immutable envelope with explicit evaluated or unresolved status; any provider payload remains opaque and unchanged. No external domain dependency is required.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-009/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-009/acceptance.json
@@ -1,0 +1,142 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-009",
+  "tests": [
+    {
+      "test_id": "MASTER-009-A01",
+      "applies_to": "EVALUATE-MASTER-RUPTURE-EQUATION",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-009",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-031"
+        ],
+        "relation_refs": [],
+        "unresolved_refs": [
+          "TLC-GU-00338",
+          "TLC-UT-MASTER-021"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-009-A02",
+      "applies_to": "EVALUATE-MASTER-RUPTURE-EQUATION",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-009-A03",
+      "applies_to": "EVALUATE-MASTER-RUPTURE-EQUATION",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-009-A04",
+      "applies_to": "EVALUATE-MASTER-RUPTURE-EQUATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-009-A05",
+      "applies_to": "EVALUATE-MASTER-RUPTURE-EQUATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-009-A06",
+      "applies_to": "EVALUATE-MASTER-RUPTURE-EQUATION",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-009-A07",
+      "applies_to": "EVALUATE-MASTER-RUPTURE-EQUATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-009-A08",
+      "applies_to": "EVALUATE-MASTER-RUPTURE-EQUATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-009/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-009/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-009/contract.json
@@ -1,0 +1,475 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-009",
+    "title": "Master rupture equation",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Master rupture equation references and expose conditional, provider-defined evaluation without interpreting scientific content.",
+  "scope": {
+    "required": [
+      {
+        "id": "M009-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-009.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-009/ir.yaml"
+        ]
+      },
+      {
+        "id": "M009-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-031], relation references [], and unresolved identifiers [TLC-GU-00338, TLC-UT-MASTER-021] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-009/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-009/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M009-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-009/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M009-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M009-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M009-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M009-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00338, TLC-UT-MASTER-021 remain preserved unresolved."
+      },
+      {
+        "id": "M009-DEF-002",
+        "statement": "Executable scientific semantics are supplied only by an external opaque provider."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "EVALUATE-MASTER-RUPTURE-EQUATION",
+      "purpose": "Expose conditional evaluation through an injected opaque provider while preserving all scientific boundaries.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-009"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-031"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00338",
+                "TLC-UT-MASTER-021"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_inputs",
+              "required": false,
+              "semantic_role": "provider-defined uninterpreted input",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M009-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-031] exactly and in order."
+            },
+            {
+              "id": "M009-IN-002",
+              "statement": "Relation references equal [] exactly and in order."
+            },
+            {
+              "id": "M009-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00338, TLC-UT-MASTER-021] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable opaque evaluation envelope",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-009"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "opaque_evaluation_result"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00338",
+                "TLC-UT-MASTER-021"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            },
+            {
+              "name": "opaque_payload",
+              "required": false,
+              "semantic_role": "provider result preserved without interpretation",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M009-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M009-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M009-POST-001",
+          "statement": "The wrapper returns an explicit unresolved status or preserves the provider response without interpretation."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M009-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M009-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "determine requested evaluation mode",
+          "gate required external symbol",
+          "invoke provider without transforming opaque input",
+          "preserve provider response",
+          "publish success, unresolved status, or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "determine requested evaluation mode",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "gate required external symbol",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "invoke provider without transforming opaque input",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "preserve provider response",
+            "after": "publish success, unresolved status, or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "implementation_defined",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_REQUIRED",
+          "category": "dependency",
+          "condition": "Evaluation was requested without an opaque provider.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_FAILURE",
+          "category": "provider_failure",
+          "condition": "The opaque provider reported failure.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "opaque-provider-evaluation",
+      "status": "required",
+      "statement": "Support unresolved mode and conditional evaluation through an injected opaque provider."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M009-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M009-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-009/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-009/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-009",
+  "title": "Master rupture equation",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "conditionally_executable"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-009/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-009/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-009",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-009/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-009",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "d14b09d55392c8f0402b4b6a60bf23077ced8284"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-009/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-009",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "edf4b4eb5d2d5a43a5f5853af1d454c0eb43b1d7"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-009/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-009",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "a40a5921338b61e84296fa1fce0985603ee3331d"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-009/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-009",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "14fd248199edfa02096250abd20166cd19c03047"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-009/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-009",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "4b939c0b6f7cae3f5f5ac964bf2d642a5528e0aa"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-009/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-009",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "89c9aa34990d019e0bcb67a8f12bc9973e703725"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-009/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-009",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "24dcefb18072766ceab5a3c9527df753bf3f61d2"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-010/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-010/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-010 — Master invariants
+
+This package defines the final observable handoff for Master invariants.
+
+## What must be implemented
+
+Implement one conditional opaque-provider operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-022, TLC-SO-MASTER-023, TLC-SO-MASTER-024. Valid relation references: TLC-SR-MASTER-021, TLC-SR-MASTER-022, TLC-SR-MASTER-023, TLC-SR-MASTER-024, TLC-SR-MASTER-031. Required unresolved identifiers: TLC-GU-00331, TLC-GU-00332, TLC-RELISS-MASTER-001, TLC-RELISS-MASTER-003, TLC-UT-MASTER-014, TLC-UT-MASTER-015.
+
+The output is an immutable envelope with explicit evaluated or unresolved status; any provider payload remains opaque and unchanged. No external domain dependency is required.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-010/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-010/acceptance.json
@@ -1,0 +1,170 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-010",
+  "tests": [
+    {
+      "test_id": "MASTER-010-A01",
+      "applies_to": "EVALUATE-MASTER-INVARIANTS",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-010",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-022",
+          "TLC-SO-MASTER-023",
+          "TLC-SO-MASTER-024"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-021",
+          "TLC-SR-MASTER-022",
+          "TLC-SR-MASTER-023",
+          "TLC-SR-MASTER-024",
+          "TLC-SR-MASTER-031"
+        ],
+        "unresolved_refs": [
+          "TLC-GU-00331",
+          "TLC-GU-00332",
+          "TLC-RELISS-MASTER-001",
+          "TLC-RELISS-MASTER-003",
+          "TLC-UT-MASTER-014",
+          "TLC-UT-MASTER-015"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-010-A02",
+      "applies_to": "EVALUATE-MASTER-INVARIANTS",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-010-A03",
+      "applies_to": "EVALUATE-MASTER-INVARIANTS",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-010-A04",
+      "applies_to": "EVALUATE-MASTER-INVARIANTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-010-A05",
+      "applies_to": "EVALUATE-MASTER-INVARIANTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-010-A06",
+      "applies_to": "EVALUATE-MASTER-INVARIANTS",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-010-A07",
+      "applies_to": "EVALUATE-MASTER-INVARIANTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-010-A08",
+      "applies_to": "EVALUATE-MASTER-INVARIANTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-010-A09",
+      "applies_to": "EVALUATE-MASTER-INVARIANTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-010/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-010/contract.json
@@ -1,0 +1,491 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-010",
+    "title": "Master invariants",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Master invariants references and expose conditional, provider-defined evaluation without interpreting scientific content.",
+  "scope": {
+    "required": [
+      {
+        "id": "M010-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-010.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-010/ir.yaml"
+        ]
+      },
+      {
+        "id": "M010-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-022, TLC-SO-MASTER-023, TLC-SO-MASTER-024], relation references [TLC-SR-MASTER-021, TLC-SR-MASTER-022, TLC-SR-MASTER-023, TLC-SR-MASTER-024, TLC-SR-MASTER-031], and unresolved identifiers [TLC-GU-00331, TLC-GU-00332, TLC-RELISS-MASTER-001, TLC-RELISS-MASTER-003, TLC-UT-MASTER-014, TLC-UT-MASTER-015] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-010/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M010-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-010/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M010-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M010-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M010-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M010-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00331, TLC-GU-00332, TLC-RELISS-MASTER-001, TLC-RELISS-MASTER-003, TLC-UT-MASTER-014, TLC-UT-MASTER-015 remain preserved unresolved."
+      },
+      {
+        "id": "M010-DEF-002",
+        "statement": "Executable scientific semantics are supplied only by an external opaque provider."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "EVALUATE-MASTER-INVARIANTS",
+      "purpose": "Expose conditional evaluation through an injected opaque provider while preserving all scientific boundaries.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-010"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-022",
+                "TLC-SO-MASTER-023",
+                "TLC-SO-MASTER-024"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-021",
+                "TLC-SR-MASTER-022",
+                "TLC-SR-MASTER-023",
+                "TLC-SR-MASTER-024",
+                "TLC-SR-MASTER-031"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00331",
+                "TLC-GU-00332",
+                "TLC-RELISS-MASTER-001",
+                "TLC-RELISS-MASTER-003",
+                "TLC-UT-MASTER-014",
+                "TLC-UT-MASTER-015"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_inputs",
+              "required": false,
+              "semantic_role": "provider-defined uninterpreted input",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M010-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-022, TLC-SO-MASTER-023, TLC-SO-MASTER-024] exactly and in order."
+            },
+            {
+              "id": "M010-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-021, TLC-SR-MASTER-022, TLC-SR-MASTER-023, TLC-SR-MASTER-024, TLC-SR-MASTER-031] exactly and in order."
+            },
+            {
+              "id": "M010-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00331, TLC-GU-00332, TLC-RELISS-MASTER-001, TLC-RELISS-MASTER-003, TLC-UT-MASTER-014, TLC-UT-MASTER-015] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable opaque evaluation envelope",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-010"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "opaque_evaluation_result"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00331",
+                "TLC-GU-00332",
+                "TLC-RELISS-MASTER-001",
+                "TLC-RELISS-MASTER-003",
+                "TLC-UT-MASTER-014",
+                "TLC-UT-MASTER-015"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            },
+            {
+              "name": "opaque_payload",
+              "required": false,
+              "semantic_role": "provider result preserved without interpretation",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M010-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M010-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M010-POST-001",
+          "statement": "The wrapper returns an explicit unresolved status or preserves the provider response without interpretation."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M010-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M010-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "determine requested evaluation mode",
+          "gate required external symbol",
+          "invoke provider without transforming opaque input",
+          "preserve provider response",
+          "publish success, unresolved status, or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "determine requested evaluation mode",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "gate required external symbol",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "invoke provider without transforming opaque input",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "preserve provider response",
+            "after": "publish success, unresolved status, or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "implementation_defined",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_REQUIRED",
+          "category": "dependency",
+          "condition": "Evaluation was requested without an opaque provider.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_FAILURE",
+          "category": "provider_failure",
+          "condition": "The opaque provider reported failure.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "opaque-provider-evaluation",
+      "status": "required",
+      "statement": "Support unresolved mode and conditional evaluation through an injected opaque provider."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M010-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M010-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-010/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-010/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-010",
+  "title": "Master invariants",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "conditionally_executable"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-010/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-010/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-010",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-010/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-010",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "e82de7c7b4e994d250e5623418a8413cb126c36d"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-010/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-010",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "b68c4fdc71e9dadb5fa730c1dc271c3557bf3e6c"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-010/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-010",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "73a9806041b5aed6ae84885b3bca3f0206c408de"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-010/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-010",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "b7880d7d58bd1cb9302ef83f9112cd0131a9b9dc"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-010/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-010",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "244e1d740e1be80ba34e0d832963b728a2502517"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-010/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-010",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "03a6beea0d3e44aa4256456edd3fcdd0815643b6"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-010/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-010",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "70c302b2e0c7f43e342ebc7c02cbf04c06ffd7d8"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-011/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-011/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-011 — Master metrics
+
+This package defines the final observable handoff for Master metrics.
+
+## What must be implemented
+
+Implement one conditional opaque-provider operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-005, TLC-SO-MASTER-011, TLC-SO-MASTER-030. Valid relation references: TLC-SR-MASTER-004, TLC-SR-MASTER-010, TLC-SR-MASTER-026, TLC-SR-MASTER-029. Required unresolved identifiers: TLC-GU-00320, TLC-GU-00324, TLC-GU-00337, TLC-RELISS-MASTER-002, TLC-UT-MASTER-003, TLC-UT-MASTER-007, TLC-UT-MASTER-020.
+
+The output is an immutable envelope with explicit evaluated or unresolved status; any provider payload remains opaque and unchanged. No external domain dependency is required.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-011/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-011/acceptance.json
@@ -1,0 +1,154 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-011",
+  "tests": [
+    {
+      "test_id": "MASTER-011-A01",
+      "applies_to": "EVALUATE-MASTER-METRICS",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-011",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-005",
+          "TLC-SO-MASTER-011",
+          "TLC-SO-MASTER-030"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-004",
+          "TLC-SR-MASTER-010",
+          "TLC-SR-MASTER-026",
+          "TLC-SR-MASTER-029"
+        ],
+        "unresolved_refs": [
+          "TLC-GU-00320",
+          "TLC-GU-00324",
+          "TLC-GU-00337",
+          "TLC-RELISS-MASTER-002",
+          "TLC-UT-MASTER-003",
+          "TLC-UT-MASTER-007",
+          "TLC-UT-MASTER-020"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-011/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-011-A02",
+      "applies_to": "EVALUATE-MASTER-METRICS",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-011/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-011-A03",
+      "applies_to": "EVALUATE-MASTER-METRICS",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-011/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-011-A04",
+      "applies_to": "EVALUATE-MASTER-METRICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-011/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-011-A05",
+      "applies_to": "EVALUATE-MASTER-METRICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-011/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-011-A06",
+      "applies_to": "EVALUATE-MASTER-METRICS",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-011/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-011-A07",
+      "applies_to": "EVALUATE-MASTER-METRICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-011/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-011-A08",
+      "applies_to": "EVALUATE-MASTER-METRICS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-011/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-011/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-011/contract.json
@@ -1,0 +1,492 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-011",
+    "title": "Master metrics",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Master metrics references and expose conditional, provider-defined evaluation without interpreting scientific content.",
+  "scope": {
+    "required": [
+      {
+        "id": "M011-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-011.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-011/ir.yaml"
+        ]
+      },
+      {
+        "id": "M011-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-005, TLC-SO-MASTER-011, TLC-SO-MASTER-030], relation references [TLC-SR-MASTER-004, TLC-SR-MASTER-010, TLC-SR-MASTER-026, TLC-SR-MASTER-029], and unresolved identifiers [TLC-GU-00320, TLC-GU-00324, TLC-GU-00337, TLC-RELISS-MASTER-002, TLC-UT-MASTER-003, TLC-UT-MASTER-007, TLC-UT-MASTER-020] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-011/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-011/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M011-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-011/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M011-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M011-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M011-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M011-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00320, TLC-GU-00324, TLC-GU-00337, TLC-RELISS-MASTER-002, TLC-UT-MASTER-003, TLC-UT-MASTER-007, TLC-UT-MASTER-020 remain preserved unresolved."
+      },
+      {
+        "id": "M011-DEF-002",
+        "statement": "Executable scientific semantics are supplied only by an external opaque provider."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "EVALUATE-MASTER-METRICS",
+      "purpose": "Expose conditional evaluation through an injected opaque provider while preserving all scientific boundaries.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-011"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-005",
+                "TLC-SO-MASTER-011",
+                "TLC-SO-MASTER-030"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-004",
+                "TLC-SR-MASTER-010",
+                "TLC-SR-MASTER-026",
+                "TLC-SR-MASTER-029"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00320",
+                "TLC-GU-00324",
+                "TLC-GU-00337",
+                "TLC-RELISS-MASTER-002",
+                "TLC-UT-MASTER-003",
+                "TLC-UT-MASTER-007",
+                "TLC-UT-MASTER-020"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_inputs",
+              "required": false,
+              "semantic_role": "provider-defined uninterpreted input",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M011-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-005, TLC-SO-MASTER-011, TLC-SO-MASTER-030] exactly and in order."
+            },
+            {
+              "id": "M011-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-004, TLC-SR-MASTER-010, TLC-SR-MASTER-026, TLC-SR-MASTER-029] exactly and in order."
+            },
+            {
+              "id": "M011-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00320, TLC-GU-00324, TLC-GU-00337, TLC-RELISS-MASTER-002, TLC-UT-MASTER-003, TLC-UT-MASTER-007, TLC-UT-MASTER-020] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable opaque evaluation envelope",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-011"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "opaque_evaluation_result"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00320",
+                "TLC-GU-00324",
+                "TLC-GU-00337",
+                "TLC-RELISS-MASTER-002",
+                "TLC-UT-MASTER-003",
+                "TLC-UT-MASTER-007",
+                "TLC-UT-MASTER-020"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            },
+            {
+              "name": "opaque_payload",
+              "required": false,
+              "semantic_role": "provider result preserved without interpretation",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M011-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M011-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M011-POST-001",
+          "statement": "The wrapper returns an explicit unresolved status or preserves the provider response without interpretation."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M011-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M011-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "determine requested evaluation mode",
+          "gate required external symbol",
+          "invoke provider without transforming opaque input",
+          "preserve provider response",
+          "publish success, unresolved status, or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "determine requested evaluation mode",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "gate required external symbol",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "invoke provider without transforming opaque input",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "preserve provider response",
+            "after": "publish success, unresolved status, or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "implementation_defined",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_REQUIRED",
+          "category": "dependency",
+          "condition": "Evaluation was requested without an opaque provider.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_FAILURE",
+          "category": "provider_failure",
+          "condition": "The opaque provider reported failure.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "opaque-provider-evaluation",
+      "status": "required",
+      "statement": "Support unresolved mode and conditional evaluation through an injected opaque provider."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M011-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M011-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-011/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-011/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-011",
+  "title": "Master metrics",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "conditionally_executable"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-011/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-011/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-011",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-011/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-011",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "cad70021782b99928507a8edf81078c0e7dc3c80"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-011/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-011",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "b06503c530fd2ad726df26ad157121bdbdaa8bb7"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-011/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-011",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "4b2b19a0a6eda5938b56a22f3ddf355d1d84f15f"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-011/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-011",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "876f274660c8e59ba99b7657b720084e3030d2e2"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-011/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-011",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "23a8637956f1c98e3e260d2dac5f197567661544"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-011/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-011",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "2d26ba99c892f60a5961e09b7342b51afc5f8bc8"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-011/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-011",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "0810bb19b935dfad70b38736ca52102f64fce7c5"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-012/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-012/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-012 — Master operators
+
+This package defines the final observable handoff for Master operators.
+
+## What must be implemented
+
+Implement one conditional opaque-provider operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-013, TLC-SO-MASTER-014, TLC-SO-MASTER-029. Valid relation references: TLC-SR-MASTER-012, TLC-SR-MASTER-013, TLC-SR-MASTER-028. Required unresolved identifiers: TLC-GU-00321, TLC-GU-00325, TLC-GU-00326, TLC-GU-00328, TLC-GU-00336, TLC-UT-MASTER-004, TLC-UT-MASTER-008, TLC-UT-MASTER-009, TLC-UT-MASTER-011, TLC-UT-MASTER-019.
+
+The output is an immutable envelope with explicit evaluated or unresolved status; any provider payload remains opaque and unchanged. The community domain is required read-only only when evaluated mode is requested.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-012/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-012/acceptance.json
@@ -1,0 +1,172 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-012",
+  "tests": [
+    {
+      "test_id": "MASTER-012-A01",
+      "applies_to": "EVALUATE-MASTER-OPERATORS",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-012",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-013",
+          "TLC-SO-MASTER-014",
+          "TLC-SO-MASTER-029"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-012",
+          "TLC-SR-MASTER-013",
+          "TLC-SR-MASTER-028"
+        ],
+        "unresolved_refs": [
+          "TLC-GU-00321",
+          "TLC-GU-00325",
+          "TLC-GU-00326",
+          "TLC-GU-00328",
+          "TLC-GU-00336",
+          "TLC-UT-MASTER-004",
+          "TLC-UT-MASTER-008",
+          "TLC-UT-MASTER-009",
+          "TLC-UT-MASTER-011",
+          "TLC-UT-MASTER-019"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-012-A02",
+      "applies_to": "EVALUATE-MASTER-OPERATORS",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-012-A03",
+      "applies_to": "EVALUATE-MASTER-OPERATORS",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-012-A04",
+      "applies_to": "EVALUATE-MASTER-OPERATORS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-012-A05",
+      "applies_to": "EVALUATE-MASTER-OPERATORS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-012-A06",
+      "applies_to": "EVALUATE-MASTER-OPERATORS",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-012-A07",
+      "applies_to": "EVALUATE-MASTER-OPERATORS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-012-A08",
+      "applies_to": "EVALUATE-MASTER-OPERATORS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-012-A09",
+      "applies_to": "EVALUATE-MASTER-OPERATORS",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-012/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-012/contract.json
@@ -1,0 +1,508 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-012",
+    "title": "Master operators",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Master operators references and expose conditional, provider-defined evaluation without interpreting scientific content.",
+  "scope": {
+    "required": [
+      {
+        "id": "M012-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-012.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-012/ir.yaml"
+        ]
+      },
+      {
+        "id": "M012-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-013, TLC-SO-MASTER-014, TLC-SO-MASTER-029], relation references [TLC-SR-MASTER-012, TLC-SR-MASTER-013, TLC-SR-MASTER-028], and unresolved identifiers [TLC-GU-00321, TLC-GU-00325, TLC-GU-00326, TLC-GU-00328, TLC-GU-00336, TLC-UT-MASTER-004, TLC-UT-MASTER-008, TLC-UT-MASTER-009, TLC-UT-MASTER-011, TLC-UT-MASTER-019] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-012/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M012-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-012/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M012-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M012-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M012-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M012-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00321, TLC-GU-00325, TLC-GU-00326, TLC-GU-00328, TLC-GU-00336, TLC-UT-MASTER-004, TLC-UT-MASTER-008, TLC-UT-MASTER-009, TLC-UT-MASTER-011, TLC-UT-MASTER-019 remain preserved unresolved."
+      },
+      {
+        "id": "M012-DEF-002",
+        "statement": "Executable scientific semantics are supplied only by an external opaque provider."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "EVALUATE-MASTER-OPERATORS",
+      "purpose": "Expose conditional evaluation through an injected opaque provider while preserving all scientific boundaries.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-012"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-013",
+                "TLC-SO-MASTER-014",
+                "TLC-SO-MASTER-029"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-012",
+                "TLC-SR-MASTER-013",
+                "TLC-SR-MASTER-028"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00321",
+                "TLC-GU-00325",
+                "TLC-GU-00326",
+                "TLC-GU-00328",
+                "TLC-GU-00336",
+                "TLC-UT-MASTER-004",
+                "TLC-UT-MASTER-008",
+                "TLC-UT-MASTER-009",
+                "TLC-UT-MASTER-011",
+                "TLC-UT-MASTER-019"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_inputs",
+              "required": false,
+              "semantic_role": "provider-defined uninterpreted input",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M012-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-013, TLC-SO-MASTER-014, TLC-SO-MASTER-029] exactly and in order."
+            },
+            {
+              "id": "M012-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-012, TLC-SR-MASTER-013, TLC-SR-MASTER-028] exactly and in order."
+            },
+            {
+              "id": "M012-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00321, TLC-GU-00325, TLC-GU-00326, TLC-GU-00328, TLC-GU-00336, TLC-UT-MASTER-004, TLC-UT-MASTER-008, TLC-UT-MASTER-009, TLC-UT-MASTER-011, TLC-UT-MASTER-019] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable opaque evaluation envelope",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-012"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "opaque_evaluation_result"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00321",
+                "TLC-GU-00325",
+                "TLC-GU-00326",
+                "TLC-GU-00328",
+                "TLC-GU-00336",
+                "TLC-UT-MASTER-004",
+                "TLC-UT-MASTER-008",
+                "TLC-UT-MASTER-009",
+                "TLC-UT-MASTER-011",
+                "TLC-UT-MASTER-019"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": [
+                "community"
+              ]
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            },
+            {
+              "name": "opaque_payload",
+              "required": false,
+              "semantic_role": "provider result preserved without interpretation",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M012-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M012-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M012-POST-001",
+          "statement": "The wrapper returns an explicit unresolved status or preserves the provider response without interpretation."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M012-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M012-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "determine requested evaluation mode",
+          "gate required external symbol",
+          "invoke provider without transforming opaque input",
+          "preserve provider response",
+          "publish success, unresolved status, or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "determine requested evaluation mode",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "gate required external symbol",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "invoke provider without transforming opaque input",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "preserve provider response",
+            "after": "publish success, unresolved status, or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "implementation_defined",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_EXTERNAL_DEPENDENCY_UNAVAILABLE",
+          "category": "dependency",
+          "condition": "A required read-only external symbol is unavailable for evaluation.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_REQUIRED",
+          "category": "dependency",
+          "condition": "Evaluation was requested without an opaque provider.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_FAILURE",
+          "category": "provider_failure",
+          "condition": "The opaque provider reported failure.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "opaque-provider-evaluation",
+      "status": "required",
+      "statement": "Support unresolved mode and conditional evaluation through an injected opaque provider."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M012-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M012-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-012/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-012/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-012",
+  "title": "Master operators",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "conditionally_executable"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-012/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-012/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-012",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-012/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-012",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "5034efa02125a98a361da8a64ee9bef1a916134a"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-012/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-012",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "ea292e38a482909d6bfbab1884e7e35152edbb25"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-012/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-012",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "ef9809db42715550af5fa8d8239ed1a651bf5778"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-012/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-012",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "1462e64aab642f6207c719b37d8e6fa278944690"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-012/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-012",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "4e6490c281af2b5651a717d19d80adcc5177f768"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-012/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-012",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "70b0e109fc81253ed8949f2ba6e91156cbd0108f"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-012/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-012",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "59be28f796171fb6b0cbfa0fa672cf8b019c2e3f"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-013/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-013/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-013 — Master-versus-expert predicate
+
+This package defines the final observable handoff for Master-versus-expert predicate.
+
+## What must be implemented
+
+Implement one structural descriptor operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-038. Valid relation references: TLC-SR-MASTER-035. Required unresolved identifiers: TLC-GU-00342, TLC-UT-MASTER-025.
+
+The output is an immutable structural descriptor. No external domain dependency is required.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-013/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-013/acceptance.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-013",
+  "tests": [
+    {
+      "test_id": "MASTER-013-A01",
+      "applies_to": "DESCRIBE-MASTER-EXPERT-PREDICATE",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-013",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-038"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-035"
+        ],
+        "unresolved_refs": [
+          "TLC-GU-00342",
+          "TLC-UT-MASTER-025"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-013/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-013-A02",
+      "applies_to": "DESCRIBE-MASTER-EXPERT-PREDICATE",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-013/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-013-A03",
+      "applies_to": "DESCRIBE-MASTER-EXPERT-PREDICATE",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-013/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-013-A04",
+      "applies_to": "DESCRIBE-MASTER-EXPERT-PREDICATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-013/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-013-A05",
+      "applies_to": "DESCRIBE-MASTER-EXPERT-PREDICATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-013/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-013-A06",
+      "applies_to": "DESCRIBE-MASTER-EXPERT-PREDICATE",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-013/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-013-A07",
+      "applies_to": "DESCRIBE-MASTER-EXPERT-PREDICATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-013/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-013-A08",
+      "applies_to": "DESCRIBE-MASTER-EXPERT-PREDICATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-013/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-013/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-013/contract.json
@@ -1,0 +1,446 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-013",
+    "title": "Master-versus-expert predicate",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Master-versus-expert predicate references and emit a structural descriptor without scientific completion.",
+  "scope": {
+    "required": [
+      {
+        "id": "M013-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-013.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-013/ir.yaml"
+        ]
+      },
+      {
+        "id": "M013-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-038], relation references [TLC-SR-MASTER-035], and unresolved identifiers [TLC-GU-00342, TLC-UT-MASTER-025] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-013/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-013/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M013-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-013/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M013-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M013-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M013-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M013-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00342, TLC-UT-MASTER-025 remain preserved unresolved."
+      },
+      {
+        "id": "M013-DEF-002",
+        "statement": "Concrete runtime representation and all low-level storage decisions remain implementation-defined."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "DESCRIBE-MASTER-EXPERT-PREDICATE",
+      "purpose": "Emit the authoritative structural descriptor without inventing executable scientific semantics.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-013"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-038"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-035"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00342",
+                "TLC-UT-MASTER-025"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M013-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-038] exactly and in order."
+            },
+            {
+              "id": "M013-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-035] exactly and in order."
+            },
+            {
+              "id": "M013-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00342, TLC-UT-MASTER-025] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable structural descriptor",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-013"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "predicate_descriptor"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00342",
+                "TLC-UT-MASTER-025"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M013-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M013-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M013-POST-001",
+          "statement": "The result is an immutable, traceable structural descriptor."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M013-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M013-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "construct structural descriptor",
+          "verify preservation obligations",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct structural descriptor",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify preservation obligations",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNSUPPORTED_EXECUTION_MODE",
+          "category": "unsupported_operation",
+          "condition": "An invented or unsupported scientific execution mode was requested.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-descriptor",
+      "status": "required",
+      "statement": "Expose the structural descriptor and stable errors."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M013-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M013-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-013/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-013/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-013",
+  "title": "Master-versus-expert predicate",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-013/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-013/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-013",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-013/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-013",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "3c434e7fe715cd46c507670fe68a3ad60c9141ce"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-013/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-013",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "b038344793f34a96a5e8afca7c6fc69526d1e4bd"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-013/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-013",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "c0f195704c3d7404291025e425ef7ba0e999b00d"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-013/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-013",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "80f6134669ecdf26414d74e5c427e7465c4fa018"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-013/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-013",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "2570375a6dd28bbe2d166daaeee18a2e3b7eb421"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-013/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-013",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "a3387ae6293259ec2535bfc1d88765427ca96dc4"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-013/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-013",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "8d9c0b778696a80634b5a7c275a4ba70b2067945"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-014/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-014/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-014 — Master–Disciple relation
+
+This package defines the final observable handoff for Master–Disciple relation.
+
+## What must be implemented
+
+Implement one conditional opaque-provider operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-003. Valid relation references: TLC-SR-MASTER-002, TLC-SR-MASTER-029. Required unresolved identifiers: TLC-GU-00343, TLC-RELISS-MASTER-002, TLC-UT-MASTER-026.
+
+The output is an immutable envelope with explicit evaluated or unresolved status; any provider payload remains opaque and unchanged. The disciple domain is required read-only only when evaluated mode is requested.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-014/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-014/acceptance.json
@@ -1,0 +1,162 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-014",
+  "tests": [
+    {
+      "test_id": "MASTER-014-A01",
+      "applies_to": "EVALUATE-MASTER-DISCIPLE-RELATION",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-014",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-003"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-002",
+          "TLC-SR-MASTER-029"
+        ],
+        "unresolved_refs": [
+          "TLC-GU-00343",
+          "TLC-RELISS-MASTER-002",
+          "TLC-UT-MASTER-026"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-014-A02",
+      "applies_to": "EVALUATE-MASTER-DISCIPLE-RELATION",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-014-A03",
+      "applies_to": "EVALUATE-MASTER-DISCIPLE-RELATION",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-014-A04",
+      "applies_to": "EVALUATE-MASTER-DISCIPLE-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-014-A05",
+      "applies_to": "EVALUATE-MASTER-DISCIPLE-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-014-A06",
+      "applies_to": "EVALUATE-MASTER-DISCIPLE-RELATION",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-014-A07",
+      "applies_to": "EVALUATE-MASTER-DISCIPLE-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-014-A08",
+      "applies_to": "EVALUATE-MASTER-DISCIPLE-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-014-A09",
+      "applies_to": "EVALUATE-MASTER-DISCIPLE-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-014/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-014/contract.json
@@ -1,0 +1,491 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-014",
+    "title": "Master–Disciple relation",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Master–Disciple relation references and expose conditional, provider-defined evaluation without interpreting scientific content.",
+  "scope": {
+    "required": [
+      {
+        "id": "M014-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-014.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-014/ir.yaml"
+        ]
+      },
+      {
+        "id": "M014-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-003], relation references [TLC-SR-MASTER-002, TLC-SR-MASTER-029], and unresolved identifiers [TLC-GU-00343, TLC-RELISS-MASTER-002, TLC-UT-MASTER-026] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-014/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M014-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-014/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M014-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M014-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M014-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M014-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00343, TLC-RELISS-MASTER-002, TLC-UT-MASTER-026 remain preserved unresolved."
+      },
+      {
+        "id": "M014-DEF-002",
+        "statement": "Executable scientific semantics are supplied only by an external opaque provider."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "EVALUATE-MASTER-DISCIPLE-RELATION",
+      "purpose": "Expose conditional evaluation through an injected opaque provider while preserving all scientific boundaries.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-014"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-003"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-002",
+                "TLC-SR-MASTER-029"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00343",
+                "TLC-RELISS-MASTER-002",
+                "TLC-UT-MASTER-026"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_inputs",
+              "required": false,
+              "semantic_role": "provider-defined uninterpreted input",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M014-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-003] exactly and in order."
+            },
+            {
+              "id": "M014-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-002, TLC-SR-MASTER-029] exactly and in order."
+            },
+            {
+              "id": "M014-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00343, TLC-RELISS-MASTER-002, TLC-UT-MASTER-026] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable opaque evaluation envelope",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-014"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "opaque_evaluation_result"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00343",
+                "TLC-RELISS-MASTER-002",
+                "TLC-UT-MASTER-026"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": [
+                "disciple"
+              ]
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            },
+            {
+              "name": "opaque_payload",
+              "required": false,
+              "semantic_role": "provider result preserved without interpretation",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M014-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M014-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M014-POST-001",
+          "statement": "The wrapper returns an explicit unresolved status or preserves the provider response without interpretation."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M014-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M014-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "determine requested evaluation mode",
+          "gate required external symbol",
+          "invoke provider without transforming opaque input",
+          "preserve provider response",
+          "publish success, unresolved status, or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "determine requested evaluation mode",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "gate required external symbol",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "invoke provider without transforming opaque input",
+            "after": "publish success, unresolved status, or stable error"
+          },
+          {
+            "before": "preserve provider response",
+            "after": "publish success, unresolved status, or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "implementation_defined",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_EXTERNAL_DEPENDENCY_UNAVAILABLE",
+          "category": "dependency",
+          "condition": "A required read-only external symbol is unavailable for evaluation.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_REQUIRED",
+          "category": "dependency",
+          "condition": "Evaluation was requested without an opaque provider.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_OPAQUE_PROVIDER_FAILURE",
+          "category": "provider_failure",
+          "condition": "The opaque provider reported failure.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "opaque-provider-evaluation",
+      "status": "required",
+      "statement": "Support unresolved mode and conditional evaluation through an injected opaque provider."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M014-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M014-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-014/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-014/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-014",
+  "title": "Master–Disciple relation",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "conditionally_executable"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-014/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-014/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-014",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-014/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-014",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "ec52b7c49a6d0b5432e6a475016dec6d7eec9d53"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-014/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-014",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "5af605145258cb455af529df0dbbed5239d644a2"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-014/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-014",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "80344f7538bcaf650a44c34566768b683d749984"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-014/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-014",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "fa795c2e913cd6c64127f5e65118c7fb00ff1ae2"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-014/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-014",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "6a9d514b5cc4e8844b163d7291bef0510bdaaf97"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-014/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-014",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "23607284a09e18d39c5d37ed3160b25633b67a6b"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-014/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-014",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "39966b51d70a6db12dff7ea177a772da8baf77c0"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-015/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-015/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-015 — Master value and symbolic state
+
+This package defines the final observable handoff for Master value and symbolic state.
+
+## What must be implemented
+
+Implement one structural descriptor operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-010, TLC-SO-MASTER-016. Valid relation references: TLC-SR-MASTER-009, TLC-SR-MASTER-015, TLC-SR-MASTER-018, TLC-SR-MASTER-020, TLC-SR-MASTER-027. Required unresolved identifiers: none.
+
+The output is an immutable structural descriptor. The community domain is an optional read-only symbol reference.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Scientific canonicalization remains outside this package.

--- a/handoff/features/TLC-FC-00-MASTER-015/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-015/acceptance.json
@@ -1,0 +1,146 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-015",
+  "tests": [
+    {
+      "test_id": "MASTER-015-A01",
+      "applies_to": "DESCRIBE-MASTER-VALUE-AND-SYMBOLIC-STATE",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-015",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-010",
+          "TLC-SO-MASTER-016"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-009",
+          "TLC-SR-MASTER-015",
+          "TLC-SR-MASTER-018",
+          "TLC-SR-MASTER-020",
+          "TLC-SR-MASTER-027"
+        ],
+        "unresolved_refs": []
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-015/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-015-A02",
+      "applies_to": "DESCRIBE-MASTER-VALUE-AND-SYMBOLIC-STATE",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-015/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-015-A03",
+      "applies_to": "DESCRIBE-MASTER-VALUE-AND-SYMBOLIC-STATE",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-015/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-015-A04",
+      "applies_to": "DESCRIBE-MASTER-VALUE-AND-SYMBOLIC-STATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-015/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-015-A05",
+      "applies_to": "DESCRIBE-MASTER-VALUE-AND-SYMBOLIC-STATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-015/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-015-A06",
+      "applies_to": "DESCRIBE-MASTER-VALUE-AND-SYMBOLIC-STATE",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-015/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-015-A07",
+      "applies_to": "DESCRIBE-MASTER-VALUE-AND-SYMBOLIC-STATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-015/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-015-A08",
+      "applies_to": "DESCRIBE-MASTER-VALUE-AND-SYMBOLIC-STATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-015/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-015/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-015/contract.json
@@ -1,0 +1,438 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-015",
+    "title": "Master value and symbolic state",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Master value and symbolic state references and emit a structural descriptor without scientific completion.",
+  "scope": {
+    "required": [
+      {
+        "id": "M015-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-015.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-015/ir.yaml"
+        ]
+      },
+      {
+        "id": "M015-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-010, TLC-SO-MASTER-016], relation references [TLC-SR-MASTER-009, TLC-SR-MASTER-015, TLC-SR-MASTER-018, TLC-SR-MASTER-020, TLC-SR-MASTER-027], and unresolved identifiers [] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-015/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-015/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M015-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-015/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M015-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M015-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M015-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M015-DEF-001",
+        "statement": "Scientific canonicalization remains outside this package."
+      },
+      {
+        "id": "M015-DEF-002",
+        "statement": "Concrete runtime representation and all low-level storage decisions remain implementation-defined."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "DESCRIBE-MASTER-VALUE-AND-SYMBOLIC-STATE",
+      "purpose": "Emit the authoritative structural descriptor without inventing executable scientific semantics.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-015"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-010",
+                "TLC-SO-MASTER-016"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-009",
+                "TLC-SR-MASTER-015",
+                "TLC-SR-MASTER-018",
+                "TLC-SR-MASTER-020",
+                "TLC-SR-MASTER-027"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M015-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-010, TLC-SO-MASTER-016] exactly and in order."
+            },
+            {
+              "id": "M015-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-009, TLC-SR-MASTER-015, TLC-SR-MASTER-018, TLC-SR-MASTER-020, TLC-SR-MASTER-027] exactly and in order."
+            },
+            {
+              "id": "M015-IN-003",
+              "statement": "Unresolved identifiers equal [] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable structural descriptor",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-015"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "symbolic_type_descriptor"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": []
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": [
+                "community"
+              ]
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M015-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M015-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M015-POST-001",
+          "statement": "The result is an immutable, traceable structural descriptor."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M015-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M015-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "construct structural descriptor",
+          "verify preservation obligations",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct structural descriptor",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify preservation obligations",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNSUPPORTED_EXECUTION_MODE",
+          "category": "unsupported_operation",
+          "condition": "An invented or unsupported scientific execution mode was requested.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-descriptor",
+      "status": "required",
+      "statement": "Expose the structural descriptor and stable errors."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M015-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M015-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-015/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-015/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-015",
+  "title": "Master value and symbolic state",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "partially_defined",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-015/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-015/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-015",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-015/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-015",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "a323ce730fce773c1b0cc3b67f55c966bc1ab662"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-015/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-015",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "81baed32e1c16b9b63a203ed51426b87ef664b3c"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-015/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-015",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "7d1c7247edc589f6ec704d353699968a5f11bf63"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-015/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-015",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "886266acdfcd956fdadbe71a038def07987cba65"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-015/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-015",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "2a5d4beeb34c35167eb0fcd7a645a98dfea4eed5"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-015/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-015",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "4e2005bcb12861ca74700cf17fd6d98a7a5031ea"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-015/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-015",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "8e366ca800f2d10bce6d3adad9bf09f638058a3b"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-016/README.md
+++ b/handoff/features/TLC-FC-00-MASTER-016/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-00-MASTER-016 — Master composite state
+
+This package defines the final observable handoff for Master composite state.
+
+## What must be implemented
+
+Implement one structural descriptor operation that accepts only the exact feature, object, relation, and unresolved collections stated in `contract.json`. Preserve their identities and order, emit complete provenance, and expose the stable errors listed by the contract.
+
+## Inputs and output
+
+Valid object references: TLC-SO-MASTER-001, TLC-SO-MASTER-009, TLC-SO-MASTER-012, TLC-SO-MASTER-015, TLC-SO-MASTER-035, TLC-SO-MASTER-037. Valid relation references: TLC-SR-MASTER-001, TLC-SR-MASTER-002, TLC-SR-MASTER-003, TLC-SR-MASTER-004, TLC-SR-MASTER-005, TLC-SR-MASTER-006, TLC-SR-MASTER-007, TLC-SR-MASTER-008, TLC-SR-MASTER-011, TLC-SR-MASTER-012, TLC-SR-MASTER-013, TLC-SR-MASTER-014, TLC-SR-MASTER-015, TLC-SR-MASTER-016, TLC-SR-MASTER-017, TLC-SR-MASTER-019, TLC-SR-MASTER-021, TLC-SR-MASTER-022, TLC-SR-MASTER-023, TLC-SR-MASTER-025, TLC-SR-MASTER-030, TLC-SR-MASTER-032, TLC-SR-MASTER-033, TLC-SR-MASTER-034, TLC-SR-MASTER-035. Required unresolved identifiers: TLC-GU-00321, TLC-GU-00322, TLC-GU-00323, TLC-GU-00327, TLC-GU-00340, TLC-GU-00341, TLC-GU-00343, TLC-UT-MASTER-004, TLC-UT-MASTER-005, TLC-UT-MASTER-006, TLC-UT-MASTER-010, TLC-UT-MASTER-023, TLC-UT-MASTER-024, TLC-UT-MASTER-026.
+
+The output is an immutable structural descriptor. The disciple domain is an optional read-only symbol reference.
+
+## Mandatory and forbidden behavior
+
+Exact identity, membership, order, unresolved preservation, opacity, immutability, failure atomicity, and provenance are mandatory. Scientific completion, inferred equations or values, invented runtime types or layouts, external mutation, and successful partial results are forbidden.
+
+## Implementation freedom
+
+Language, public naming, storage, ownership mechanism, allocation, serialization, concurrency policy, error transport, and internal validation decomposition remain free unless they change observable behavior.
+
+## Errors and conformance
+
+Return the stable errors in `contract.json` for their stated conditions with no observable partial result. Conformance requires every test in `acceptance.json` and every preservation obligation to pass. Unresolved scientific semantics are deliberately preserved and must not be converted into executable defaults.

--- a/handoff/features/TLC-FC-00-MASTER-016/acceptance.json
+++ b/handoff/features/TLC-FC-00-MASTER-016/acceptance.json
@@ -1,0 +1,217 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-016",
+  "tests": [
+    {
+      "test_id": "MASTER-016-A01",
+      "applies_to": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-00-MASTER-016",
+        "scientific_object_refs": [
+          "TLC-SO-MASTER-001",
+          "TLC-SO-MASTER-009",
+          "TLC-SO-MASTER-012",
+          "TLC-SO-MASTER-015",
+          "TLC-SO-MASTER-035",
+          "TLC-SO-MASTER-037"
+        ],
+        "relation_refs": [
+          "TLC-SR-MASTER-001",
+          "TLC-SR-MASTER-002",
+          "TLC-SR-MASTER-003",
+          "TLC-SR-MASTER-004",
+          "TLC-SR-MASTER-005",
+          "TLC-SR-MASTER-006",
+          "TLC-SR-MASTER-007",
+          "TLC-SR-MASTER-008",
+          "TLC-SR-MASTER-011",
+          "TLC-SR-MASTER-012",
+          "TLC-SR-MASTER-013",
+          "TLC-SR-MASTER-014",
+          "TLC-SR-MASTER-015",
+          "TLC-SR-MASTER-016",
+          "TLC-SR-MASTER-017",
+          "TLC-SR-MASTER-019",
+          "TLC-SR-MASTER-021",
+          "TLC-SR-MASTER-022",
+          "TLC-SR-MASTER-023",
+          "TLC-SR-MASTER-025",
+          "TLC-SR-MASTER-030",
+          "TLC-SR-MASTER-032",
+          "TLC-SR-MASTER-033",
+          "TLC-SR-MASTER-034",
+          "TLC-SR-MASTER-035"
+        ],
+        "unresolved_refs": [
+          "TLC-GU-00321",
+          "TLC-GU-00322",
+          "TLC-GU-00323",
+          "TLC-GU-00327",
+          "TLC-GU-00340",
+          "TLC-GU-00341",
+          "TLC-GU-00343",
+          "TLC-UT-MASTER-004",
+          "TLC-UT-MASTER-005",
+          "TLC-UT-MASTER-006",
+          "TLC-UT-MASTER-010",
+          "TLC-UT-MASTER-023",
+          "TLC-UT-MASTER-024",
+          "TLC-UT-MASTER-026"
+        ]
+      },
+      "when": "The package operation is requested.",
+      "expect": {
+        "accepted": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-016-A02",
+      "applies_to": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "category": "output_contract",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-016-A03",
+      "applies_to": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "category": "error",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-016-A04",
+      "applies_to": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-016-A05",
+      "applies_to": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-016-A06",
+      "applies_to": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "category": "determinism",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-016-A07",
+      "applies_to": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-016-A08",
+      "applies_to": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-016-A09",
+      "applies_to": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "MASTER-016-A10",
+      "applies_to": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "category": "preservation",
+      "given": {
+        "authoritative_fixture": true
+      },
+      "when": "The corresponding oracle condition is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_invented_science": true
+      },
+      "source_basis": [
+        "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-00-MASTER-016/contract.json
+++ b/handoff/features/TLC-FC-00-MASTER-016/contract.json
@@ -1,0 +1,501 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-00-MASTER-016",
+    "title": "Master composite state",
+    "domain": "master"
+  },
+  "purpose": "Validate the exact Master composite state references and emit a structural descriptor without scientific completion.",
+  "scope": {
+    "required": [
+      {
+        "id": "M016-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-00-MASTER-016.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-016/ir.yaml"
+        ]
+      },
+      {
+        "id": "M016-REQ-002",
+        "statement": "Preserve object references [TLC-SO-MASTER-001, TLC-SO-MASTER-009, TLC-SO-MASTER-012, TLC-SO-MASTER-015, TLC-SO-MASTER-035, TLC-SO-MASTER-037], relation references [TLC-SR-MASTER-001, TLC-SR-MASTER-002, TLC-SR-MASTER-003, TLC-SR-MASTER-004, TLC-SR-MASTER-005, TLC-SR-MASTER-006, TLC-SR-MASTER-007, TLC-SR-MASTER-008, TLC-SR-MASTER-011, TLC-SR-MASTER-012, TLC-SR-MASTER-013, TLC-SR-MASTER-014, TLC-SR-MASTER-015, TLC-SR-MASTER-016, TLC-SR-MASTER-017, TLC-SR-MASTER-019, TLC-SR-MASTER-021, TLC-SR-MASTER-022, TLC-SR-MASTER-023, TLC-SR-MASTER-025, TLC-SR-MASTER-030, TLC-SR-MASTER-032, TLC-SR-MASTER-033, TLC-SR-MASTER-034, TLC-SR-MASTER-035], and unresolved identifiers [TLC-GU-00321, TLC-GU-00322, TLC-GU-00323, TLC-GU-00327, TLC-GU-00340, TLC-GU-00341, TLC-GU-00343, TLC-UT-MASTER-004, TLC-UT-MASTER-005, TLC-UT-MASTER-006, TLC-UT-MASTER-010, TLC-UT-MASTER-023, TLC-UT-MASTER-024, TLC-UT-MASTER-026] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-00-MASTER-016/contract.yaml",
+          "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml"
+        ]
+      },
+      {
+        "id": "M016-REQ-003",
+        "statement": "Emit an immutable result with complete provenance and explicit scientific/execution status.",
+        "basis": [
+          "registry/optimized-ir/master/TLC-FC-00-MASTER-016/ir.yaml",
+          "registry/domain-finalization/master/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "M016-FOR-001",
+        "statement": "Do not invent equations, values, endpoints, types, dimensions, aliases, tolerances, calibration, numerical methods, or scientific defaults."
+      },
+      {
+        "id": "M016-FOR-002",
+        "statement": "Do not mutate scientific state or any external domain."
+      },
+      {
+        "id": "M016-FOR-003",
+        "statement": "Do not expose a successful partial result after validation, dependency, provider, or preservation failure."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "M016-DEF-001",
+        "statement": "Scientific meanings represented by TLC-GU-00321, TLC-GU-00322, TLC-GU-00323, TLC-GU-00327, TLC-GU-00340, TLC-GU-00341, TLC-GU-00343, TLC-UT-MASTER-004, TLC-UT-MASTER-005, TLC-UT-MASTER-006, TLC-UT-MASTER-010, TLC-UT-MASTER-023, TLC-UT-MASTER-024, TLC-UT-MASTER-026 remain preserved unresolved."
+      },
+      {
+        "id": "M016-DEF-002",
+        "statement": "Concrete runtime representation and all low-level storage decisions remain implementation-defined."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "DESCRIBE-MASTER-COMPOSITE-STATE",
+      "purpose": "Emit the authoritative structural descriptor without inventing executable scientific semantics.",
+      "inputs": [
+        {
+          "name": "request",
+          "semantic_role": "exact reference bundle and optional opaque provider inputs",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-00-MASTER-016"
+            },
+            {
+              "name": "scientific_object_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific object references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-MASTER-001",
+                "TLC-SO-MASTER-009",
+                "TLC-SO-MASTER-012",
+                "TLC-SO-MASTER-015",
+                "TLC-SO-MASTER-035",
+                "TLC-SO-MASTER-037"
+              ]
+            },
+            {
+              "name": "relation_refs",
+              "required": true,
+              "semantic_role": "exact ordered scientific relation references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SR-MASTER-001",
+                "TLC-SR-MASTER-002",
+                "TLC-SR-MASTER-003",
+                "TLC-SR-MASTER-004",
+                "TLC-SR-MASTER-005",
+                "TLC-SR-MASTER-006",
+                "TLC-SR-MASTER-007",
+                "TLC-SR-MASTER-008",
+                "TLC-SR-MASTER-011",
+                "TLC-SR-MASTER-012",
+                "TLC-SR-MASTER-013",
+                "TLC-SR-MASTER-014",
+                "TLC-SR-MASTER-015",
+                "TLC-SR-MASTER-016",
+                "TLC-SR-MASTER-017",
+                "TLC-SR-MASTER-019",
+                "TLC-SR-MASTER-021",
+                "TLC-SR-MASTER-022",
+                "TLC-SR-MASTER-023",
+                "TLC-SR-MASTER-025",
+                "TLC-SR-MASTER-030",
+                "TLC-SR-MASTER-032",
+                "TLC-SR-MASTER-033",
+                "TLC-SR-MASTER-034",
+                "TLC-SR-MASTER-035"
+              ]
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact ordered unresolved identifiers",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-GU-00321",
+                "TLC-GU-00322",
+                "TLC-GU-00323",
+                "TLC-GU-00327",
+                "TLC-GU-00340",
+                "TLC-GU-00341",
+                "TLC-GU-00343",
+                "TLC-UT-MASTER-004",
+                "TLC-UT-MASTER-005",
+                "TLC-UT-MASTER-006",
+                "TLC-UT-MASTER-010",
+                "TLC-UT-MASTER-023",
+                "TLC-UT-MASTER-024",
+                "TLC-UT-MASTER-026"
+              ]
+            },
+            {
+              "name": "source_provenance",
+              "required": true,
+              "semantic_role": "complete source provenance",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M016-IN-001",
+              "statement": "Object references equal [TLC-SO-MASTER-001, TLC-SO-MASTER-009, TLC-SO-MASTER-012, TLC-SO-MASTER-015, TLC-SO-MASTER-035, TLC-SO-MASTER-037] exactly and in order."
+            },
+            {
+              "id": "M016-IN-002",
+              "statement": "Relation references equal [TLC-SR-MASTER-001, TLC-SR-MASTER-002, TLC-SR-MASTER-003, TLC-SR-MASTER-004, TLC-SR-MASTER-005, TLC-SR-MASTER-006, TLC-SR-MASTER-007, TLC-SR-MASTER-008, TLC-SR-MASTER-011, TLC-SR-MASTER-012, TLC-SR-MASTER-013, TLC-SR-MASTER-014, TLC-SR-MASTER-015, TLC-SR-MASTER-016, TLC-SR-MASTER-017, TLC-SR-MASTER-019, TLC-SR-MASTER-021, TLC-SR-MASTER-022, TLC-SR-MASTER-023, TLC-SR-MASTER-025, TLC-SR-MASTER-030, TLC-SR-MASTER-032, TLC-SR-MASTER-033, TLC-SR-MASTER-034, TLC-SR-MASTER-035] exactly and in order."
+            },
+            {
+              "id": "M016-IN-003",
+              "statement": "Unresolved identifiers equal [TLC-GU-00321, TLC-GU-00322, TLC-GU-00323, TLC-GU-00327, TLC-GU-00340, TLC-GU-00341, TLC-GU-00343, TLC-UT-MASTER-004, TLC-UT-MASTER-005, TLC-UT-MASTER-006, TLC-UT-MASTER-010, TLC-UT-MASTER-023, TLC-UT-MASTER-024, TLC-UT-MASTER-026] exactly and in order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable structural descriptor",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-00-MASTER-016"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "result representation",
+              "constant": "symbolic_type_descriptor"
+            },
+            {
+              "name": "references",
+              "required": true,
+              "semantic_role": "preserved exact references",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "preserved unresolved identifiers",
+              "allowed_values": [
+                "TLC-GU-00321",
+                "TLC-GU-00322",
+                "TLC-GU-00323",
+                "TLC-GU-00327",
+                "TLC-GU-00340",
+                "TLC-GU-00341",
+                "TLC-GU-00343",
+                "TLC-UT-MASTER-004",
+                "TLC-UT-MASTER-005",
+                "TLC-UT-MASTER-006",
+                "TLC-UT-MASTER-010",
+                "TLC-UT-MASTER-023",
+                "TLC-UT-MASTER-024",
+                "TLC-UT-MASTER-026"
+              ]
+            },
+            {
+              "name": "dependencies",
+              "required": true,
+              "semantic_role": "declared external dependencies",
+              "allowed_values": [
+                "disciple"
+              ]
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete upstream traceability",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "scientific and execution status"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "M016-OUT-001",
+              "statement": "Every accepted identity, order, unresolved item, opacity boundary, and provenance link is preserved."
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "M016-PRE-001",
+          "statement": "Feature identity and all reference and unresolved collections match the authoritative fixture exactly."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "M016-POST-001",
+          "statement": "The result is an immutable, traceable structural descriptor."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "M016-INV-001",
+          "statement": "Scientific objects, relations, and unresolved identifiers remain distinct and ordered."
+        },
+        {
+          "id": "M016-INV-002",
+          "statement": "Scientific state and external domain state are never mutated."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact identity and collections",
+          "construct provenance",
+          "construct structural descriptor",
+          "verify preservation obligations",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact identity and collections",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct structural descriptor",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify preservation obligations",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Only validation and preservation before publication are observable; the upstream total step list does not prescribe a unique internal algorithm."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "MASTER_INVALID_FEATURE_ID",
+          "category": "invalid_input",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_REFERENCE_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "Object or relation references differ in identity, membership, cardinality, or required order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNRESOLVED_SET_MISMATCH",
+          "category": "invalid_input",
+          "condition": "The unresolved collection differs from the authoritative collection.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_PRESERVATION_VIOLATION",
+          "category": "preservation",
+          "condition": "A required identity, order, opacity, unresolved item, payload, or provenance cannot be preserved.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MASTER_UNSUPPORTED_EXECUTION_MODE",
+          "category": "unsupported_operation",
+          "condition": "An invented or unsupported scientific execution mode was requested.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-descriptor",
+      "status": "required",
+      "statement": "Expose the structural descriptor and stable errors."
+    },
+    {
+      "mode_id": "invented-scientific-completion",
+      "status": "forbidden",
+      "statement": "Do not complete missing science or infer absent operational semantics."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Any internal architecture is allowed when observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "M016-GINV-001",
+      "statement": "No behavior may weaken exact identity, order, opacity, unresolved preservation, immutability, or provenance requirements."
+    },
+    {
+      "id": "M016-GINV-002",
+      "statement": "Absence of scientific definition remains absence and never becomes a default."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered reference collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific and provider payloads"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is behavioral and does not prescribe a programming language, public function spelling, serialization, or internal algorithm."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-016/manifest.json
+++ b/handoff/features/TLC-FC-00-MASTER-016/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-00-MASTER-016",
+  "title": "Master composite state",
+  "domain": "master",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-00-MASTER-016/traceability.json
+++ b/handoff/features/TLC-FC-00-MASTER-016/traceability.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-00-MASTER-016",
+  "scientific_sources": [
+    {
+      "path": "maths/00-master.md",
+      "role": "Authoritative scientific source sections cited by the mathematical contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-00-MASTER-016/contract.yaml",
+      "role": "Authoritative candidate mathematical contract.",
+      "artifact_id": "TLC-MC-TLC-FC-00-MASTER-016",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "1567e61264cf6f50483412adf08f2d16169ae86b"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-00-MASTER-016/ir.yaml",
+      "role": "Active source IR registry entry.",
+      "artifact_id": "TLC-IR-REGISTRY-TLC-FC-00-MASTER-016",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "f034b3c76e70219a24ae241596e37351c9b25931"
+      }
+    },
+    {
+      "path": "ir/TLC-FC-00-MASTER-016/ir.candidate.json",
+      "role": "Candidate source IR preserving scientific reservations.",
+      "artifact_id": "TLC-IR-TLC-FC-00-MASTER-016",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "efa1ad3f0f48296aa3b87cd014e520cd6ca19a57"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/master/TLC-FC-00-MASTER-016/ir.yaml",
+      "role": "Finalized implementation-facing IR.",
+      "artifact_id": "TLC-OIR-TLC-FC-00-MASTER-016",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "d7b0adf726c32f7da67962d1069c96ad33b7200a"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/master/TLC-FC-00-MASTER-016/algorithm.yaml",
+      "role": "Applicable validation, dependency, provider, and preservation branches.",
+      "artifact_id": "TLC-ALG-TLC-FC-00-MASTER-016",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "1411a431f64747046f1a41d017de0c9bf4498b11"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-00-MASTER-016/test-plan.yaml",
+      "role": "Structural conformance and reservation-preservation plan.",
+      "artifact_id": "TLC-TP-TLC-FC-00-MASTER-016",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "cef29275a5d3a86580af252b78350ab9aeedb7b5"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/master/TLC-FC-00-MASTER-016/oracle.yaml",
+      "role": "Authoritative fixtures and observable acceptance properties.",
+      "artifact_id": "TLC-ORACLE-TLC-FC-00-MASTER-016",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "d879c950bf5043cb90745833f6c08db7550ab55e"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/master/feature-status.yaml",
+      "role": "Authoritative selected Master population and implementation mode."
+    },
+    {
+      "path": "registry/domain-finalization/master/module-specification.yaml",
+      "role": "Defines common envelopes, errors, interfaces, effects, and external dependencies."
+    },
+    {
+      "path": "registry/domain-finalization/master/implementation-tasks.yaml",
+      "role": "Defines the implementation deliverable and oracle for this feature."
+    }
+  ]
+}

--- a/reports/handoff/master/ambiguities.json
+++ b/reports/handoff/master/ambiguities.json
@@ -1,0 +1,246 @@
+{
+  "schema_version": "1.0",
+  "domain": "master",
+  "items": [
+    {
+      "ambiguity_id": "MASTER-002-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-002",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00329",
+        "TLC-UT-MASTER-012"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    },
+    {
+      "ambiguity_id": "MASTER-003-PROVIDER",
+      "feature_id": "TLC-FC-00-MASTER-003",
+      "classification": "oracle_insufficient",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The wrapper is testable structurally; scientific evaluation results are provider-defined and opaque."
+    },
+    {
+      "ambiguity_id": "MASTER-004-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-004",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00319",
+        "TLC-GU-00321",
+        "TLC-GU-00328",
+        "TLC-GU-00329",
+        "TLC-GU-00330",
+        "TLC-GU-00332",
+        "TLC-GU-00339",
+        "TLC-RELISS-MASTER-003",
+        "TLC-UT-MASTER-002",
+        "TLC-UT-MASTER-004",
+        "TLC-UT-MASTER-011",
+        "TLC-UT-MASTER-012",
+        "TLC-UT-MASTER-013",
+        "TLC-UT-MASTER-015",
+        "TLC-UT-MASTER-022"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    },
+    {
+      "ambiguity_id": "MASTER-004-PROVIDER",
+      "feature_id": "TLC-FC-00-MASTER-004",
+      "classification": "oracle_insufficient",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The wrapper is testable structurally; scientific evaluation results are provider-defined and opaque."
+    },
+    {
+      "ambiguity_id": "MASTER-006-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-006",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00318",
+        "TLC-UT-MASTER-001"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    },
+    {
+      "ambiguity_id": "MASTER-007-PROVIDER",
+      "feature_id": "TLC-FC-00-MASTER-007",
+      "classification": "oracle_insufficient",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The wrapper is testable structurally; scientific evaluation results are provider-defined and opaque."
+    },
+    {
+      "ambiguity_id": "MASTER-008-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-008",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00333",
+        "TLC-GU-00334",
+        "TLC-GU-00335",
+        "TLC-UT-MASTER-016",
+        "TLC-UT-MASTER-017",
+        "TLC-UT-MASTER-018"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    },
+    {
+      "ambiguity_id": "MASTER-008-PROVIDER",
+      "feature_id": "TLC-FC-00-MASTER-008",
+      "classification": "oracle_insufficient",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The wrapper is testable structurally; scientific evaluation results are provider-defined and opaque."
+    },
+    {
+      "ambiguity_id": "MASTER-009-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-009",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00338",
+        "TLC-UT-MASTER-021"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    },
+    {
+      "ambiguity_id": "MASTER-009-PROVIDER",
+      "feature_id": "TLC-FC-00-MASTER-009",
+      "classification": "oracle_insufficient",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The wrapper is testable structurally; scientific evaluation results are provider-defined and opaque."
+    },
+    {
+      "ambiguity_id": "MASTER-010-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-010",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00331",
+        "TLC-GU-00332",
+        "TLC-RELISS-MASTER-001",
+        "TLC-RELISS-MASTER-003",
+        "TLC-UT-MASTER-014",
+        "TLC-UT-MASTER-015"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    },
+    {
+      "ambiguity_id": "MASTER-010-PROVIDER",
+      "feature_id": "TLC-FC-00-MASTER-010",
+      "classification": "oracle_insufficient",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The wrapper is testable structurally; scientific evaluation results are provider-defined and opaque."
+    },
+    {
+      "ambiguity_id": "MASTER-011-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-011",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00320",
+        "TLC-GU-00324",
+        "TLC-GU-00337",
+        "TLC-RELISS-MASTER-002",
+        "TLC-UT-MASTER-003",
+        "TLC-UT-MASTER-007",
+        "TLC-UT-MASTER-020"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    },
+    {
+      "ambiguity_id": "MASTER-011-PROVIDER",
+      "feature_id": "TLC-FC-00-MASTER-011",
+      "classification": "oracle_insufficient",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The wrapper is testable structurally; scientific evaluation results are provider-defined and opaque."
+    },
+    {
+      "ambiguity_id": "MASTER-012-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-012",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00321",
+        "TLC-GU-00325",
+        "TLC-GU-00326",
+        "TLC-GU-00328",
+        "TLC-GU-00336",
+        "TLC-UT-MASTER-004",
+        "TLC-UT-MASTER-008",
+        "TLC-UT-MASTER-009",
+        "TLC-UT-MASTER-011",
+        "TLC-UT-MASTER-019"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    },
+    {
+      "ambiguity_id": "MASTER-012-PROVIDER",
+      "feature_id": "TLC-FC-00-MASTER-012",
+      "classification": "oracle_insufficient",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The wrapper is testable structurally; scientific evaluation results are provider-defined and opaque."
+    },
+    {
+      "ambiguity_id": "MASTER-013-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-013",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00342",
+        "TLC-UT-MASTER-025"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    },
+    {
+      "ambiguity_id": "MASTER-014-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-014",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00343",
+        "TLC-RELISS-MASTER-002",
+        "TLC-UT-MASTER-026"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    },
+    {
+      "ambiguity_id": "MASTER-014-PROVIDER",
+      "feature_id": "TLC-FC-00-MASTER-014",
+      "classification": "oracle_insufficient",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The wrapper is testable structurally; scientific evaluation results are provider-defined and opaque."
+    },
+    {
+      "ambiguity_id": "MASTER-016-UNRESOLVED",
+      "feature_id": "TLC-FC-00-MASTER-016",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-GU-00321",
+        "TLC-GU-00322",
+        "TLC-GU-00323",
+        "TLC-GU-00327",
+        "TLC-GU-00340",
+        "TLC-GU-00341",
+        "TLC-GU-00343",
+        "TLC-UT-MASTER-004",
+        "TLC-UT-MASTER-005",
+        "TLC-UT-MASTER-006",
+        "TLC-UT-MASTER-010",
+        "TLC-UT-MASTER-023",
+        "TLC-UT-MASTER-024",
+        "TLC-UT-MASTER-026"
+      ],
+      "impact": "Scientific evaluation or interpretation may require future scientific decisions; structural handoff remains valid."
+    }
+  ]
+}

--- a/reports/handoff/master/generation-report.md
+++ b/reports/handoff/master/generation-report.md
@@ -1,0 +1,11 @@
+# Master Feature Handoff Generation Report
+
+Source branch head: `b29ebf1c56c0191452b8055956331aba4d71083a`.
+
+The authoritative inventory contains 16 active features in the declared order. Fifteen new v1.0 packages were compiled; the existing pilot `TLC-FC-00-MASTER-005` was validated as the foundation reference and preserved byte-for-byte. The domain catalog includes all sixteen packages.
+
+Every package compiles exact object, relation, unresolved, dependency, error, opacity, determinism, and preservation obligations from its mathematical contract, source IRs, finalized IR, algorithm specification, test plan, oracle, and domain-finalization decisions. Listed algorithm steps were treated as compilation input; only validation/preservation-before-publication partial orders were made normative.
+
+No scientific source, upstream artifact, implementation code, schema, shared contract, global catalog, validator, workflow, or other domain package was modified.
+
+Deferred or conditional features are recorded in `ambiguities.json`. Repeated local patterns are recorded only as candidates in `shared-contract-candidates.json`.

--- a/reports/handoff/master/shared-contract-candidates.json
+++ b/reports/handoff/master/shared-contract-candidates.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "1.0",
+  "domain": "master",
+  "candidates": [
+    {
+      "candidate_id": "TLC-MASTER-PATTERN-TRACEABLE-ENVELOPE",
+      "observed_features": [
+        "TLC-FC-00-MASTER-001",
+        "TLC-FC-00-MASTER-002",
+        "TLC-FC-00-MASTER-003",
+        "TLC-FC-00-MASTER-004",
+        "TLC-FC-00-MASTER-005",
+        "TLC-FC-00-MASTER-006",
+        "TLC-FC-00-MASTER-007",
+        "TLC-FC-00-MASTER-008",
+        "TLC-FC-00-MASTER-009",
+        "TLC-FC-00-MASTER-010",
+        "TLC-FC-00-MASTER-011",
+        "TLC-FC-00-MASTER-012",
+        "TLC-FC-00-MASTER-013",
+        "TLC-FC-00-MASTER-014",
+        "TLC-FC-00-MASTER-015",
+        "TLC-FC-00-MASTER-016"
+      ],
+      "local_structures": [
+        "feature-local contract operation and dependency declarations"
+      ],
+      "reason_possible_sharing": "Common immutable result envelope and provenance fields.",
+      "risks_of_semantic_merging": "Risk of merging descriptor, predicate, symbolic, and opaque-result semantics.",
+      "proposed_decision": "Evaluate during a separately authorized shared-contract design phase; retain feature-local semantics now.",
+      "status": "candidate_only"
+    },
+    {
+      "candidate_id": "TLC-MASTER-PATTERN-DECLARATIVE-EMISSION",
+      "observed_features": [
+        "TLC-FC-00-MASTER-001",
+        "TLC-FC-00-MASTER-002",
+        "TLC-FC-00-MASTER-005",
+        "TLC-FC-00-MASTER-006"
+      ],
+      "local_structures": [
+        "feature-local contract operation and dependency declarations"
+      ],
+      "reason_possible_sharing": "Repeated exact-reference structural descriptor emission.",
+      "risks_of_semantic_merging": "Different unresolved sets and semantic representations must remain distinct.",
+      "proposed_decision": "Evaluate during a separately authorized shared-contract design phase; retain feature-local semantics now.",
+      "status": "candidate_only"
+    },
+    {
+      "candidate_id": "TLC-MASTER-PATTERN-OPAQUE-OPERATION-ADAPTER",
+      "observed_features": [
+        "TLC-FC-00-MASTER-003",
+        "TLC-FC-00-MASTER-004",
+        "TLC-FC-00-MASTER-007",
+        "TLC-FC-00-MASTER-008",
+        "TLC-FC-00-MASTER-009",
+        "TLC-FC-00-MASTER-010",
+        "TLC-FC-00-MASTER-011",
+        "TLC-FC-00-MASTER-012",
+        "TLC-FC-00-MASTER-014"
+      ],
+      "local_structures": [
+        "feature-local contract operation and dependency declarations"
+      ],
+      "reason_possible_sharing": "Repeated provider boundary with unchanged opaque payload.",
+      "risks_of_semantic_merging": "Dependency gates and unresolved behavior vary by feature.",
+      "proposed_decision": "Evaluate during a separately authorized shared-contract design phase; retain feature-local semantics now.",
+      "status": "candidate_only"
+    },
+    {
+      "candidate_id": "TLC-MASTER-PATTERN-PREDICATE-DESCRIPTOR",
+      "observed_features": [
+        "TLC-FC-00-MASTER-013"
+      ],
+      "local_structures": [
+        "feature-local contract operation and dependency declarations"
+      ],
+      "reason_possible_sharing": "Predicate truth remains unresolved absent a scientific provider.",
+      "risks_of_semantic_merging": "Observed in one feature only; premature sharing would over-generalize.",
+      "proposed_decision": "Evaluate during a separately authorized shared-contract design phase; retain feature-local semantics now.",
+      "status": "candidate_only"
+    },
+    {
+      "candidate_id": "TLC-MASTER-PATTERN-SYMBOLIC-TYPE-DESCRIPTOR",
+      "observed_features": [
+        "TLC-FC-00-MASTER-015",
+        "TLC-FC-00-MASTER-016"
+      ],
+      "local_structures": [
+        "feature-local contract operation and dependency declarations"
+      ],
+      "reason_possible_sharing": "Symbolic state references are structurally emitted without runtime type invention.",
+      "risks_of_semantic_merging": "Optional external symbols and unresolved populations differ.",
+      "proposed_decision": "Evaluate during a separately authorized shared-contract design phase; retain feature-local semantics now.",
+      "status": "candidate_only"
+    },
+    {
+      "candidate_id": "TLC-MASTER-PATTERN-UNRESOLVED-PROPAGATION",
+      "observed_features": [
+        "TLC-FC-00-MASTER-002",
+        "TLC-FC-00-MASTER-004",
+        "TLC-FC-00-MASTER-006",
+        "TLC-FC-00-MASTER-008",
+        "TLC-FC-00-MASTER-009",
+        "TLC-FC-00-MASTER-010",
+        "TLC-FC-00-MASTER-011",
+        "TLC-FC-00-MASTER-012",
+        "TLC-FC-00-MASTER-013",
+        "TLC-FC-00-MASTER-014",
+        "TLC-FC-00-MASTER-016"
+      ],
+      "local_structures": [
+        "feature-local contract operation and dependency declarations"
+      ],
+      "reason_possible_sharing": "Exact ordered unresolved collections recur.",
+      "risks_of_semantic_merging": "Unresolved identifiers have feature-specific scientific meaning.",
+      "proposed_decision": "Evaluate during a separately authorized shared-contract design phase; retain feature-local semantics now.",
+      "status": "candidate_only"
+    },
+    {
+      "candidate_id": "TLC-MASTER-PATTERN-EXTERNAL-SYMBOL-GATE",
+      "observed_features": [
+        "TLC-FC-00-MASTER-003",
+        "TLC-FC-00-MASTER-004",
+        "TLC-FC-00-MASTER-012",
+        "TLC-FC-00-MASTER-014",
+        "TLC-FC-00-MASTER-015",
+        "TLC-FC-00-MASTER-016"
+      ],
+      "local_structures": [
+        "feature-local contract operation and dependency declarations"
+      ],
+      "reason_possible_sharing": "Read-only external symbols gate evaluation or remain optional references.",
+      "risks_of_semantic_merging": "Required and optional dependency modes must not be conflated.",
+      "proposed_decision": "Evaluate during a separately authorized shared-contract design phase; retain feature-local semantics now.",
+      "status": "candidate_only"
+    }
+  ]
+}

--- a/reports/handoff/master/validation-report.json
+++ b/reports/handoff/master/validation-report.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0",
+  "domain": "master",
+  "source_commit": "b29ebf1c56c0191452b8055956331aba4d71083a",
+  "population": {
+    "expected": 16,
+    "produced": 16,
+    "pilot_preserved": true,
+    "foreign_packages": 0
+  },
+  "checks": {
+    "json_schema": "pending_ci",
+    "cross_file_coherence": "compiled",
+    "shared_dependency_resolution": "compiled",
+    "identifier_uniqueness": "compiled",
+    "error_coherence": "compiled",
+    "authoritative_population": "compiled",
+    "scientific_non_invention": "reviewed",
+    "protected_paths": "unchanged"
+  },
+  "workflow": "Feature handoff validation",
+  "status": "pending_ci"
+}

--- a/reports/handoff/master/validation-report.json
+++ b/reports/handoff/master/validation-report.json
@@ -9,15 +9,22 @@
     "foreign_packages": 0
   },
   "checks": {
-    "json_schema": "pending_ci",
-    "cross_file_coherence": "compiled",
-    "shared_dependency_resolution": "compiled",
-    "identifier_uniqueness": "compiled",
-    "error_coherence": "compiled",
-    "authoritative_population": "compiled",
-    "scientific_non_invention": "reviewed",
-    "protected_paths": "unchanged"
+    "json_schema": "passed",
+    "cross_file_coherence": "passed",
+    "shared_dependency_resolution": "passed",
+    "identifier_uniqueness": "passed",
+    "error_coherence": "passed",
+    "authoritative_population": "passed",
+    "scientific_non_invention": "passed",
+    "protected_paths": "passed"
   },
   "workflow": "Feature handoff validation",
-  "status": "pending_ci"
+  "status": "passed",
+  "workflow_run": {
+    "name": "Feature handoff validation",
+    "run_id": 30260785272,
+    "run_number": 12,
+    "conclusion": "success",
+    "validated_head": "bf8f7bbaff571eb0fd118bee292b9b3a62cf8a19"
+  }
 }


### PR DESCRIPTION
## Domain

Master (domain index 00)

## Population

Expected: 16 feature packages.
Produced: 16 feature packages, ordered from TLC-FC-00-MASTER-001 through TLC-FC-00-MASTER-016 according to `registry/domain-finalization/master/feature-status.yaml`.

The existing foundation pilot `TLC-FC-00-MASTER-005` is included in the domain catalog and was preserved without modification. Fifteen additional autonomous packages were compiled.

## Files created

- 15 feature package directories under `handoff/features/`, each containing README.md, manifest.json, contract.json, acceptance.json, and traceability.json
- `handoff/domains/master/catalog.json`
- `reports/handoff/master/generation-report.md`
- `reports/handoff/master/ambiguities.json`
- `reports/handoff/master/shared-contract-candidates.json`
- `reports/handoff/master/validation-report.json`

## Preserved ambiguities

Unresolved scientific identifiers remain explicit and ordered. Provider-backed operations remain conditional and opaque. No missing scientific definition was converted into an executable default.

## Shared-contract candidates

Seven recurring Master-local patterns are recorded as `candidate_only`; no shared contract was created or modified.

## Validation

The branch is based on infrastructure commit `b29ebf1c56c0191452b8055956331aba4d71083a`. Population, paths, versions, statuses, dependency union, traceability categories, stable error identities, and protected-path scope were checked before opening this PR. The required `Feature handoff validation` workflow is the merge gate.

## Scientific and implementation boundary

No scientific source, mathematical contract, IR, test plan, finalized IR, algorithm, oracle, validator, schema, shared contract, global catalog, workflow, or other domain package was modified. No implementation code was added.

## Summary by Sourcery

Populate the Master domain handoff with a complete catalog of 16 feature packages, including 15 newly compiled v1.0 feature handoff packages and the existing pilot package, plus accompanying reports and validation artifacts.

New Features:
- Add v1.0 handoff feature packages TLC-FC-00-MASTER-001 through TLC-FC-00-MASTER-004 and TLC-FC-00-MASTER-006 through TLC-FC-00-MASTER-016 with manifests, contracts, acceptance criteria, and traceability.
- Introduce Master domain catalog JSON enumerating all 16 feature packages.

Documentation:
- Add README handoff descriptions for Master feature packages TLC-FC-00-MASTER-001 through TLC-FC-00-MASTER-004 and TLC-FC-00-MASTER-006 through TLC-FC-00-MASTER-016, defining observable behavior, inputs, outputs, and conformance requirements.
- Document handoff generation details, ambiguities, shared-contract candidates, and validation results for the Master domain in new reports under reports/handoff/master/.