### PR TITLE
fix(handoff): preserve authoritative error-code formats

### DIFF
--- a/handoff/schemas/contract.schema.json
+++ b/handoff/schemas/contract.schema.json
@@ -179,7 +179,7 @@
       "additionalProperties": false,
       "required": ["code", "category", "condition", "recoverability", "public_result", "failure_atomicity", "transport"],
       "properties": {
-        "code": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]+$"},
+        "code": {"type": "string", "pattern": "^(?:[A-Z][A-Z0-9_]+|[A-Z][A-Za-z0-9]+)$"},
         "category": {"type": "string", "minLength": 1},
         "condition": {"type": "string", "minLength": 1},
         "recoverability": {"enum": ["recoverable", "retryable", "non_retryable", "implementation_defined", "not_applicable"]},

--- a/reports/handoff/infrastructure/authoritative-error-code-formats.md
+++ b/reports/handoff/infrastructure/authoritative-error-code-formats.md
@@ -1,0 +1,5 @@
+# Authoritative error-code formats
+
+Feature sources use two stable public error-code conventions: uppercase snake case and PascalCase. The feature contract schema now accepts exactly those two forms so handoff packages can preserve authoritative identifiers without renaming them.
+
+The change does not alter any existing code, error meaning, package, shared contract, scientific artifact, or runtime transport. Codes must still begin with an uppercase letter and contain only ASCII letters, digits, and—only for the uppercase convention—underscores.


### PR DESCRIPTION
Allow the feature-contract schema to preserve the two established authoritative error-code conventions: existing uppercase snake case and source-defined PascalCase. The pattern remains closed to those two forms. No package, science, shared contract, validator behavior, or runtime transport is changed.

## Summary by Sourcery

Constrain handoff feature contract error-code validation to two accepted authoritative formats and document the allowed conventions.

Enhancements:
- Update the handoff feature contract schema to accept only uppercase snake case and PascalCase as authoritative error-code formats while preserving existing identifiers.

Documentation:
- Add documentation describing the authoritative error-code formats accepted by the handoff feature contract schema and clarifying that the change does not affect runtime behavior.