### PR TITLE
feat(handoff): compile Invariants feature packages

### DIFF
--- a/handoff/domains/invariants/catalog.json
+++ b/handoff/domains/invariants/catalog.json
@@ -80,7 +80,7 @@
   ],
   "statuses": {
     "population": "complete",
-    "validation": "pending"
+    "validation": "validated"
   },
   "shared_dependencies": [
     {

--- a/handoff/domains/invariants/catalog.json
+++ b/handoff/domains/invariants/catalog.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": "1.0",
+  "package_model_version": "1.0.0",
+  "domain": "invariants",
+  "domain_index": 4,
+  "expected_feature_count": 10,
+  "ordered_feature_ids": [
+    "TLC-FC-04-INVARIANTS-001",
+    "TLC-FC-04-INVARIANTS-002",
+    "TLC-FC-04-INVARIANTS-003",
+    "TLC-FC-04-INVARIANTS-004",
+    "TLC-FC-04-INVARIANTS-005",
+    "TLC-FC-04-INVARIANTS-006",
+    "TLC-FC-04-INVARIANTS-007",
+    "TLC-FC-04-INVARIANTS-008",
+    "TLC-FC-04-INVARIANTS-009",
+    "TLC-FC-04-INVARIANTS-010"
+  ],
+  "feature_packages": [
+    {
+      "feature_id": "TLC-FC-04-INVARIANTS-001",
+      "path": "handoff/features/TLC-FC-04-INVARIANTS-001",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-04-INVARIANTS-002",
+      "path": "handoff/features/TLC-FC-04-INVARIANTS-002",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-04-INVARIANTS-003",
+      "path": "handoff/features/TLC-FC-04-INVARIANTS-003",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-04-INVARIANTS-004",
+      "path": "handoff/features/TLC-FC-04-INVARIANTS-004",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-04-INVARIANTS-005",
+      "path": "handoff/features/TLC-FC-04-INVARIANTS-005",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-04-INVARIANTS-006",
+      "path": "handoff/features/TLC-FC-04-INVARIANTS-006",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-04-INVARIANTS-007",
+      "path": "handoff/features/TLC-FC-04-INVARIANTS-007",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-04-INVARIANTS-008",
+      "path": "handoff/features/TLC-FC-04-INVARIANTS-008",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-04-INVARIANTS-009",
+      "path": "handoff/features/TLC-FC-04-INVARIANTS-009",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-04-INVARIANTS-010",
+      "path": "handoff/features/TLC-FC-04-INVARIANTS-010",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    }
+  ],
+  "statuses": {
+    "population": "complete",
+    "validation": "pending"
+  },
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "metadata": {
+    "authoritative_inventory": "registry/domain-finalization/invariants/feature-status.yaml",
+    "generated_by": "Feature Handoff Package compiler",
+    "validation_tool": "tools/handoff/validate_handoff.py",
+    "source_commit": "022e6076ceeeb87b31065f2a9a28e95f1811d077"
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-001/README.md
+++ b/handoff/features/TLC-FC-04-INVARIANTS-001/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-04-INVARIANTS-001 — Admissibility constraint set
+
+This package defines the final structural handoff for Admissibility constraint set.
+
+## What must be implemented
+
+Implement `build_admissibility_constraint_set` as a deterministic, immutable evidence transformation. It validates feature-covered identities and source references, preserves opaque content and historical catalogue status, and returns a `ConstraintSet` with complete provenance.
+
+## Valid inputs and required output
+
+The accepted covered evidence identities are: TLC-SO-INVARIANTS-010, TLC-SO-INVARIANTS-032, TLC-SO-INVARIANTS-033, TLC-SO-INVARIANTS-046, TLC-SR-INVARIANTS-009, TLC-SR-INVARIANTS-031, TLC-SR-INVARIANTS-032, TLC-SR-INVARIANTS-045. The required catalogue status is `retained_with_reservations`. Required unresolved identifiers are: none. Required provisional assumptions are: TLC-EA-INVARIANTS-001-001.
+
+The required output is an immutable `ConstraintSet`. returns exactly one entry per supplied covered axiom ID with source order and references retained
+
+## Mandatory and forbidden behavior
+
+Identity, source order, provenance, opaque values, status, assumptions, reservations, unresolved mappings, input immutability, deterministic structural equality, and failure atomicity are mandatory. Scientific truth evaluation, status promotion, inferred thresholds or comparators, transition graphs, chronology, causality, symmetry, transitivity, dimensions, units, precision, and numerical methods are forbidden.
+
+## Implementation freedom
+
+Language, public wrapper naming, storage, allocation, ownership mechanism, serialization, concurrency policy, error transport, and internal traversal remain free when observable behavior is unchanged.
+
+## Errors and conformance
+
+The authoritative observable error codes are: DuplicateAxiomId, UnknownAxiomId, MissingSourceReference, ScientificEvaluationProhibited, PreservationViolation. Errors publish no partial result. Conformance requires every test in `acceptance.json`, exact preservation of the source envelope, and rejection of scientific evaluation. Scientific truth conditions remain opaque and require future externally sourced evaluation semantics.

--- a/handoff/features/TLC-FC-04-INVARIANTS-001/acceptance.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-001/acceptance.json
@@ -1,0 +1,189 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-001",
+  "tests": [
+    {
+      "test_id": "INV001-ACCEPT-NOMINAL",
+      "applies_to": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-04-INVARIANTS-001",
+        "covered_evidence_ids": [
+          "TLC-SO-INVARIANTS-010",
+          "TLC-SO-INVARIANTS-032",
+          "TLC-SO-INVARIANTS-033",
+          "TLC-SO-INVARIANTS-046",
+          "TLC-SR-INVARIANTS-009",
+          "TLC-SR-INVARIANTS-031",
+          "TLC-SR-INVARIANTS-032",
+          "TLC-SR-INVARIANTS-045"
+        ],
+        "catalogue_status": "retained_with_reservations",
+        "unresolved_refs": []
+      },
+      "when": "The build_admissibility_constraint_set oracle scenario is exercised.",
+      "expect": {
+        "accepted": true,
+        "output_type": "ConstraintSet",
+        "immutable": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV001-ACCEPT-PRECONDITION-DUPLICATE",
+      "applies_to": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV001-ACCEPT-PRECONDITION-DUPLICATE"
+      },
+      "when": "The build_admissibility_constraint_set oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV001-ACCEPT-PRECONDITION-UNKNOWN",
+      "applies_to": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV001-ACCEPT-PRECONDITION-UNKNOWN"
+      },
+      "when": "The build_admissibility_constraint_set oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV001-ACCEPT-SOURCE-REFERENCE",
+      "applies_to": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV001-ACCEPT-SOURCE-REFERENCE"
+      },
+      "when": "The build_admissibility_constraint_set oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV001-ACCEPT-OPAQUE",
+      "applies_to": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV001-ACCEPT-OPAQUE"
+      },
+      "when": "The build_admissibility_constraint_set oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV001-ACCEPT-ORDER",
+      "applies_to": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV001-ACCEPT-ORDER"
+      },
+      "when": "The build_admissibility_constraint_set oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV001-ACCEPT-DETERMINISM",
+      "applies_to": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "category": "determinism",
+      "given": {
+        "authoritative_oracle_scenario": "INV001-ACCEPT-DETERMINISM"
+      },
+      "when": "The build_admissibility_constraint_set oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV001-ACCEPT-RESERVATIONS",
+      "applies_to": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV001-ACCEPT-RESERVATIONS"
+      },
+      "when": "The build_admissibility_constraint_set oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV001-ACCEPT-NO-SCIENCE",
+      "applies_to": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "category": "unsupported_operation",
+      "given": {
+        "authoritative_oracle_scenario": "INV001-ACCEPT-NO-SCIENCE"
+      },
+      "when": "The build_admissibility_constraint_set oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV001-ACCEPT-CONFORMANCE",
+      "applies_to": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV001-ACCEPT-CONFORMANCE"
+      },
+      "when": "The build_admissibility_constraint_set oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-001/contract.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-001/contract.json
@@ -1,0 +1,459 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-04-INVARIANTS-001",
+    "title": "Admissibility constraint set",
+    "domain": "invariants"
+  },
+  "purpose": "Validate source-backed admissibility constraint set evidence and returns exactly one entry per supplied covered axiom ID with source order and references retained Scientific truth evaluation is not performed.",
+  "scope": {
+    "required": [
+      {
+        "id": "INV001-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-04-INVARIANTS-001 and covered evidence identifiers [TLC-SO-INVARIANTS-010, TLC-SO-INVARIANTS-032, TLC-SO-INVARIANTS-033, TLC-SO-INVARIANTS-046, TLC-SR-INVARIANTS-009, TLC-SR-INVARIANTS-031, TLC-SR-INVARIANTS-032, TLC-SR-INVARIANTS-045].",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-001/contract.yaml",
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-001/ir.yaml"
+        ]
+      },
+      {
+        "id": "INV001-REQ-002",
+        "statement": "Preserve catalogue status retained_with_reservations, source order, provenance, opaque values, unresolved identifiers [], and assumptions [TLC-EA-INVARIANTS-001-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-001/contract.yaml",
+          "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml"
+        ]
+      },
+      {
+        "id": "INV001-REQ-003",
+        "statement": "Emit an immutable ConstraintSet with a complete preservation envelope.",
+        "basis": [
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-001/ir.yaml",
+          "registry/domain-finalization/invariants/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "INV001-FOR-001",
+        "statement": "Do not evaluate scientific truth or infer a comparator, threshold value, runtime domain, transition graph, chronology, causality, symmetry, transitivity, units, dimensions, precision, or numerical method."
+      },
+      {
+        "id": "INV001-FOR-002",
+        "statement": "Do not promote documentary, deferred, provisionally separated, or rejected source metadata to executable scientific status."
+      },
+      {
+        "id": "INV001-FOR-003",
+        "statement": "Do not mutate inputs, scientific state, external domain state, or publish a partial successful result."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "INV001-DEF-001",
+        "statement": "Scientific evaluation requires a future externally sourced evaluator; this package defines no evaluator interface or truth criterion."
+      },
+      {
+        "id": "INV001-DEF-002",
+        "statement": "Opaque scientific truth conditions remain external and uninterpreted."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "BUILD-ADMISSIBILITY-CONSTRAINT-SET",
+      "purpose": "Construct the immutable ConstraintSet from validated source evidence without scientific evaluation.",
+      "inputs": [
+        {
+          "name": "evidence",
+          "semantic_role": "AdmissibilityAxiomRecord[]",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-04-INVARIANTS-001"
+            },
+            {
+              "name": "evidence_ids",
+              "required": true,
+              "semantic_role": "exact covered object and relation identities",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-INVARIANTS-010",
+                "TLC-SO-INVARIANTS-032",
+                "TLC-SO-INVARIANTS-033",
+                "TLC-SO-INVARIANTS-046",
+                "TLC-SR-INVARIANTS-009",
+                "TLC-SR-INVARIANTS-031",
+                "TLC-SR-INVARIANTS-032",
+                "TLC-SR-INVARIANTS-045"
+              ]
+            },
+            {
+              "name": "source_references",
+              "required": true,
+              "semantic_role": "source provenance for every evidence item",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_values",
+              "required": true,
+              "semantic_role": "uninterpreted source statements and scientific truth conditions",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "catalogue_status",
+              "required": true,
+              "semantic_role": "exact historical catalogue status",
+              "constant": "retained_with_reservations"
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact unresolved identifiers attached to affected evidence",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "assumption_refs",
+              "required": true,
+              "semantic_role": "exact provisional engineering assumption identifiers",
+              "allowed_values": [
+                "TLC-EA-INVARIANTS-001-001"
+              ]
+            }
+          ],
+          "collection": {
+            "kind": "ordered_set",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-INVARIANTS-010",
+              "TLC-SO-INVARIANTS-032",
+              "TLC-SO-INVARIANTS-033",
+              "TLC-SO-INVARIANTS-046",
+              "TLC-SR-INVARIANTS-009",
+              "TLC-SR-INVARIANTS-031",
+              "TLC-SR-INVARIANTS-032",
+              "TLC-SR-INVARIANTS-045"
+            ],
+            "cardinality": {
+              "minimum": 8,
+              "maximum": 8
+            },
+            "ordering": "required",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV001-IN-001",
+              "statement": "Every supplied identity is feature-covered, unique where required, and accompanied by source provenance."
+            },
+            {
+              "id": "INV001-IN-002",
+              "statement": "Source-declared order is preserved; otherwise validated input order is retained only as engineering order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable ConstraintSet",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-04-INVARIANTS-001"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "feature-specific structural representation",
+              "constant": "ConstraintSet"
+            },
+            {
+              "name": "entries",
+              "required": true,
+              "semantic_role": "immutable evidence entries with exact identities and order",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "unresolved identifiers attached to affected entries",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete preservation envelope",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "preserved catalogue and scientific status",
+              "constant": "retained_with_reservations"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV001-OUT-001",
+              "statement": "returns exactly one entry per supplied covered axiom ID with source order and references retained"
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "INV001-PRE-001",
+          "statement": "Every required identity, relationship, source reference, opaque symbol, unresolved mapping, and status value is present and source-consistent."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "INV001-POST-001",
+          "statement": "returns exactly one entry per supplied covered axiom ID with source order and references retained No scientific truth claim is added."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "INV001-INV-001",
+          "statement": "Covered identities, source order, references, opaque values, catalogue status, assumptions, reservations, and unresolved mappings are unchanged."
+        },
+        {
+          "id": "INV001-INV-002",
+          "statement": "Inputs and all external or scientific state remain unmodified."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate covered identities and required provenance",
+          "validate status, unresolved, assumption, and opaque preservation metadata",
+          "construct the feature-specific immutable representation",
+          "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate covered identities and required provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "validate status, unresolved, assumption, and opaque preservation metadata",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct the feature-specific immutable representation",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Validation and conservation must precede publication. The upstream total traversal sequence is not a unique architectural prescription."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "owned_result",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "result_lifetime",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "required",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "not_applicable",
+        "floating_point": "not_applicable",
+        "randomness": "forbidden"
+      },
+      "error_contract": [
+        {
+          "code": "DuplicateAxiomId",
+          "category": "invalid_input",
+          "condition": "A supplied axiom identity is duplicated.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnknownAxiomId",
+          "category": "invalid_input",
+          "condition": "An axiom identity is outside feature coverage.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "invalid_input",
+          "condition": "Required source provenance is absent.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificEvaluationProhibited",
+          "category": "unsupported_operation",
+          "condition": "Truth, numeric, temporal, ordering, state, transition, or other scientific evaluation is requested without a sourced evaluator.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "PreservationViolation",
+          "category": "preservation",
+          "condition": "A source identity, order, opaque value, status, assumption, reservation, unresolved mapping, or provenance link changes or is lost.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-construction",
+      "status": "required",
+      "statement": "Expose build_admissibility_constraint_set as a deterministic structural operation producing ConstraintSet."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not decide truth, compute numerical values, detect states, or infer transitions."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal representation and validation decomposition remain free when observable preservation behavior is identical."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "INV001-GINV-001",
+      "statement": "No implementation behavior may weaken source identity, order, opacity, status, unresolved, assumption, reservation, immutability, or provenance obligations."
+    },
+    {
+      "id": "INV001-GINV-002",
+      "statement": "Historical rejection or deferral metadata is documentary and must remain visible without suppressing this finalized structural operation."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific and evidence references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered identifier collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted source statements and scientific truth conditions"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral structural errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable preservation result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is structural and behavioral. It does not prescribe a programming language, serialization, storage model, or complete internal step order."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-001/manifest.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-001/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-04-INVARIANTS-001",
+  "title": "Admissibility constraint set",
+  "domain": "invariants",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "external_provider_required",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-001/traceability.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-001/traceability.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-001",
+  "scientific_sources": [
+    {
+      "path": "maths/04-invariants.md",
+      "role": "Authoritative scientific source sections cited by the limited engineering contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-001/contract.yaml",
+      "role": "Defines covered evidence, exact structural behavior, reservations, and scientific boundary.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "fb4cd02fb17b2a48712603a770c31e9c6ecc3b7f"
+      }
+    },
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-001/traceability.yaml",
+      "role": "Preserves detailed contract-to-source traceability.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "3f6e35bac2f6899a015365c66a48c1b6bad11f8f"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-001/ir.prototype.json",
+      "role": "Prototype IR with reservations and operation-specific interface.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "680f34df3b243cc2f197ba5c6d3b1624addf5aba"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-001/ir.yaml",
+      "role": "Selected finalized IR defining immutable structural behavior and stable errors.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "a549d65db2c82672e6f5536f6e6794f22748ec26"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/invariants/TLC-FC-04-INVARIANTS-001/algorithm.yaml",
+      "role": "Applicable validation, construction, conservation, and error branches; total ordering is not adopted beyond observable requirements.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "46beef3b806d20ee738f26f67f3e48f6f25b3269"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-001/test-plan.yaml",
+      "role": "Source structural test plan and reservation-preservation scenarios.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "30ab3e5077fb74733fdc1ea8646003b16d9434a7"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/invariants/TLC-FC-04-INVARIANTS-001/oracle.yaml",
+      "role": "Authoritative nominal, error, opacity, ordering, determinism, and conformance expectations.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "d126043280b267a6a753ae5f1c599f31fb1d15df"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/invariants/feature-status.yaml",
+      "role": "Authoritative ten-feature inventory and historical status interpretation."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/module-specification.yaml",
+      "role": "Defines public operations, common structural rules, error vocabulary, dependencies, and scientific boundary."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/implementation-tasks.yaml",
+      "role": "Defines feature deliverables and acceptance obligations."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/patterns.yaml",
+      "role": "Records domain-local common patterns without creating shared handoff contracts."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-002/README.md
+++ b/handoff/features/TLC-FC-04-INVARIANTS-002/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-04-INVARIANTS-002 — Documentary definition evidence index
+
+This package defines the final structural handoff for Documentary definition evidence index.
+
+## What must be implemented
+
+Implement `index_definition_fragments` as a deterministic, immutable evidence transformation. It validates feature-covered identities and source references, preserves opaque content and historical catalogue status, and returns a `DefinitionEvidenceIndex` with complete provenance.
+
+## Valid inputs and required output
+
+The accepted covered evidence identities are: TLC-SO-INVARIANTS-017, TLC-SO-INVARIANTS-022, TLC-SO-INVARIANTS-027, TLC-SO-INVARIANTS-035, TLC-SO-INVARIANTS-040, TLC-SO-INVARIANTS-045, TLC-SO-INVARIANTS-053, TLC-SO-INVARIANTS-058, TLC-SO-INVARIANTS-062, TLC-SR-INVARIANTS-016, TLC-SR-INVARIANTS-021, TLC-SR-INVARIANTS-026, TLC-SR-INVARIANTS-034, TLC-SR-INVARIANTS-039, TLC-SR-INVARIANTS-044, TLC-SR-INVARIANTS-052, TLC-SR-INVARIANTS-057, TLC-SR-INVARIANTS-061. The required catalogue status is `rejected_as_feature`. Required unresolved identifiers are: none. Required provisional assumptions are: TLC-EA-INVARIANTS-002-001.
+
+The required output is an immutable `DefinitionEvidenceIndex`. returns an index keyed by definition object ID with every entry documentary and non-executable
+
+## Mandatory and forbidden behavior
+
+Identity, source order, provenance, opaque values, status, assumptions, reservations, unresolved mappings, input immutability, deterministic structural equality, and failure atomicity are mandatory. Scientific truth evaluation, status promotion, inferred thresholds or comparators, transition graphs, chronology, causality, symmetry, transitivity, dimensions, units, precision, and numerical methods are forbidden.
+
+## Implementation freedom
+
+Language, public wrapper naming, storage, allocation, ownership mechanism, serialization, concurrency policy, error transport, and internal traversal remain free when observable behavior is unchanged.
+
+## Errors and conformance
+
+The authoritative observable error codes are: DuplicateDefinitionId, InvalidCoveredIdentifier, MissingSourceReference, FeatureStatusPromotion, ScientificEvaluationProhibited, PreservationViolation. Errors publish no partial result. Conformance requires every test in `acceptance.json`, exact preservation of the source envelope, and rejection of scientific evaluation. Scientific truth conditions remain opaque and require future externally sourced evaluation semantics.

--- a/handoff/features/TLC-FC-04-INVARIANTS-002/acceptance.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-002/acceptance.json
@@ -1,0 +1,199 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-002",
+  "tests": [
+    {
+      "test_id": "INV002-ACCEPT-NOMINAL",
+      "applies_to": "INDEX-DEFINITION-FRAGMENTS",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-04-INVARIANTS-002",
+        "covered_evidence_ids": [
+          "TLC-SO-INVARIANTS-017",
+          "TLC-SO-INVARIANTS-022",
+          "TLC-SO-INVARIANTS-027",
+          "TLC-SO-INVARIANTS-035",
+          "TLC-SO-INVARIANTS-040",
+          "TLC-SO-INVARIANTS-045",
+          "TLC-SO-INVARIANTS-053",
+          "TLC-SO-INVARIANTS-058",
+          "TLC-SO-INVARIANTS-062",
+          "TLC-SR-INVARIANTS-016",
+          "TLC-SR-INVARIANTS-021",
+          "TLC-SR-INVARIANTS-026",
+          "TLC-SR-INVARIANTS-034",
+          "TLC-SR-INVARIANTS-039",
+          "TLC-SR-INVARIANTS-044",
+          "TLC-SR-INVARIANTS-052",
+          "TLC-SR-INVARIANTS-057",
+          "TLC-SR-INVARIANTS-061"
+        ],
+        "catalogue_status": "rejected_as_feature",
+        "unresolved_refs": []
+      },
+      "when": "The index_definition_fragments oracle scenario is exercised.",
+      "expect": {
+        "accepted": true,
+        "output_type": "DefinitionEvidenceIndex",
+        "immutable": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV002-ACCEPT-DUPLICATE",
+      "applies_to": "INDEX-DEFINITION-FRAGMENTS",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV002-ACCEPT-DUPLICATE"
+      },
+      "when": "The index_definition_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV002-ACCEPT-UNKNOWN",
+      "applies_to": "INDEX-DEFINITION-FRAGMENTS",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV002-ACCEPT-UNKNOWN"
+      },
+      "when": "The index_definition_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV002-ACCEPT-SOURCE-RANGE",
+      "applies_to": "INDEX-DEFINITION-FRAGMENTS",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV002-ACCEPT-SOURCE-RANGE"
+      },
+      "when": "The index_definition_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV002-ACCEPT-STATUS",
+      "applies_to": "INDEX-DEFINITION-FRAGMENTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV002-ACCEPT-STATUS"
+      },
+      "when": "The index_definition_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV002-ACCEPT-OPAQUE",
+      "applies_to": "INDEX-DEFINITION-FRAGMENTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV002-ACCEPT-OPAQUE"
+      },
+      "when": "The index_definition_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV002-ACCEPT-ORDER",
+      "applies_to": "INDEX-DEFINITION-FRAGMENTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV002-ACCEPT-ORDER"
+      },
+      "when": "The index_definition_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV002-ACCEPT-DETERMINISM",
+      "applies_to": "INDEX-DEFINITION-FRAGMENTS",
+      "category": "determinism",
+      "given": {
+        "authoritative_oracle_scenario": "INV002-ACCEPT-DETERMINISM"
+      },
+      "when": "The index_definition_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV002-ACCEPT-ASSUMPTION",
+      "applies_to": "INDEX-DEFINITION-FRAGMENTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV002-ACCEPT-ASSUMPTION"
+      },
+      "when": "The index_definition_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV002-ACCEPT-CONFORMANCE",
+      "applies_to": "INDEX-DEFINITION-FRAGMENTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV002-ACCEPT-CONFORMANCE"
+      },
+      "when": "The index_definition_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-002/contract.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-002/contract.json
@@ -1,0 +1,488 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-04-INVARIANTS-002",
+    "title": "Documentary definition evidence index",
+    "domain": "invariants"
+  },
+  "purpose": "Validate source-backed documentary definition evidence index evidence and returns an index keyed by definition object ID with every entry documentary and non-executable Scientific truth evaluation is not performed.",
+  "scope": {
+    "required": [
+      {
+        "id": "INV002-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-04-INVARIANTS-002 and covered evidence identifiers [TLC-SO-INVARIANTS-017, TLC-SO-INVARIANTS-022, TLC-SO-INVARIANTS-027, TLC-SO-INVARIANTS-035, TLC-SO-INVARIANTS-040, TLC-SO-INVARIANTS-045, TLC-SO-INVARIANTS-053, TLC-SO-INVARIANTS-058, TLC-SO-INVARIANTS-062, TLC-SR-INVARIANTS-016, TLC-SR-INVARIANTS-021, TLC-SR-INVARIANTS-026, TLC-SR-INVARIANTS-034, TLC-SR-INVARIANTS-039, TLC-SR-INVARIANTS-044, TLC-SR-INVARIANTS-052, TLC-SR-INVARIANTS-057, TLC-SR-INVARIANTS-061].",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-002/contract.yaml",
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-002/ir.yaml"
+        ]
+      },
+      {
+        "id": "INV002-REQ-002",
+        "statement": "Preserve catalogue status rejected_as_feature, source order, provenance, opaque values, unresolved identifiers [], and assumptions [TLC-EA-INVARIANTS-002-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-002/contract.yaml",
+          "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml"
+        ]
+      },
+      {
+        "id": "INV002-REQ-003",
+        "statement": "Emit an immutable DefinitionEvidenceIndex with a complete preservation envelope.",
+        "basis": [
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-002/ir.yaml",
+          "registry/domain-finalization/invariants/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "INV002-FOR-001",
+        "statement": "Do not evaluate scientific truth or infer a comparator, threshold value, runtime domain, transition graph, chronology, causality, symmetry, transitivity, units, dimensions, precision, or numerical method."
+      },
+      {
+        "id": "INV002-FOR-002",
+        "statement": "Do not promote documentary, deferred, provisionally separated, or rejected source metadata to executable scientific status."
+      },
+      {
+        "id": "INV002-FOR-003",
+        "statement": "Do not mutate inputs, scientific state, external domain state, or publish a partial successful result."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "INV002-DEF-001",
+        "statement": "Scientific evaluation requires a future externally sourced evaluator; this package defines no evaluator interface or truth criterion."
+      },
+      {
+        "id": "INV002-DEF-002",
+        "statement": "Opaque scientific truth conditions remain external and uninterpreted."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "INDEX-DEFINITION-FRAGMENTS",
+      "purpose": "Construct the immutable DefinitionEvidenceIndex from validated source evidence without scientific evaluation.",
+      "inputs": [
+        {
+          "name": "evidence",
+          "semantic_role": "DefinitionFragment[]",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-04-INVARIANTS-002"
+            },
+            {
+              "name": "evidence_ids",
+              "required": true,
+              "semantic_role": "exact covered object and relation identities",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-INVARIANTS-017",
+                "TLC-SO-INVARIANTS-022",
+                "TLC-SO-INVARIANTS-027",
+                "TLC-SO-INVARIANTS-035",
+                "TLC-SO-INVARIANTS-040",
+                "TLC-SO-INVARIANTS-045",
+                "TLC-SO-INVARIANTS-053",
+                "TLC-SO-INVARIANTS-058",
+                "TLC-SO-INVARIANTS-062",
+                "TLC-SR-INVARIANTS-016",
+                "TLC-SR-INVARIANTS-021",
+                "TLC-SR-INVARIANTS-026",
+                "TLC-SR-INVARIANTS-034",
+                "TLC-SR-INVARIANTS-039",
+                "TLC-SR-INVARIANTS-044",
+                "TLC-SR-INVARIANTS-052",
+                "TLC-SR-INVARIANTS-057",
+                "TLC-SR-INVARIANTS-061"
+              ]
+            },
+            {
+              "name": "source_references",
+              "required": true,
+              "semantic_role": "source provenance for every evidence item",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_values",
+              "required": true,
+              "semantic_role": "uninterpreted source statements and scientific truth conditions",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "catalogue_status",
+              "required": true,
+              "semantic_role": "exact historical catalogue status",
+              "constant": "rejected_as_feature"
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact unresolved identifiers attached to affected evidence",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "assumption_refs",
+              "required": true,
+              "semantic_role": "exact provisional engineering assumption identifiers",
+              "allowed_values": [
+                "TLC-EA-INVARIANTS-002-001"
+              ]
+            }
+          ],
+          "collection": {
+            "kind": "ordered_set",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-INVARIANTS-017",
+              "TLC-SO-INVARIANTS-022",
+              "TLC-SO-INVARIANTS-027",
+              "TLC-SO-INVARIANTS-035",
+              "TLC-SO-INVARIANTS-040",
+              "TLC-SO-INVARIANTS-045",
+              "TLC-SO-INVARIANTS-053",
+              "TLC-SO-INVARIANTS-058",
+              "TLC-SO-INVARIANTS-062",
+              "TLC-SR-INVARIANTS-016",
+              "TLC-SR-INVARIANTS-021",
+              "TLC-SR-INVARIANTS-026",
+              "TLC-SR-INVARIANTS-034",
+              "TLC-SR-INVARIANTS-039",
+              "TLC-SR-INVARIANTS-044",
+              "TLC-SR-INVARIANTS-052",
+              "TLC-SR-INVARIANTS-057",
+              "TLC-SR-INVARIANTS-061"
+            ],
+            "cardinality": {
+              "minimum": 18,
+              "maximum": 18
+            },
+            "ordering": "required",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV002-IN-001",
+              "statement": "Every supplied identity is feature-covered, unique where required, and accompanied by source provenance."
+            },
+            {
+              "id": "INV002-IN-002",
+              "statement": "Source-declared order is preserved; otherwise validated input order is retained only as engineering order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable DefinitionEvidenceIndex",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-04-INVARIANTS-002"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "feature-specific structural representation",
+              "constant": "DefinitionEvidenceIndex"
+            },
+            {
+              "name": "entries",
+              "required": true,
+              "semantic_role": "immutable evidence entries with exact identities and order",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "unresolved identifiers attached to affected entries",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete preservation envelope",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "preserved catalogue and scientific status",
+              "constant": "rejected_as_feature"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV002-OUT-001",
+              "statement": "returns an index keyed by definition object ID with every entry documentary and non-executable"
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "INV002-PRE-001",
+          "statement": "Every required identity, relationship, source reference, opaque symbol, unresolved mapping, and status value is present and source-consistent."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "INV002-POST-001",
+          "statement": "returns an index keyed by definition object ID with every entry documentary and non-executable No scientific truth claim is added."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "INV002-INV-001",
+          "statement": "Covered identities, source order, references, opaque values, catalogue status, assumptions, reservations, and unresolved mappings are unchanged."
+        },
+        {
+          "id": "INV002-INV-002",
+          "statement": "Inputs and all external or scientific state remain unmodified."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate covered identities and required provenance",
+          "validate status, unresolved, assumption, and opaque preservation metadata",
+          "construct the feature-specific immutable representation",
+          "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate covered identities and required provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "validate status, unresolved, assumption, and opaque preservation metadata",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct the feature-specific immutable representation",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Validation and conservation must precede publication. The upstream total traversal sequence is not a unique architectural prescription."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "owned_result",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "result_lifetime",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "required",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "not_applicable",
+        "floating_point": "not_applicable",
+        "randomness": "forbidden"
+      },
+      "error_contract": [
+        {
+          "code": "DuplicateDefinitionId",
+          "category": "invalid_input",
+          "condition": "The authoritative DuplicateDefinitionId condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "InvalidCoveredIdentifier",
+          "category": "invalid_input",
+          "condition": "An evidence identifier is outside feature coverage.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "invalid_input",
+          "condition": "Required source provenance is absent.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "FeatureStatusPromotion",
+          "category": "preservation",
+          "condition": "Rejected documentary feature status is promoted.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificEvaluationProhibited",
+          "category": "unsupported_operation",
+          "condition": "Truth, numeric, temporal, ordering, state, transition, or other scientific evaluation is requested without a sourced evaluator.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "PreservationViolation",
+          "category": "preservation",
+          "condition": "A source identity, order, opaque value, status, assumption, reservation, unresolved mapping, or provenance link changes or is lost.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-construction",
+      "status": "required",
+      "statement": "Expose index_definition_fragments as a deterministic structural operation producing DefinitionEvidenceIndex."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not decide truth, compute numerical values, detect states, or infer transitions."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal representation and validation decomposition remain free when observable preservation behavior is identical."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "INV002-GINV-001",
+      "statement": "No implementation behavior may weaken source identity, order, opacity, status, unresolved, assumption, reservation, immutability, or provenance obligations."
+    },
+    {
+      "id": "INV002-GINV-002",
+      "statement": "Historical rejection or deferral metadata is documentary and must remain visible without suppressing this finalized structural operation."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific and evidence references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered identifier collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted source statements and scientific truth conditions"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral structural errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable preservation result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is structural and behavioral. It does not prescribe a programming language, serialization, storage model, or complete internal step order."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-002/manifest.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-002/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-04-INVARIANTS-002",
+  "title": "Documentary definition evidence index",
+  "domain": "invariants",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "external_provider_required",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-002/traceability.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-002/traceability.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-002",
+  "scientific_sources": [
+    {
+      "path": "maths/04-invariants.md",
+      "role": "Authoritative scientific source sections cited by the limited engineering contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-002/contract.yaml",
+      "role": "Defines covered evidence, exact structural behavior, reservations, and scientific boundary.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "357a631eed6565c8fb150730544f99c91dc57336"
+      }
+    },
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-002/traceability.yaml",
+      "role": "Preserves detailed contract-to-source traceability.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "13a0f3083fed813f4851222a786cf35722acf586"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-002/ir.prototype.json",
+      "role": "Prototype IR with reservations and operation-specific interface.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "a53a1a8b93ae285d1e1eba549b616fd61fbd2d63"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-002/ir.yaml",
+      "role": "Selected finalized IR defining immutable structural behavior and stable errors.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "4989b0081032754a7ca275f3c9e64cd044d95beb"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/invariants/TLC-FC-04-INVARIANTS-002/algorithm.yaml",
+      "role": "Applicable validation, construction, conservation, and error branches; total ordering is not adopted beyond observable requirements.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "6fa8d0d7c0a6ede9bc7398a59f80d8209c9ec93b"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-002/test-plan.yaml",
+      "role": "Source structural test plan and reservation-preservation scenarios.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "a08be693bfb282e51be6a7489f7a29891cf262ac"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/invariants/TLC-FC-04-INVARIANTS-002/oracle.yaml",
+      "role": "Authoritative nominal, error, opacity, ordering, determinism, and conformance expectations.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "7ec49de4120ad67b53299489b0dfd0726b14ec4e"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/invariants/feature-status.yaml",
+      "role": "Authoritative ten-feature inventory and historical status interpretation."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/module-specification.yaml",
+      "role": "Defines public operations, common structural rules, error vocabulary, dependencies, and scientific boundary."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/implementation-tasks.yaml",
+      "role": "Defines feature deliverables and acceptance obligations."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/patterns.yaml",
+      "role": "Records domain-local common patterns without creating shared handoff contracts."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-003/README.md
+++ b/handoff/features/TLC-FC-04-INVARIANTS-003/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-04-INVARIANTS-003 — Invariant declaration catalog
+
+This package defines the final structural handoff for Invariant declaration catalog.
+
+## What must be implemented
+
+Implement `build_invariant_declaration_catalog` as a deterministic, immutable evidence transformation. It validates feature-covered identities and source references, preserves opaque content and historical catalogue status, and returns a `InvariantDeclarationCatalog` with complete provenance.
+
+## Valid inputs and required output
+
+The accepted covered evidence identities are: TLC-SO-INVARIANTS-002, TLC-SO-INVARIANTS-003, TLC-SO-INVARIANTS-004, TLC-SO-INVARIANTS-005, TLC-SO-INVARIANTS-006, TLC-SO-INVARIANTS-008, TLC-SO-INVARIANTS-009, TLC-SO-INVARIANTS-011, TLC-SO-INVARIANTS-012, TLC-SO-INVARIANTS-014, TLC-SO-INVARIANTS-015, TLC-SO-INVARIANTS-016, TLC-SO-INVARIANTS-018, TLC-SO-INVARIANTS-019, TLC-SO-INVARIANTS-020, TLC-SO-INVARIANTS-023, TLC-SO-INVARIANTS-024, TLC-SO-INVARIANTS-025, TLC-SO-INVARIANTS-028, TLC-SO-INVARIANTS-029, TLC-SO-INVARIANTS-030, TLC-SO-INVARIANTS-034, TLC-SO-INVARIANTS-036, TLC-SO-INVARIANTS-037, TLC-SO-INVARIANTS-038, TLC-SO-INVARIANTS-042, TLC-SO-INVARIANTS-043, TLC-SO-INVARIANTS-047, TLC-SO-INVARIANTS-048, TLC-SO-INVARIANTS-055, TLC-SO-INVARIANTS-056, TLC-SO-INVARIANTS-060, TLC-SO-INVARIANTS-064, TLC-SR-INVARIANTS-001, TLC-SR-INVARIANTS-002, TLC-SR-INVARIANTS-003, TLC-SR-INVARIANTS-004, TLC-SR-INVARIANTS-005, TLC-SR-INVARIANTS-007, TLC-SR-INVARIANTS-008, TLC-SR-INVARIANTS-010, TLC-SR-INVARIANTS-011, TLC-SR-INVARIANTS-013, TLC-SR-INVARIANTS-014, TLC-SR-INVARIANTS-015, TLC-SR-INVARIANTS-017, TLC-SR-INVARIANTS-018, TLC-SR-INVARIANTS-019, TLC-SR-INVARIANTS-022, TLC-SR-INVARIANTS-023, TLC-SR-INVARIANTS-024, TLC-SR-INVARIANTS-027, TLC-SR-INVARIANTS-028, TLC-SR-INVARIANTS-029, TLC-SR-INVARIANTS-033, TLC-SR-INVARIANTS-035, TLC-SR-INVARIANTS-036, TLC-SR-INVARIANTS-037, TLC-SR-INVARIANTS-041, TLC-SR-INVARIANTS-042, TLC-SR-INVARIANTS-046, TLC-SR-INVARIANTS-047, TLC-SR-INVARIANTS-054, TLC-SR-INVARIANTS-055, TLC-SR-INVARIANTS-059, TLC-SR-INVARIANTS-063. The required catalogue status is `deferred_for_scientific_decision`. Required unresolved identifiers are: none. Required provisional assumptions are: TLC-EA-INVARIANTS-003-001.
+
+The required output is an immutable `InvariantDeclarationCatalog`. returns a catalogue preserving declaration IDs, object types, source scopes, and linked evidence relations
+
+## Mandatory and forbidden behavior
+
+Identity, source order, provenance, opaque values, status, assumptions, reservations, unresolved mappings, input immutability, deterministic structural equality, and failure atomicity are mandatory. Scientific truth evaluation, status promotion, inferred thresholds or comparators, transition graphs, chronology, causality, symmetry, transitivity, dimensions, units, precision, and numerical methods are forbidden.
+
+## Implementation freedom
+
+Language, public wrapper naming, storage, allocation, ownership mechanism, serialization, concurrency policy, error transport, and internal traversal remain free when observable behavior is unchanged.
+
+## Errors and conformance
+
+The authoritative observable error codes are: UnknownDeclarationId, DanglingEvidenceRelation, MissingSourceReference, ScientificEvaluationProhibited, PreservationViolation. Errors publish no partial result. Conformance requires every test in `acceptance.json`, exact preservation of the source envelope, and rejection of scientific evaluation. Scientific truth conditions remain opaque and require future externally sourced evaluation semantics.

--- a/handoff/features/TLC-FC-04-INVARIANTS-003/acceptance.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-003/acceptance.json
@@ -1,0 +1,247 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-003",
+  "tests": [
+    {
+      "test_id": "INV003-ACCEPT-NOMINAL",
+      "applies_to": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-04-INVARIANTS-003",
+        "covered_evidence_ids": [
+          "TLC-SO-INVARIANTS-002",
+          "TLC-SO-INVARIANTS-003",
+          "TLC-SO-INVARIANTS-004",
+          "TLC-SO-INVARIANTS-005",
+          "TLC-SO-INVARIANTS-006",
+          "TLC-SO-INVARIANTS-008",
+          "TLC-SO-INVARIANTS-009",
+          "TLC-SO-INVARIANTS-011",
+          "TLC-SO-INVARIANTS-012",
+          "TLC-SO-INVARIANTS-014",
+          "TLC-SO-INVARIANTS-015",
+          "TLC-SO-INVARIANTS-016",
+          "TLC-SO-INVARIANTS-018",
+          "TLC-SO-INVARIANTS-019",
+          "TLC-SO-INVARIANTS-020",
+          "TLC-SO-INVARIANTS-023",
+          "TLC-SO-INVARIANTS-024",
+          "TLC-SO-INVARIANTS-025",
+          "TLC-SO-INVARIANTS-028",
+          "TLC-SO-INVARIANTS-029",
+          "TLC-SO-INVARIANTS-030",
+          "TLC-SO-INVARIANTS-034",
+          "TLC-SO-INVARIANTS-036",
+          "TLC-SO-INVARIANTS-037",
+          "TLC-SO-INVARIANTS-038",
+          "TLC-SO-INVARIANTS-042",
+          "TLC-SO-INVARIANTS-043",
+          "TLC-SO-INVARIANTS-047",
+          "TLC-SO-INVARIANTS-048",
+          "TLC-SO-INVARIANTS-055",
+          "TLC-SO-INVARIANTS-056",
+          "TLC-SO-INVARIANTS-060",
+          "TLC-SO-INVARIANTS-064",
+          "TLC-SR-INVARIANTS-001",
+          "TLC-SR-INVARIANTS-002",
+          "TLC-SR-INVARIANTS-003",
+          "TLC-SR-INVARIANTS-004",
+          "TLC-SR-INVARIANTS-005",
+          "TLC-SR-INVARIANTS-007",
+          "TLC-SR-INVARIANTS-008",
+          "TLC-SR-INVARIANTS-010",
+          "TLC-SR-INVARIANTS-011",
+          "TLC-SR-INVARIANTS-013",
+          "TLC-SR-INVARIANTS-014",
+          "TLC-SR-INVARIANTS-015",
+          "TLC-SR-INVARIANTS-017",
+          "TLC-SR-INVARIANTS-018",
+          "TLC-SR-INVARIANTS-019",
+          "TLC-SR-INVARIANTS-022",
+          "TLC-SR-INVARIANTS-023",
+          "TLC-SR-INVARIANTS-024",
+          "TLC-SR-INVARIANTS-027",
+          "TLC-SR-INVARIANTS-028",
+          "TLC-SR-INVARIANTS-029",
+          "TLC-SR-INVARIANTS-033",
+          "TLC-SR-INVARIANTS-035",
+          "TLC-SR-INVARIANTS-036",
+          "TLC-SR-INVARIANTS-037",
+          "TLC-SR-INVARIANTS-041",
+          "TLC-SR-INVARIANTS-042",
+          "TLC-SR-INVARIANTS-046",
+          "TLC-SR-INVARIANTS-047",
+          "TLC-SR-INVARIANTS-054",
+          "TLC-SR-INVARIANTS-055",
+          "TLC-SR-INVARIANTS-059",
+          "TLC-SR-INVARIANTS-063"
+        ],
+        "catalogue_status": "deferred_for_scientific_decision",
+        "unresolved_refs": []
+      },
+      "when": "The build_invariant_declaration_catalog oracle scenario is exercised.",
+      "expect": {
+        "accepted": true,
+        "output_type": "InvariantDeclarationCatalog",
+        "immutable": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV003-ACCEPT-UNKNOWN-DECLARATION",
+      "applies_to": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV003-ACCEPT-UNKNOWN-DECLARATION"
+      },
+      "when": "The build_invariant_declaration_catalog oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV003-ACCEPT-DANGLING-RELATION",
+      "applies_to": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV003-ACCEPT-DANGLING-RELATION"
+      },
+      "when": "The build_invariant_declaration_catalog oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV003-ACCEPT-SCOPE",
+      "applies_to": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV003-ACCEPT-SCOPE"
+      },
+      "when": "The build_invariant_declaration_catalog oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV003-ACCEPT-OPAQUE",
+      "applies_to": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV003-ACCEPT-OPAQUE"
+      },
+      "when": "The build_invariant_declaration_catalog oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV003-ACCEPT-DETERMINISM",
+      "applies_to": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "category": "determinism",
+      "given": {
+        "authoritative_oracle_scenario": "INV003-ACCEPT-DETERMINISM"
+      },
+      "when": "The build_invariant_declaration_catalog oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV003-ACCEPT-RESERVATIONS",
+      "applies_to": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV003-ACCEPT-RESERVATIONS"
+      },
+      "when": "The build_invariant_declaration_catalog oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV003-ACCEPT-NO-INFERRED-RELATIONS",
+      "applies_to": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV003-ACCEPT-NO-INFERRED-RELATIONS"
+      },
+      "when": "The build_invariant_declaration_catalog oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV003-ACCEPT-NO-SCIENCE",
+      "applies_to": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "category": "unsupported_operation",
+      "given": {
+        "authoritative_oracle_scenario": "INV003-ACCEPT-NO-SCIENCE"
+      },
+      "when": "The build_invariant_declaration_catalog oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV003-ACCEPT-CONFORMANCE",
+      "applies_to": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV003-ACCEPT-CONFORMANCE"
+      },
+      "when": "The build_invariant_declaration_catalog oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-003/contract.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-003/contract.json
@@ -1,0 +1,575 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-04-INVARIANTS-003",
+    "title": "Invariant declaration catalog",
+    "domain": "invariants"
+  },
+  "purpose": "Validate source-backed invariant declaration catalog evidence and returns a catalogue preserving declaration IDs, object types, source scopes, and linked evidence relations Scientific truth evaluation is not performed.",
+  "scope": {
+    "required": [
+      {
+        "id": "INV003-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-04-INVARIANTS-003 and covered evidence identifiers [TLC-SO-INVARIANTS-002, TLC-SO-INVARIANTS-003, TLC-SO-INVARIANTS-004, TLC-SO-INVARIANTS-005, TLC-SO-INVARIANTS-006, TLC-SO-INVARIANTS-008, TLC-SO-INVARIANTS-009, TLC-SO-INVARIANTS-011, TLC-SO-INVARIANTS-012, TLC-SO-INVARIANTS-014, TLC-SO-INVARIANTS-015, TLC-SO-INVARIANTS-016, TLC-SO-INVARIANTS-018, TLC-SO-INVARIANTS-019, TLC-SO-INVARIANTS-020, TLC-SO-INVARIANTS-023, TLC-SO-INVARIANTS-024, TLC-SO-INVARIANTS-025, TLC-SO-INVARIANTS-028, TLC-SO-INVARIANTS-029, TLC-SO-INVARIANTS-030, TLC-SO-INVARIANTS-034, TLC-SO-INVARIANTS-036, TLC-SO-INVARIANTS-037, TLC-SO-INVARIANTS-038, TLC-SO-INVARIANTS-042, TLC-SO-INVARIANTS-043, TLC-SO-INVARIANTS-047, TLC-SO-INVARIANTS-048, TLC-SO-INVARIANTS-055, TLC-SO-INVARIANTS-056, TLC-SO-INVARIANTS-060, TLC-SO-INVARIANTS-064, TLC-SR-INVARIANTS-001, TLC-SR-INVARIANTS-002, TLC-SR-INVARIANTS-003, TLC-SR-INVARIANTS-004, TLC-SR-INVARIANTS-005, TLC-SR-INVARIANTS-007, TLC-SR-INVARIANTS-008, TLC-SR-INVARIANTS-010, TLC-SR-INVARIANTS-011, TLC-SR-INVARIANTS-013, TLC-SR-INVARIANTS-014, TLC-SR-INVARIANTS-015, TLC-SR-INVARIANTS-017, TLC-SR-INVARIANTS-018, TLC-SR-INVARIANTS-019, TLC-SR-INVARIANTS-022, TLC-SR-INVARIANTS-023, TLC-SR-INVARIANTS-024, TLC-SR-INVARIANTS-027, TLC-SR-INVARIANTS-028, TLC-SR-INVARIANTS-029, TLC-SR-INVARIANTS-033, TLC-SR-INVARIANTS-035, TLC-SR-INVARIANTS-036, TLC-SR-INVARIANTS-037, TLC-SR-INVARIANTS-041, TLC-SR-INVARIANTS-042, TLC-SR-INVARIANTS-046, TLC-SR-INVARIANTS-047, TLC-SR-INVARIANTS-054, TLC-SR-INVARIANTS-055, TLC-SR-INVARIANTS-059, TLC-SR-INVARIANTS-063].",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-003/contract.yaml",
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-003/ir.yaml"
+        ]
+      },
+      {
+        "id": "INV003-REQ-002",
+        "statement": "Preserve catalogue status deferred_for_scientific_decision, source order, provenance, opaque values, unresolved identifiers [], and assumptions [TLC-EA-INVARIANTS-003-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-003/contract.yaml",
+          "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml"
+        ]
+      },
+      {
+        "id": "INV003-REQ-003",
+        "statement": "Emit an immutable InvariantDeclarationCatalog with a complete preservation envelope.",
+        "basis": [
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-003/ir.yaml",
+          "registry/domain-finalization/invariants/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "INV003-FOR-001",
+        "statement": "Do not evaluate scientific truth or infer a comparator, threshold value, runtime domain, transition graph, chronology, causality, symmetry, transitivity, units, dimensions, precision, or numerical method."
+      },
+      {
+        "id": "INV003-FOR-002",
+        "statement": "Do not promote documentary, deferred, provisionally separated, or rejected source metadata to executable scientific status."
+      },
+      {
+        "id": "INV003-FOR-003",
+        "statement": "Do not mutate inputs, scientific state, external domain state, or publish a partial successful result."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "INV003-DEF-001",
+        "statement": "Scientific evaluation requires a future externally sourced evaluator; this package defines no evaluator interface or truth criterion."
+      },
+      {
+        "id": "INV003-DEF-002",
+        "statement": "Opaque scientific truth conditions remain external and uninterpreted."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "BUILD-INVARIANT-DECLARATION-CATALOG",
+      "purpose": "Construct the immutable InvariantDeclarationCatalog from validated source evidence without scientific evaluation.",
+      "inputs": [
+        {
+          "name": "evidence",
+          "semantic_role": "InvariantDeclarationEvidence[]",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-04-INVARIANTS-003"
+            },
+            {
+              "name": "evidence_ids",
+              "required": true,
+              "semantic_role": "exact covered object and relation identities",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-INVARIANTS-002",
+                "TLC-SO-INVARIANTS-003",
+                "TLC-SO-INVARIANTS-004",
+                "TLC-SO-INVARIANTS-005",
+                "TLC-SO-INVARIANTS-006",
+                "TLC-SO-INVARIANTS-008",
+                "TLC-SO-INVARIANTS-009",
+                "TLC-SO-INVARIANTS-011",
+                "TLC-SO-INVARIANTS-012",
+                "TLC-SO-INVARIANTS-014",
+                "TLC-SO-INVARIANTS-015",
+                "TLC-SO-INVARIANTS-016",
+                "TLC-SO-INVARIANTS-018",
+                "TLC-SO-INVARIANTS-019",
+                "TLC-SO-INVARIANTS-020",
+                "TLC-SO-INVARIANTS-023",
+                "TLC-SO-INVARIANTS-024",
+                "TLC-SO-INVARIANTS-025",
+                "TLC-SO-INVARIANTS-028",
+                "TLC-SO-INVARIANTS-029",
+                "TLC-SO-INVARIANTS-030",
+                "TLC-SO-INVARIANTS-034",
+                "TLC-SO-INVARIANTS-036",
+                "TLC-SO-INVARIANTS-037",
+                "TLC-SO-INVARIANTS-038",
+                "TLC-SO-INVARIANTS-042",
+                "TLC-SO-INVARIANTS-043",
+                "TLC-SO-INVARIANTS-047",
+                "TLC-SO-INVARIANTS-048",
+                "TLC-SO-INVARIANTS-055",
+                "TLC-SO-INVARIANTS-056",
+                "TLC-SO-INVARIANTS-060",
+                "TLC-SO-INVARIANTS-064",
+                "TLC-SR-INVARIANTS-001",
+                "TLC-SR-INVARIANTS-002",
+                "TLC-SR-INVARIANTS-003",
+                "TLC-SR-INVARIANTS-004",
+                "TLC-SR-INVARIANTS-005",
+                "TLC-SR-INVARIANTS-007",
+                "TLC-SR-INVARIANTS-008",
+                "TLC-SR-INVARIANTS-010",
+                "TLC-SR-INVARIANTS-011",
+                "TLC-SR-INVARIANTS-013",
+                "TLC-SR-INVARIANTS-014",
+                "TLC-SR-INVARIANTS-015",
+                "TLC-SR-INVARIANTS-017",
+                "TLC-SR-INVARIANTS-018",
+                "TLC-SR-INVARIANTS-019",
+                "TLC-SR-INVARIANTS-022",
+                "TLC-SR-INVARIANTS-023",
+                "TLC-SR-INVARIANTS-024",
+                "TLC-SR-INVARIANTS-027",
+                "TLC-SR-INVARIANTS-028",
+                "TLC-SR-INVARIANTS-029",
+                "TLC-SR-INVARIANTS-033",
+                "TLC-SR-INVARIANTS-035",
+                "TLC-SR-INVARIANTS-036",
+                "TLC-SR-INVARIANTS-037",
+                "TLC-SR-INVARIANTS-041",
+                "TLC-SR-INVARIANTS-042",
+                "TLC-SR-INVARIANTS-046",
+                "TLC-SR-INVARIANTS-047",
+                "TLC-SR-INVARIANTS-054",
+                "TLC-SR-INVARIANTS-055",
+                "TLC-SR-INVARIANTS-059",
+                "TLC-SR-INVARIANTS-063"
+              ]
+            },
+            {
+              "name": "source_references",
+              "required": true,
+              "semantic_role": "source provenance for every evidence item",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_values",
+              "required": true,
+              "semantic_role": "uninterpreted source statements and scientific truth conditions",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "catalogue_status",
+              "required": true,
+              "semantic_role": "exact historical catalogue status",
+              "constant": "deferred_for_scientific_decision"
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact unresolved identifiers attached to affected evidence",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "assumption_refs",
+              "required": true,
+              "semantic_role": "exact provisional engineering assumption identifiers",
+              "allowed_values": [
+                "TLC-EA-INVARIANTS-003-001"
+              ]
+            }
+          ],
+          "collection": {
+            "kind": "ordered_set",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-INVARIANTS-002",
+              "TLC-SO-INVARIANTS-003",
+              "TLC-SO-INVARIANTS-004",
+              "TLC-SO-INVARIANTS-005",
+              "TLC-SO-INVARIANTS-006",
+              "TLC-SO-INVARIANTS-008",
+              "TLC-SO-INVARIANTS-009",
+              "TLC-SO-INVARIANTS-011",
+              "TLC-SO-INVARIANTS-012",
+              "TLC-SO-INVARIANTS-014",
+              "TLC-SO-INVARIANTS-015",
+              "TLC-SO-INVARIANTS-016",
+              "TLC-SO-INVARIANTS-018",
+              "TLC-SO-INVARIANTS-019",
+              "TLC-SO-INVARIANTS-020",
+              "TLC-SO-INVARIANTS-023",
+              "TLC-SO-INVARIANTS-024",
+              "TLC-SO-INVARIANTS-025",
+              "TLC-SO-INVARIANTS-028",
+              "TLC-SO-INVARIANTS-029",
+              "TLC-SO-INVARIANTS-030",
+              "TLC-SO-INVARIANTS-034",
+              "TLC-SO-INVARIANTS-036",
+              "TLC-SO-INVARIANTS-037",
+              "TLC-SO-INVARIANTS-038",
+              "TLC-SO-INVARIANTS-042",
+              "TLC-SO-INVARIANTS-043",
+              "TLC-SO-INVARIANTS-047",
+              "TLC-SO-INVARIANTS-048",
+              "TLC-SO-INVARIANTS-055",
+              "TLC-SO-INVARIANTS-056",
+              "TLC-SO-INVARIANTS-060",
+              "TLC-SO-INVARIANTS-064",
+              "TLC-SR-INVARIANTS-001",
+              "TLC-SR-INVARIANTS-002",
+              "TLC-SR-INVARIANTS-003",
+              "TLC-SR-INVARIANTS-004",
+              "TLC-SR-INVARIANTS-005",
+              "TLC-SR-INVARIANTS-007",
+              "TLC-SR-INVARIANTS-008",
+              "TLC-SR-INVARIANTS-010",
+              "TLC-SR-INVARIANTS-011",
+              "TLC-SR-INVARIANTS-013",
+              "TLC-SR-INVARIANTS-014",
+              "TLC-SR-INVARIANTS-015",
+              "TLC-SR-INVARIANTS-017",
+              "TLC-SR-INVARIANTS-018",
+              "TLC-SR-INVARIANTS-019",
+              "TLC-SR-INVARIANTS-022",
+              "TLC-SR-INVARIANTS-023",
+              "TLC-SR-INVARIANTS-024",
+              "TLC-SR-INVARIANTS-027",
+              "TLC-SR-INVARIANTS-028",
+              "TLC-SR-INVARIANTS-029",
+              "TLC-SR-INVARIANTS-033",
+              "TLC-SR-INVARIANTS-035",
+              "TLC-SR-INVARIANTS-036",
+              "TLC-SR-INVARIANTS-037",
+              "TLC-SR-INVARIANTS-041",
+              "TLC-SR-INVARIANTS-042",
+              "TLC-SR-INVARIANTS-046",
+              "TLC-SR-INVARIANTS-047",
+              "TLC-SR-INVARIANTS-054",
+              "TLC-SR-INVARIANTS-055",
+              "TLC-SR-INVARIANTS-059",
+              "TLC-SR-INVARIANTS-063"
+            ],
+            "cardinality": {
+              "minimum": 66,
+              "maximum": 66
+            },
+            "ordering": "required",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV003-IN-001",
+              "statement": "Every supplied identity is feature-covered, unique where required, and accompanied by source provenance."
+            },
+            {
+              "id": "INV003-IN-002",
+              "statement": "Source-declared order is preserved; otherwise validated input order is retained only as engineering order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable InvariantDeclarationCatalog",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-04-INVARIANTS-003"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "feature-specific structural representation",
+              "constant": "InvariantDeclarationCatalog"
+            },
+            {
+              "name": "entries",
+              "required": true,
+              "semantic_role": "immutable evidence entries with exact identities and order",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "unresolved identifiers attached to affected entries",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete preservation envelope",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "preserved catalogue and scientific status",
+              "constant": "deferred_for_scientific_decision"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV003-OUT-001",
+              "statement": "returns a catalogue preserving declaration IDs, object types, source scopes, and linked evidence relations"
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "INV003-PRE-001",
+          "statement": "Every required identity, relationship, source reference, opaque symbol, unresolved mapping, and status value is present and source-consistent."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "INV003-POST-001",
+          "statement": "returns a catalogue preserving declaration IDs, object types, source scopes, and linked evidence relations No scientific truth claim is added."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "INV003-INV-001",
+          "statement": "Covered identities, source order, references, opaque values, catalogue status, assumptions, reservations, and unresolved mappings are unchanged."
+        },
+        {
+          "id": "INV003-INV-002",
+          "statement": "Inputs and all external or scientific state remain unmodified."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate covered identities and required provenance",
+          "validate status, unresolved, assumption, and opaque preservation metadata",
+          "construct the feature-specific immutable representation",
+          "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate covered identities and required provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "validate status, unresolved, assumption, and opaque preservation metadata",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct the feature-specific immutable representation",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Validation and conservation must precede publication. The upstream total traversal sequence is not a unique architectural prescription."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "owned_result",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "result_lifetime",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "required",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "not_applicable",
+        "floating_point": "not_applicable",
+        "randomness": "forbidden"
+      },
+      "error_contract": [
+        {
+          "code": "UnknownDeclarationId",
+          "category": "invalid_input",
+          "condition": "The authoritative UnknownDeclarationId condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "DanglingEvidenceRelation",
+          "category": "invalid_input",
+          "condition": "The authoritative DanglingEvidenceRelation condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "invalid_input",
+          "condition": "Required source provenance is absent.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificEvaluationProhibited",
+          "category": "unsupported_operation",
+          "condition": "Truth, numeric, temporal, ordering, state, transition, or other scientific evaluation is requested without a sourced evaluator.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "PreservationViolation",
+          "category": "preservation",
+          "condition": "A source identity, order, opaque value, status, assumption, reservation, unresolved mapping, or provenance link changes or is lost.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-construction",
+      "status": "required",
+      "statement": "Expose build_invariant_declaration_catalog as a deterministic structural operation producing InvariantDeclarationCatalog."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not decide truth, compute numerical values, detect states, or infer transitions."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal representation and validation decomposition remain free when observable preservation behavior is identical."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "INV003-GINV-001",
+      "statement": "No implementation behavior may weaken source identity, order, opacity, status, unresolved, assumption, reservation, immutability, or provenance obligations."
+    },
+    {
+      "id": "INV003-GINV-002",
+      "statement": "Historical rejection or deferral metadata is documentary and must remain visible without suppressing this finalized structural operation."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific and evidence references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered identifier collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted source statements and scientific truth conditions"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral structural errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable preservation result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is structural and behavioral. It does not prescribe a programming language, serialization, storage model, or complete internal step order."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-003/manifest.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-003/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-04-INVARIANTS-003",
+  "title": "Invariant declaration catalog",
+  "domain": "invariants",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "external_provider_required",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-003/traceability.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-003/traceability.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-003",
+  "scientific_sources": [
+    {
+      "path": "maths/04-invariants.md",
+      "role": "Authoritative scientific source sections cited by the limited engineering contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-003/contract.yaml",
+      "role": "Defines covered evidence, exact structural behavior, reservations, and scientific boundary.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "90b29d663ecb8fece9c29549e802c0df2ba041f2"
+      }
+    },
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-003/traceability.yaml",
+      "role": "Preserves detailed contract-to-source traceability.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "3ff867772114a5f0b63ee2a8d92d96444485c185"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-003/ir.prototype.json",
+      "role": "Prototype IR with reservations and operation-specific interface.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "96a875478c640f05c8648519c00c8088c8686f19"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-003/ir.yaml",
+      "role": "Selected finalized IR defining immutable structural behavior and stable errors.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "ea65f013ed08064d0b10c00aed2dfe05f974d584"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/invariants/TLC-FC-04-INVARIANTS-003/algorithm.yaml",
+      "role": "Applicable validation, construction, conservation, and error branches; total ordering is not adopted beyond observable requirements.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "5ce367e4cde39b8ced9f3570b257f8b912c356b8"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-003/test-plan.yaml",
+      "role": "Source structural test plan and reservation-preservation scenarios.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "60cef2b95d421f79cf06a4f352f0b7f3ef479d89"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/invariants/TLC-FC-04-INVARIANTS-003/oracle.yaml",
+      "role": "Authoritative nominal, error, opacity, ordering, determinism, and conformance expectations.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "2a559810249d7f0200c7bb822b35e177ae0a9bf7"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/invariants/feature-status.yaml",
+      "role": "Authoritative ten-feature inventory and historical status interpretation."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/module-specification.yaml",
+      "role": "Defines public operations, common structural rules, error vocabulary, dependencies, and scientific boundary."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/implementation-tasks.yaml",
+      "role": "Defines feature deliverables and acceptance obligations."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/patterns.yaml",
+      "role": "Records domain-local common patterns without creating shared handoff contracts."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-004/README.md
+++ b/handoff/features/TLC-FC-04-INVARIANTS-004/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-04-INVARIANTS-004 — Disciple invariant scope declaration
+
+This package defines the final structural handoff for Disciple invariant scope declaration.
+
+## What must be implemented
+
+Implement `declare_disciple_invariant_scope` as a deterministic, immutable evidence transformation. It validates feature-covered identities and source references, preserves opaque content and historical catalogue status, and returns a `ScopedInvariantDeclaration` with complete provenance.
+
+## Valid inputs and required output
+
+The accepted covered evidence identities are: TLC-SO-INVARIANTS-007, TLC-SR-INVARIANTS-006. The required catalogue status is `deferred_for_scientific_decision`. Required unresolved identifiers are: none. Required provisional assumptions are: TLC-EA-INVARIANTS-004-001.
+
+The required output is an immutable `ScopedInvariantDeclaration`. returns one declaration scoped to the disciple evidence record and marked scientifically deferred
+
+## Mandatory and forbidden behavior
+
+Identity, source order, provenance, opaque values, status, assumptions, reservations, unresolved mappings, input immutability, deterministic structural equality, and failure atomicity are mandatory. Scientific truth evaluation, status promotion, inferred thresholds or comparators, transition graphs, chronology, causality, symmetry, transitivity, dimensions, units, precision, and numerical methods are forbidden.
+
+## Implementation freedom
+
+Language, public wrapper naming, storage, allocation, ownership mechanism, serialization, concurrency policy, error transport, and internal traversal remain free when observable behavior is unchanged.
+
+## Errors and conformance
+
+The authoritative observable error codes are: WrongScopeObject, MissingRootReference, StatusPromotionProhibited, ScientificEvaluationProhibited, PreservationViolation. Errors publish no partial result. Conformance requires every test in `acceptance.json`, exact preservation of the source envelope, and rejection of scientific evaluation. Scientific truth conditions remain opaque and require future externally sourced evaluation semantics.

--- a/handoff/features/TLC-FC-04-INVARIANTS-004/acceptance.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-004/acceptance.json
@@ -1,0 +1,166 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-004",
+  "tests": [
+    {
+      "test_id": "INV004-ACCEPT-NOMINAL",
+      "applies_to": "DECLARE-DISCIPLE-INVARIANT-SCOPE",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-04-INVARIANTS-004",
+        "covered_evidence_ids": [
+          "TLC-SO-INVARIANTS-007",
+          "TLC-SR-INVARIANTS-006"
+        ],
+        "catalogue_status": "deferred_for_scientific_decision",
+        "unresolved_refs": []
+      },
+      "when": "The declare_disciple_invariant_scope oracle scenario is exercised.",
+      "expect": {
+        "accepted": true,
+        "output_type": "ScopedInvariantDeclaration",
+        "immutable": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV004-ACCEPT-WRONG-OBJECT",
+      "applies_to": "DECLARE-DISCIPLE-INVARIANT-SCOPE",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV004-ACCEPT-WRONG-OBJECT"
+      },
+      "when": "The declare_disciple_invariant_scope oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV004-ACCEPT-MISSING-ROOT",
+      "applies_to": "DECLARE-DISCIPLE-INVARIANT-SCOPE",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV004-ACCEPT-MISSING-ROOT"
+      },
+      "when": "The declare_disciple_invariant_scope oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV004-ACCEPT-OPAQUE",
+      "applies_to": "DECLARE-DISCIPLE-INVARIANT-SCOPE",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV004-ACCEPT-OPAQUE"
+      },
+      "when": "The declare_disciple_invariant_scope oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV004-ACCEPT-NO-MEMBERS",
+      "applies_to": "DECLARE-DISCIPLE-INVARIANT-SCOPE",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV004-ACCEPT-NO-MEMBERS"
+      },
+      "when": "The declare_disciple_invariant_scope oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV004-ACCEPT-PROMOTION",
+      "applies_to": "DECLARE-DISCIPLE-INVARIANT-SCOPE",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV004-ACCEPT-PROMOTION"
+      },
+      "when": "The declare_disciple_invariant_scope oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV004-ACCEPT-DETERMINISM",
+      "applies_to": "DECLARE-DISCIPLE-INVARIANT-SCOPE",
+      "category": "determinism",
+      "given": {
+        "authoritative_oracle_scenario": "INV004-ACCEPT-DETERMINISM"
+      },
+      "when": "The declare_disciple_invariant_scope oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV004-ACCEPT-RESERVATIONS",
+      "applies_to": "DECLARE-DISCIPLE-INVARIANT-SCOPE",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV004-ACCEPT-RESERVATIONS"
+      },
+      "when": "The declare_disciple_invariant_scope oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV004-ACCEPT-CONFORMANCE",
+      "applies_to": "DECLARE-DISCIPLE-INVARIANT-SCOPE",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV004-ACCEPT-CONFORMANCE"
+      },
+      "when": "The declare_disciple_invariant_scope oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-004/contract.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-004/contract.json
@@ -1,0 +1,447 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-04-INVARIANTS-004",
+    "title": "Disciple invariant scope declaration",
+    "domain": "invariants"
+  },
+  "purpose": "Validate source-backed disciple invariant scope declaration evidence and returns one declaration scoped to the disciple evidence record and marked scientifically deferred Scientific truth evaluation is not performed.",
+  "scope": {
+    "required": [
+      {
+        "id": "INV004-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-04-INVARIANTS-004 and covered evidence identifiers [TLC-SO-INVARIANTS-007, TLC-SR-INVARIANTS-006].",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-004/contract.yaml",
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-004/ir.yaml"
+        ]
+      },
+      {
+        "id": "INV004-REQ-002",
+        "statement": "Preserve catalogue status deferred_for_scientific_decision, source order, provenance, opaque values, unresolved identifiers [], and assumptions [TLC-EA-INVARIANTS-004-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-004/contract.yaml",
+          "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml"
+        ]
+      },
+      {
+        "id": "INV004-REQ-003",
+        "statement": "Emit an immutable ScopedInvariantDeclaration with a complete preservation envelope.",
+        "basis": [
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-004/ir.yaml",
+          "registry/domain-finalization/invariants/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "INV004-FOR-001",
+        "statement": "Do not evaluate scientific truth or infer a comparator, threshold value, runtime domain, transition graph, chronology, causality, symmetry, transitivity, units, dimensions, precision, or numerical method."
+      },
+      {
+        "id": "INV004-FOR-002",
+        "statement": "Do not promote documentary, deferred, provisionally separated, or rejected source metadata to executable scientific status."
+      },
+      {
+        "id": "INV004-FOR-003",
+        "statement": "Do not mutate inputs, scientific state, external domain state, or publish a partial successful result."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "INV004-DEF-001",
+        "statement": "Scientific evaluation requires a future externally sourced evaluator; this package defines no evaluator interface or truth criterion."
+      },
+      {
+        "id": "INV004-DEF-002",
+        "statement": "Opaque scientific truth conditions remain external and uninterpreted."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "DECLARE-DISCIPLE-INVARIANT-SCOPE",
+      "purpose": "Construct the immutable ScopedInvariantDeclaration from validated source evidence without scientific evaluation.",
+      "inputs": [
+        {
+          "name": "evidence",
+          "semantic_role": "DiscipleInvariantScopeEvidence",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-04-INVARIANTS-004"
+            },
+            {
+              "name": "evidence_ids",
+              "required": true,
+              "semantic_role": "exact covered object and relation identities",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-INVARIANTS-007",
+                "TLC-SR-INVARIANTS-006"
+              ]
+            },
+            {
+              "name": "source_references",
+              "required": true,
+              "semantic_role": "source provenance for every evidence item",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_values",
+              "required": true,
+              "semantic_role": "uninterpreted source statements and scientific truth conditions",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "catalogue_status",
+              "required": true,
+              "semantic_role": "exact historical catalogue status",
+              "constant": "deferred_for_scientific_decision"
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact unresolved identifiers attached to affected evidence",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "assumption_refs",
+              "required": true,
+              "semantic_role": "exact provisional engineering assumption identifiers",
+              "allowed_values": [
+                "TLC-EA-INVARIANTS-004-001"
+              ]
+            }
+          ],
+          "collection": {
+            "kind": "ordered_set",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-INVARIANTS-007",
+              "TLC-SR-INVARIANTS-006"
+            ],
+            "cardinality": {
+              "minimum": 2,
+              "maximum": 2
+            },
+            "ordering": "required",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV004-IN-001",
+              "statement": "Every supplied identity is feature-covered, unique where required, and accompanied by source provenance."
+            },
+            {
+              "id": "INV004-IN-002",
+              "statement": "Source-declared order is preserved; otherwise validated input order is retained only as engineering order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable ScopedInvariantDeclaration",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-04-INVARIANTS-004"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "feature-specific structural representation",
+              "constant": "ScopedInvariantDeclaration"
+            },
+            {
+              "name": "entries",
+              "required": true,
+              "semantic_role": "immutable evidence entries with exact identities and order",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "unresolved identifiers attached to affected entries",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete preservation envelope",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "preserved catalogue and scientific status",
+              "constant": "deferred_for_scientific_decision"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV004-OUT-001",
+              "statement": "returns one declaration scoped to the disciple evidence record and marked scientifically deferred"
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "INV004-PRE-001",
+          "statement": "Every required identity, relationship, source reference, opaque symbol, unresolved mapping, and status value is present and source-consistent."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "INV004-POST-001",
+          "statement": "returns one declaration scoped to the disciple evidence record and marked scientifically deferred No scientific truth claim is added."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "INV004-INV-001",
+          "statement": "Covered identities, source order, references, opaque values, catalogue status, assumptions, reservations, and unresolved mappings are unchanged."
+        },
+        {
+          "id": "INV004-INV-002",
+          "statement": "Inputs and all external or scientific state remain unmodified."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate covered identities and required provenance",
+          "validate status, unresolved, assumption, and opaque preservation metadata",
+          "construct the feature-specific immutable representation",
+          "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate covered identities and required provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "validate status, unresolved, assumption, and opaque preservation metadata",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct the feature-specific immutable representation",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Validation and conservation must precede publication. The upstream total traversal sequence is not a unique architectural prescription."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "owned_result",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "result_lifetime",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "required",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "not_applicable",
+        "floating_point": "not_applicable",
+        "randomness": "forbidden"
+      },
+      "error_contract": [
+        {
+          "code": "WrongScopeObject",
+          "category": "invalid_input",
+          "condition": "The authoritative WrongScopeObject condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingRootReference",
+          "category": "invalid_input",
+          "condition": "The authoritative MissingRootReference condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "StatusPromotionProhibited",
+          "category": "preservation",
+          "condition": "Documentary, deferred, or rejected metadata is promoted to executable scientific status.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificEvaluationProhibited",
+          "category": "unsupported_operation",
+          "condition": "Truth, numeric, temporal, ordering, state, transition, or other scientific evaluation is requested without a sourced evaluator.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "PreservationViolation",
+          "category": "preservation",
+          "condition": "A source identity, order, opaque value, status, assumption, reservation, unresolved mapping, or provenance link changes or is lost.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-construction",
+      "status": "required",
+      "statement": "Expose declare_disciple_invariant_scope as a deterministic structural operation producing ScopedInvariantDeclaration."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not decide truth, compute numerical values, detect states, or infer transitions."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal representation and validation decomposition remain free when observable preservation behavior is identical."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "INV004-GINV-001",
+      "statement": "No implementation behavior may weaken source identity, order, opacity, status, unresolved, assumption, reservation, immutability, or provenance obligations."
+    },
+    {
+      "id": "INV004-GINV-002",
+      "statement": "Historical rejection or deferral metadata is documentary and must remain visible without suppressing this finalized structural operation."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific and evidence references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered identifier collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted source statements and scientific truth conditions"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral structural errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable preservation result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is structural and behavioral. It does not prescribe a programming language, serialization, storage model, or complete internal step order."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-004/manifest.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-004/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-04-INVARIANTS-004",
+  "title": "Disciple invariant scope declaration",
+  "domain": "invariants",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "external_provider_required",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-004/traceability.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-004/traceability.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-004",
+  "scientific_sources": [
+    {
+      "path": "maths/04-invariants.md",
+      "role": "Authoritative scientific source sections cited by the limited engineering contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-004/contract.yaml",
+      "role": "Defines covered evidence, exact structural behavior, reservations, and scientific boundary.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "8cd3a2a700e033f75094332cc85a8105fe32fdf0"
+      }
+    },
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-004/traceability.yaml",
+      "role": "Preserves detailed contract-to-source traceability.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "47a5afb4a38a317d71d7d9e141700d0e07536087"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-004/ir.prototype.json",
+      "role": "Prototype IR with reservations and operation-specific interface.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "4561d1dc65e53ef232a24df7515b448347eeec19"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-004/ir.yaml",
+      "role": "Selected finalized IR defining immutable structural behavior and stable errors.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "e9af1c03b0788f6b2cfeab600a54c60abb450acf"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/invariants/TLC-FC-04-INVARIANTS-004/algorithm.yaml",
+      "role": "Applicable validation, construction, conservation, and error branches; total ordering is not adopted beyond observable requirements.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "3a7411e68980df5efc96290515f4b51eebcde9bd"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-004/test-plan.yaml",
+      "role": "Source structural test plan and reservation-preservation scenarios.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "4e50aa8b7634f7b77e08f3d83e4e83c2b5deea47"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/invariants/TLC-FC-04-INVARIANTS-004/oracle.yaml",
+      "role": "Authoritative nominal, error, opacity, ordering, determinism, and conformance expectations.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "91a1580c7c5f56e7cedc61c6739702698cfa2872"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/invariants/feature-status.yaml",
+      "role": "Authoritative ten-feature inventory and historical status interpretation."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/module-specification.yaml",
+      "role": "Defines public operations, common structural rules, error vocabulary, dependencies, and scientific boundary."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/implementation-tasks.yaml",
+      "role": "Defines feature deliverables and acceptance obligations."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/patterns.yaml",
+      "role": "Records domain-local common patterns without creating shared handoff contracts."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-005/README.md
+++ b/handoff/features/TLC-FC-04-INVARIANTS-005/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-04-INVARIANTS-005 — Invariant interpretation annotations
+
+This package defines the final structural handoff for Invariant interpretation annotations.
+
+## What must be implemented
+
+Implement `attach_interpretation_annotations` as a deterministic, immutable evidence transformation. It validates feature-covered identities and source references, preserves opaque content and historical catalogue status, and returns a `AnnotatedInvariantEvidence` with complete provenance.
+
+## Valid inputs and required output
+
+The accepted covered evidence identities are: TLC-SO-INVARIANTS-031, TLC-SO-INVARIANTS-044, TLC-SO-INVARIANTS-049, TLC-SR-INVARIANTS-030, TLC-SR-INVARIANTS-043, TLC-SR-INVARIANTS-048. The required catalogue status is `deferred_for_scientific_decision`. Required unresolved identifiers are: none. Required provisional assumptions are: TLC-EA-INVARIANTS-005-001.
+
+The required output is an immutable `AnnotatedInvariantEvidence`. returns root evidence with three ordered non-normative annotations that cannot change invariant truth or status
+
+## Mandatory and forbidden behavior
+
+Identity, source order, provenance, opaque values, status, assumptions, reservations, unresolved mappings, input immutability, deterministic structural equality, and failure atomicity are mandatory. Scientific truth evaluation, status promotion, inferred thresholds or comparators, transition graphs, chronology, causality, symmetry, transitivity, dimensions, units, precision, and numerical methods are forbidden.
+
+## Implementation freedom
+
+Language, public wrapper naming, storage, allocation, ownership mechanism, serialization, concurrency policy, error transport, and internal traversal remain free when observable behavior is unchanged.
+
+## Errors and conformance
+
+The authoritative observable error codes are: UnknownAnnotationId, AnnotationTargetMismatch, DuplicateIdentifier, StatusPromotionProhibited, ScientificEvaluationProhibited, PreservationViolation. Errors publish no partial result. Conformance requires every test in `acceptance.json`, exact preservation of the source envelope, and rejection of scientific evaluation. Scientific truth conditions remain opaque and require future externally sourced evaluation semantics.

--- a/handoff/features/TLC-FC-04-INVARIANTS-005/acceptance.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-005/acceptance.json
@@ -1,0 +1,187 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-005",
+  "tests": [
+    {
+      "test_id": "INV005-ACCEPT-NOMINAL",
+      "applies_to": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-04-INVARIANTS-005",
+        "covered_evidence_ids": [
+          "TLC-SO-INVARIANTS-031",
+          "TLC-SO-INVARIANTS-044",
+          "TLC-SO-INVARIANTS-049",
+          "TLC-SR-INVARIANTS-030",
+          "TLC-SR-INVARIANTS-043",
+          "TLC-SR-INVARIANTS-048"
+        ],
+        "catalogue_status": "deferred_for_scientific_decision",
+        "unresolved_refs": []
+      },
+      "when": "The attach_interpretation_annotations oracle scenario is exercised.",
+      "expect": {
+        "accepted": true,
+        "output_type": "AnnotatedInvariantEvidence",
+        "immutable": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV005-ACCEPT-UNKNOWN",
+      "applies_to": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV005-ACCEPT-UNKNOWN"
+      },
+      "when": "The attach_interpretation_annotations oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV005-ACCEPT-TARGET",
+      "applies_to": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV005-ACCEPT-TARGET"
+      },
+      "when": "The attach_interpretation_annotations oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV005-ACCEPT-DUPLICATE",
+      "applies_to": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV005-ACCEPT-DUPLICATE"
+      },
+      "when": "The attach_interpretation_annotations oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV005-ACCEPT-OPAQUE",
+      "applies_to": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV005-ACCEPT-OPAQUE"
+      },
+      "when": "The attach_interpretation_annotations oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV005-ACCEPT-TRUTH-NEUTRALITY",
+      "applies_to": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV005-ACCEPT-TRUTH-NEUTRALITY"
+      },
+      "when": "The attach_interpretation_annotations oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV005-ACCEPT-PROMOTION",
+      "applies_to": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV005-ACCEPT-PROMOTION"
+      },
+      "when": "The attach_interpretation_annotations oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV005-ACCEPT-DETERMINISM",
+      "applies_to": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "category": "determinism",
+      "given": {
+        "authoritative_oracle_scenario": "INV005-ACCEPT-DETERMINISM"
+      },
+      "when": "The attach_interpretation_annotations oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV005-ACCEPT-RESERVATIONS",
+      "applies_to": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV005-ACCEPT-RESERVATIONS"
+      },
+      "when": "The attach_interpretation_annotations oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV005-ACCEPT-CONFORMANCE",
+      "applies_to": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV005-ACCEPT-CONFORMANCE"
+      },
+      "when": "The attach_interpretation_annotations oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-005/contract.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-005/contract.json
@@ -1,0 +1,464 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-04-INVARIANTS-005",
+    "title": "Invariant interpretation annotations",
+    "domain": "invariants"
+  },
+  "purpose": "Validate source-backed invariant interpretation annotations evidence and returns root evidence with three ordered non-normative annotations that cannot change invariant truth or status Scientific truth evaluation is not performed.",
+  "scope": {
+    "required": [
+      {
+        "id": "INV005-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-04-INVARIANTS-005 and covered evidence identifiers [TLC-SO-INVARIANTS-031, TLC-SO-INVARIANTS-044, TLC-SO-INVARIANTS-049, TLC-SR-INVARIANTS-030, TLC-SR-INVARIANTS-043, TLC-SR-INVARIANTS-048].",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-005/contract.yaml",
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-005/ir.yaml"
+        ]
+      },
+      {
+        "id": "INV005-REQ-002",
+        "statement": "Preserve catalogue status deferred_for_scientific_decision, source order, provenance, opaque values, unresolved identifiers [], and assumptions [TLC-EA-INVARIANTS-005-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-005/contract.yaml",
+          "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml"
+        ]
+      },
+      {
+        "id": "INV005-REQ-003",
+        "statement": "Emit an immutable AnnotatedInvariantEvidence with a complete preservation envelope.",
+        "basis": [
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-005/ir.yaml",
+          "registry/domain-finalization/invariants/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "INV005-FOR-001",
+        "statement": "Do not evaluate scientific truth or infer a comparator, threshold value, runtime domain, transition graph, chronology, causality, symmetry, transitivity, units, dimensions, precision, or numerical method."
+      },
+      {
+        "id": "INV005-FOR-002",
+        "statement": "Do not promote documentary, deferred, provisionally separated, or rejected source metadata to executable scientific status."
+      },
+      {
+        "id": "INV005-FOR-003",
+        "statement": "Do not mutate inputs, scientific state, external domain state, or publish a partial successful result."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "INV005-DEF-001",
+        "statement": "Scientific evaluation requires a future externally sourced evaluator; this package defines no evaluator interface or truth criterion."
+      },
+      {
+        "id": "INV005-DEF-002",
+        "statement": "Opaque scientific truth conditions remain external and uninterpreted."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "ATTACH-INTERPRETATION-ANNOTATIONS",
+      "purpose": "Construct the immutable AnnotatedInvariantEvidence from validated source evidence without scientific evaluation.",
+      "inputs": [
+        {
+          "name": "evidence",
+          "semantic_role": "InterpretationAnnotation[]",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-04-INVARIANTS-005"
+            },
+            {
+              "name": "evidence_ids",
+              "required": true,
+              "semantic_role": "exact covered object and relation identities",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-INVARIANTS-031",
+                "TLC-SO-INVARIANTS-044",
+                "TLC-SO-INVARIANTS-049",
+                "TLC-SR-INVARIANTS-030",
+                "TLC-SR-INVARIANTS-043",
+                "TLC-SR-INVARIANTS-048"
+              ]
+            },
+            {
+              "name": "source_references",
+              "required": true,
+              "semantic_role": "source provenance for every evidence item",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_values",
+              "required": true,
+              "semantic_role": "uninterpreted source statements and scientific truth conditions",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "catalogue_status",
+              "required": true,
+              "semantic_role": "exact historical catalogue status",
+              "constant": "deferred_for_scientific_decision"
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact unresolved identifiers attached to affected evidence",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "assumption_refs",
+              "required": true,
+              "semantic_role": "exact provisional engineering assumption identifiers",
+              "allowed_values": [
+                "TLC-EA-INVARIANTS-005-001"
+              ]
+            }
+          ],
+          "collection": {
+            "kind": "ordered_set",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-INVARIANTS-031",
+              "TLC-SO-INVARIANTS-044",
+              "TLC-SO-INVARIANTS-049",
+              "TLC-SR-INVARIANTS-030",
+              "TLC-SR-INVARIANTS-043",
+              "TLC-SR-INVARIANTS-048"
+            ],
+            "cardinality": {
+              "minimum": 6,
+              "maximum": 6
+            },
+            "ordering": "required",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV005-IN-001",
+              "statement": "Every supplied identity is feature-covered, unique where required, and accompanied by source provenance."
+            },
+            {
+              "id": "INV005-IN-002",
+              "statement": "Source-declared order is preserved; otherwise validated input order is retained only as engineering order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable AnnotatedInvariantEvidence",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-04-INVARIANTS-005"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "feature-specific structural representation",
+              "constant": "AnnotatedInvariantEvidence"
+            },
+            {
+              "name": "entries",
+              "required": true,
+              "semantic_role": "immutable evidence entries with exact identities and order",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "unresolved identifiers attached to affected entries",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete preservation envelope",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "preserved catalogue and scientific status",
+              "constant": "deferred_for_scientific_decision"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV005-OUT-001",
+              "statement": "returns root evidence with three ordered non-normative annotations that cannot change invariant truth or status"
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "INV005-PRE-001",
+          "statement": "Every required identity, relationship, source reference, opaque symbol, unresolved mapping, and status value is present and source-consistent."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "INV005-POST-001",
+          "statement": "returns root evidence with three ordered non-normative annotations that cannot change invariant truth or status No scientific truth claim is added."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "INV005-INV-001",
+          "statement": "Covered identities, source order, references, opaque values, catalogue status, assumptions, reservations, and unresolved mappings are unchanged."
+        },
+        {
+          "id": "INV005-INV-002",
+          "statement": "Inputs and all external or scientific state remain unmodified."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate covered identities and required provenance",
+          "validate status, unresolved, assumption, and opaque preservation metadata",
+          "construct the feature-specific immutable representation",
+          "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate covered identities and required provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "validate status, unresolved, assumption, and opaque preservation metadata",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct the feature-specific immutable representation",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Validation and conservation must precede publication. The upstream total traversal sequence is not a unique architectural prescription."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "owned_result",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "result_lifetime",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "required",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "not_applicable",
+        "floating_point": "not_applicable",
+        "randomness": "forbidden"
+      },
+      "error_contract": [
+        {
+          "code": "UnknownAnnotationId",
+          "category": "invalid_input",
+          "condition": "The authoritative UnknownAnnotationId condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "AnnotationTargetMismatch",
+          "category": "invalid_input",
+          "condition": "The authoritative AnnotationTargetMismatch condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "DuplicateIdentifier",
+          "category": "invalid_input",
+          "condition": "A feature-owned identifier is duplicated.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "StatusPromotionProhibited",
+          "category": "preservation",
+          "condition": "Documentary, deferred, or rejected metadata is promoted to executable scientific status.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificEvaluationProhibited",
+          "category": "unsupported_operation",
+          "condition": "Truth, numeric, temporal, ordering, state, transition, or other scientific evaluation is requested without a sourced evaluator.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "PreservationViolation",
+          "category": "preservation",
+          "condition": "A source identity, order, opaque value, status, assumption, reservation, unresolved mapping, or provenance link changes or is lost.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-construction",
+      "status": "required",
+      "statement": "Expose attach_interpretation_annotations as a deterministic structural operation producing AnnotatedInvariantEvidence."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not decide truth, compute numerical values, detect states, or infer transitions."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal representation and validation decomposition remain free when observable preservation behavior is identical."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "INV005-GINV-001",
+      "statement": "No implementation behavior may weaken source identity, order, opacity, status, unresolved, assumption, reservation, immutability, or provenance obligations."
+    },
+    {
+      "id": "INV005-GINV-002",
+      "statement": "Historical rejection or deferral metadata is documentary and must remain visible without suppressing this finalized structural operation."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific and evidence references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered identifier collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted source statements and scientific truth conditions"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral structural errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable preservation result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is structural and behavioral. It does not prescribe a programming language, serialization, storage model, or complete internal step order."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-005/manifest.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-005/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-04-INVARIANTS-005",
+  "title": "Invariant interpretation annotations",
+  "domain": "invariants",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "external_provider_required",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-005/traceability.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-005/traceability.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-005",
+  "scientific_sources": [
+    {
+      "path": "maths/04-invariants.md",
+      "role": "Authoritative scientific source sections cited by the limited engineering contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-005/contract.yaml",
+      "role": "Defines covered evidence, exact structural behavior, reservations, and scientific boundary.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "a481cac44c7030a8b166f1bab4b83d2096dd6bf1"
+      }
+    },
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-005/traceability.yaml",
+      "role": "Preserves detailed contract-to-source traceability.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "783affb9eac33382887f43c717848698bccaac41"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-005/ir.prototype.json",
+      "role": "Prototype IR with reservations and operation-specific interface.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "851b6d31feb0fc2465c7d1e1302c29d0c5c8fc14"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-005/ir.yaml",
+      "role": "Selected finalized IR defining immutable structural behavior and stable errors.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "34022a1e35a6e89ed1d0beecccd06cb51d51eb51"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/invariants/TLC-FC-04-INVARIANTS-005/algorithm.yaml",
+      "role": "Applicable validation, construction, conservation, and error branches; total ordering is not adopted beyond observable requirements.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "303ff7d452083a536b9e1efc918aba5ae7bf2433"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-005/test-plan.yaml",
+      "role": "Source structural test plan and reservation-preservation scenarios.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "598420dafc9862331eca90081edb624430451cec"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/invariants/TLC-FC-04-INVARIANTS-005/oracle.yaml",
+      "role": "Authoritative nominal, error, opacity, ordering, determinism, and conformance expectations.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "9901f7f07c6a79b02c2545731d0f019e531bca68"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/invariants/feature-status.yaml",
+      "role": "Authoritative ten-feature inventory and historical status interpretation."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/module-specification.yaml",
+      "role": "Defines public operations, common structural rules, error vocabulary, dependencies, and scientific boundary."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/implementation-tasks.yaml",
+      "role": "Defines feature deliverables and acceptance obligations."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/patterns.yaml",
+      "role": "Records domain-local common patterns without creating shared handoff contracts."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-006/README.md
+++ b/handoff/features/TLC-FC-04-INVARIANTS-006/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-04-INVARIANTS-006 — Collective ethics invariant expression
+
+This package defines the final structural handoff for Collective ethics invariant expression.
+
+## What must be implemented
+
+Implement `construct_collective_ethics_invariant_expression` as a deterministic, immutable evidence transformation. It validates feature-covered identities and source references, preserves opaque content and historical catalogue status, and returns a `SymbolicCollectiveEthicsInvariant` with complete provenance.
+
+## Valid inputs and required output
+
+The accepted covered evidence identities are: TLC-SO-INVARIANTS-013, TLC-SO-INVARIANTS-057, TLC-SR-INVARIANTS-012, TLC-SR-INVARIANTS-056. The required catalogue status is `deferred_for_targeted_extraction`. Required unresolved identifiers are: none. Required provisional assumptions are: TLC-EA-INVARIANTS-006-001.
+
+The required output is an immutable `SymbolicCollectiveEthicsInvariant`. produces the source-defined integral AST followed by derivative-equals-zero and gradient-equals-zero constraint ASTs with provenance
+
+## Mandatory and forbidden behavior
+
+Identity, source order, provenance, opaque values, status, assumptions, reservations, unresolved mappings, input immutability, deterministic structural equality, and failure atomicity are mandatory. Scientific truth evaluation, status promotion, inferred thresholds or comparators, transition graphs, chronology, causality, symmetry, transitivity, dimensions, units, precision, and numerical methods are forbidden.
+
+## Implementation freedom
+
+Language, public wrapper naming, storage, allocation, ownership mechanism, serialization, concurrency policy, error transport, and internal traversal remain free when observable behavior is unchanged.
+
+## Errors and conformance
+
+The authoritative observable error codes are: MissingRequiredSymbol, MissingCollectiveEthicsEvidence, ScientificEvaluationProhibited, PreservationViolation. Errors publish no partial result. Conformance requires every test in `acceptance.json`, exact preservation of the source envelope, and rejection of scientific evaluation. Scientific truth conditions remain opaque and require future externally sourced evaluation semantics.

--- a/handoff/features/TLC-FC-04-INVARIANTS-006/acceptance.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-006/acceptance.json
@@ -1,0 +1,185 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-006",
+  "tests": [
+    {
+      "test_id": "INV006-ACCEPT-NOMINAL",
+      "applies_to": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-04-INVARIANTS-006",
+        "covered_evidence_ids": [
+          "TLC-SO-INVARIANTS-013",
+          "TLC-SO-INVARIANTS-057",
+          "TLC-SR-INVARIANTS-012",
+          "TLC-SR-INVARIANTS-056"
+        ],
+        "catalogue_status": "deferred_for_targeted_extraction",
+        "unresolved_refs": []
+      },
+      "when": "The construct_collective_ethics_invariant_expression oracle scenario is exercised.",
+      "expect": {
+        "accepted": true,
+        "output_type": "SymbolicCollectiveEthicsInvariant",
+        "immutable": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV006-ACCEPT-SHAPE",
+      "applies_to": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV006-ACCEPT-SHAPE"
+      },
+      "when": "The construct_collective_ethics_invariant_expression oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV006-ACCEPT-MISSING-SYMBOL",
+      "applies_to": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV006-ACCEPT-MISSING-SYMBOL"
+      },
+      "when": "The construct_collective_ethics_invariant_expression oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV006-ACCEPT-MISSING-EVIDENCE",
+      "applies_to": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV006-ACCEPT-MISSING-EVIDENCE"
+      },
+      "when": "The construct_collective_ethics_invariant_expression oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV006-ACCEPT-OPAQUE",
+      "applies_to": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV006-ACCEPT-OPAQUE"
+      },
+      "when": "The construct_collective_ethics_invariant_expression oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV006-ACCEPT-NO-EVALUATION",
+      "applies_to": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "category": "unsupported_operation",
+      "given": {
+        "authoritative_oracle_scenario": "INV006-ACCEPT-NO-EVALUATION"
+      },
+      "when": "The construct_collective_ethics_invariant_expression oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV006-ACCEPT-NO-SIMPLIFICATION",
+      "applies_to": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV006-ACCEPT-NO-SIMPLIFICATION"
+      },
+      "when": "The construct_collective_ethics_invariant_expression oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV006-ACCEPT-DETERMINISM",
+      "applies_to": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "category": "determinism",
+      "given": {
+        "authoritative_oracle_scenario": "INV006-ACCEPT-DETERMINISM"
+      },
+      "when": "The construct_collective_ethics_invariant_expression oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV006-ACCEPT-RESERVATIONS",
+      "applies_to": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV006-ACCEPT-RESERVATIONS"
+      },
+      "when": "The construct_collective_ethics_invariant_expression oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV006-ACCEPT-CONFORMANCE",
+      "applies_to": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV006-ACCEPT-CONFORMANCE"
+      },
+      "when": "The construct_collective_ethics_invariant_expression oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-006/contract.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-006/contract.json
@@ -1,0 +1,442 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-04-INVARIANTS-006",
+    "title": "Collective ethics invariant expression",
+    "domain": "invariants"
+  },
+  "purpose": "Validate source-backed collective ethics invariant expression evidence and produces the source-defined integral AST followed by derivative-equals-zero and gradient-equals-zero constraint ASTs with provenance Scientific truth evaluation is not performed.",
+  "scope": {
+    "required": [
+      {
+        "id": "INV006-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-04-INVARIANTS-006 and covered evidence identifiers [TLC-SO-INVARIANTS-013, TLC-SO-INVARIANTS-057, TLC-SR-INVARIANTS-012, TLC-SR-INVARIANTS-056].",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-006/contract.yaml",
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-006/ir.yaml"
+        ]
+      },
+      {
+        "id": "INV006-REQ-002",
+        "statement": "Preserve catalogue status deferred_for_targeted_extraction, source order, provenance, opaque values, unresolved identifiers [], and assumptions [TLC-EA-INVARIANTS-006-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-006/contract.yaml",
+          "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml"
+        ]
+      },
+      {
+        "id": "INV006-REQ-003",
+        "statement": "Emit an immutable SymbolicCollectiveEthicsInvariant with a complete preservation envelope.",
+        "basis": [
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-006/ir.yaml",
+          "registry/domain-finalization/invariants/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "INV006-FOR-001",
+        "statement": "Do not evaluate scientific truth or infer a comparator, threshold value, runtime domain, transition graph, chronology, causality, symmetry, transitivity, units, dimensions, precision, or numerical method."
+      },
+      {
+        "id": "INV006-FOR-002",
+        "statement": "Do not promote documentary, deferred, provisionally separated, or rejected source metadata to executable scientific status."
+      },
+      {
+        "id": "INV006-FOR-003",
+        "statement": "Do not mutate inputs, scientific state, external domain state, or publish a partial successful result."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "INV006-DEF-001",
+        "statement": "Scientific evaluation requires a future externally sourced evaluator; this package defines no evaluator interface or truth criterion."
+      },
+      {
+        "id": "INV006-DEF-002",
+        "statement": "Opaque scientific truth conditions remain external and uninterpreted."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "CONSTRUCT-COLLECTIVE-ETHICS-INVARIANT-EXPRESSION",
+      "purpose": "Construct the immutable SymbolicCollectiveEthicsInvariant from validated source evidence without scientific evaluation.",
+      "inputs": [
+        {
+          "name": "evidence",
+          "semantic_role": "CollectiveEthicsExpressionSymbols",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-04-INVARIANTS-006"
+            },
+            {
+              "name": "evidence_ids",
+              "required": true,
+              "semantic_role": "exact covered object and relation identities",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-INVARIANTS-013",
+                "TLC-SO-INVARIANTS-057",
+                "TLC-SR-INVARIANTS-012",
+                "TLC-SR-INVARIANTS-056"
+              ]
+            },
+            {
+              "name": "source_references",
+              "required": true,
+              "semantic_role": "source provenance for every evidence item",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_values",
+              "required": true,
+              "semantic_role": "uninterpreted source statements and scientific truth conditions",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "catalogue_status",
+              "required": true,
+              "semantic_role": "exact historical catalogue status",
+              "constant": "deferred_for_targeted_extraction"
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact unresolved identifiers attached to affected evidence",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "assumption_refs",
+              "required": true,
+              "semantic_role": "exact provisional engineering assumption identifiers",
+              "allowed_values": [
+                "TLC-EA-INVARIANTS-006-001"
+              ]
+            }
+          ],
+          "collection": {
+            "kind": "ordered_set",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-INVARIANTS-013",
+              "TLC-SO-INVARIANTS-057",
+              "TLC-SR-INVARIANTS-012",
+              "TLC-SR-INVARIANTS-056"
+            ],
+            "cardinality": {
+              "minimum": 4,
+              "maximum": 4
+            },
+            "ordering": "required",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV006-IN-001",
+              "statement": "Every supplied identity is feature-covered, unique where required, and accompanied by source provenance."
+            },
+            {
+              "id": "INV006-IN-002",
+              "statement": "Source-declared order is preserved; otherwise validated input order is retained only as engineering order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable SymbolicCollectiveEthicsInvariant",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-04-INVARIANTS-006"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "feature-specific structural representation",
+              "constant": "SymbolicCollectiveEthicsInvariant"
+            },
+            {
+              "name": "entries",
+              "required": true,
+              "semantic_role": "immutable evidence entries with exact identities and order",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "unresolved identifiers attached to affected entries",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete preservation envelope",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "preserved catalogue and scientific status",
+              "constant": "deferred_for_targeted_extraction"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV006-OUT-001",
+              "statement": "produces the source-defined integral AST followed by derivative-equals-zero and gradient-equals-zero constraint ASTs with provenance"
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "INV006-PRE-001",
+          "statement": "Every required identity, relationship, source reference, opaque symbol, unresolved mapping, and status value is present and source-consistent."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "INV006-POST-001",
+          "statement": "produces the source-defined integral AST followed by derivative-equals-zero and gradient-equals-zero constraint ASTs with provenance No scientific truth claim is added."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "INV006-INV-001",
+          "statement": "Covered identities, source order, references, opaque values, catalogue status, assumptions, reservations, and unresolved mappings are unchanged."
+        },
+        {
+          "id": "INV006-INV-002",
+          "statement": "Inputs and all external or scientific state remain unmodified."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate covered identities and required provenance",
+          "validate status, unresolved, assumption, and opaque preservation metadata",
+          "construct the feature-specific immutable representation",
+          "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate covered identities and required provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "validate status, unresolved, assumption, and opaque preservation metadata",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct the feature-specific immutable representation",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Validation and conservation must precede publication. The upstream total traversal sequence is not a unique architectural prescription."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "owned_result",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "result_lifetime",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "required",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "not_applicable",
+        "floating_point": "not_applicable",
+        "randomness": "forbidden"
+      },
+      "error_contract": [
+        {
+          "code": "MissingRequiredSymbol",
+          "category": "invalid_input",
+          "condition": "The authoritative MissingRequiredSymbol condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingCollectiveEthicsEvidence",
+          "category": "invalid_input",
+          "condition": "The authoritative MissingCollectiveEthicsEvidence condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificEvaluationProhibited",
+          "category": "unsupported_operation",
+          "condition": "Truth, numeric, temporal, ordering, state, transition, or other scientific evaluation is requested without a sourced evaluator.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "PreservationViolation",
+          "category": "preservation",
+          "condition": "A source identity, order, opaque value, status, assumption, reservation, unresolved mapping, or provenance link changes or is lost.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-construction",
+      "status": "required",
+      "statement": "Expose construct_collective_ethics_invariant_expression as a deterministic structural operation producing SymbolicCollectiveEthicsInvariant."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not decide truth, compute numerical values, detect states, or infer transitions."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal representation and validation decomposition remain free when observable preservation behavior is identical."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "INV006-GINV-001",
+      "statement": "No implementation behavior may weaken source identity, order, opacity, status, unresolved, assumption, reservation, immutability, or provenance obligations."
+    },
+    {
+      "id": "INV006-GINV-002",
+      "statement": "Historical rejection or deferral metadata is documentary and must remain visible without suppressing this finalized structural operation."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific and evidence references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered identifier collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted source statements and scientific truth conditions"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral structural errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable preservation result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is structural and behavioral. It does not prescribe a programming language, serialization, storage model, or complete internal step order."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-006/manifest.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-006/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-04-INVARIANTS-006",
+  "title": "Collective ethics invariant expression",
+  "domain": "invariants",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "external_provider_required",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-006/traceability.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-006/traceability.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-006",
+  "scientific_sources": [
+    {
+      "path": "maths/04-invariants.md",
+      "role": "Authoritative scientific source sections cited by the limited engineering contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-006/contract.yaml",
+      "role": "Defines covered evidence, exact structural behavior, reservations, and scientific boundary.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "65b0b77219b55a0f87a0030841775665d146dbc6"
+      }
+    },
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-006/traceability.yaml",
+      "role": "Preserves detailed contract-to-source traceability.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "43d7a78bcef5c3d8fe8133a5ebe93f5f2b28ed8e"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-006/ir.prototype.json",
+      "role": "Prototype IR with reservations and operation-specific interface.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "5372e1ae9e1dbf71ef36e1e4cc1f3052f922f17c"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-006/ir.yaml",
+      "role": "Selected finalized IR defining immutable structural behavior and stable errors.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "acd8bff1d97170ce71db3b1944cc42f19dd53ac7"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/invariants/TLC-FC-04-INVARIANTS-006/algorithm.yaml",
+      "role": "Applicable validation, construction, conservation, and error branches; total ordering is not adopted beyond observable requirements.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "09a401741173789a479c89440dad4e9c6a47a98d"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-006/test-plan.yaml",
+      "role": "Source structural test plan and reservation-preservation scenarios.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "f59e0a643cc04227387750cc434e282e06edf353"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/invariants/TLC-FC-04-INVARIANTS-006/oracle.yaml",
+      "role": "Authoritative nominal, error, opacity, ordering, determinism, and conformance expectations.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "aee49b7e6bc07e98968a5f1f45efa48182c469ea"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/invariants/feature-status.yaml",
+      "role": "Authoritative ten-feature inventory and historical status interpretation."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/module-specification.yaml",
+      "role": "Defines public operations, common structural rules, error vocabulary, dependencies, and scientific boundary."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/implementation-tasks.yaml",
+      "role": "Defines feature deliverables and acceptance obligations."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/patterns.yaml",
+      "role": "Records domain-local common patterns without creating shared handoff contracts."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-007/README.md
+++ b/handoff/features/TLC-FC-04-INVARIANTS-007/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-04-INVARIANTS-007 — Disintegration relation record
+
+This package defines the final structural handoff for Disintegration relation record.
+
+## What must be implemented
+
+Implement `construct_disintegration_relation` as a deterministic, immutable evidence transformation. It validates feature-covered identities and source references, preserves opaque content and historical catalogue status, and returns a `DisintegrationRelationRecord` with complete provenance.
+
+## Valid inputs and required output
+
+The accepted covered evidence identities are: TLC-SO-INVARIANTS-068, TLC-SR-INVARIANTS-067. The required catalogue status is `retained_with_reservations`. Required unresolved identifiers are: none. Required provisional assumptions are: TLC-EA-INVARIANTS-007-001.
+
+The required output is an immutable `DisintegrationRelationRecord`. returns one refers_to edge with source, target, relation ID, and evidence reference preserved
+
+## Mandatory and forbidden behavior
+
+Identity, source order, provenance, opaque values, status, assumptions, reservations, unresolved mappings, input immutability, deterministic structural equality, and failure atomicity are mandatory. Scientific truth evaluation, status promotion, inferred thresholds or comparators, transition graphs, chronology, causality, symmetry, transitivity, dimensions, units, precision, and numerical methods are forbidden.
+
+## Implementation freedom
+
+Language, public wrapper naming, storage, allocation, ownership mechanism, serialization, concurrency policy, error transport, and internal traversal remain free when observable behavior is unchanged.
+
+## Errors and conformance
+
+The authoritative observable error codes are: EndpointMismatch, UnknownRelationId, MissingSourceReference, ScientificEvaluationProhibited, PreservationViolation. Errors publish no partial result. Conformance requires every test in `acceptance.json`, exact preservation of the source envelope, and rejection of scientific evaluation. Scientific truth conditions remain opaque and require future externally sourced evaluation semantics.

--- a/handoff/features/TLC-FC-04-INVARIANTS-007/acceptance.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-007/acceptance.json
@@ -1,0 +1,166 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-007",
+  "tests": [
+    {
+      "test_id": "INV007-ACCEPT-NOMINAL",
+      "applies_to": "CONSTRUCT-DISINTEGRATION-RELATION",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-04-INVARIANTS-007",
+        "covered_evidence_ids": [
+          "TLC-SO-INVARIANTS-068",
+          "TLC-SR-INVARIANTS-067"
+        ],
+        "catalogue_status": "retained_with_reservations",
+        "unresolved_refs": []
+      },
+      "when": "The construct_disintegration_relation oracle scenario is exercised.",
+      "expect": {
+        "accepted": true,
+        "output_type": "DisintegrationRelationRecord",
+        "immutable": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV007-ACCEPT-RELATION-ID",
+      "applies_to": "CONSTRUCT-DISINTEGRATION-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV007-ACCEPT-RELATION-ID"
+      },
+      "when": "The construct_disintegration_relation oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV007-ACCEPT-ENDPOINT",
+      "applies_to": "CONSTRUCT-DISINTEGRATION-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV007-ACCEPT-ENDPOINT"
+      },
+      "when": "The construct_disintegration_relation oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV007-ACCEPT-EVIDENCE",
+      "applies_to": "CONSTRUCT-DISINTEGRATION-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV007-ACCEPT-EVIDENCE"
+      },
+      "when": "The construct_disintegration_relation oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV007-ACCEPT-OPAQUE",
+      "applies_to": "CONSTRUCT-DISINTEGRATION-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV007-ACCEPT-OPAQUE"
+      },
+      "when": "The construct_disintegration_relation oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV007-ACCEPT-NO-INFERENCE",
+      "applies_to": "CONSTRUCT-DISINTEGRATION-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV007-ACCEPT-NO-INFERENCE"
+      },
+      "when": "The construct_disintegration_relation oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV007-ACCEPT-DETERMINISM",
+      "applies_to": "CONSTRUCT-DISINTEGRATION-RELATION",
+      "category": "determinism",
+      "given": {
+        "authoritative_oracle_scenario": "INV007-ACCEPT-DETERMINISM"
+      },
+      "when": "The construct_disintegration_relation oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV007-ACCEPT-RESERVATIONS",
+      "applies_to": "CONSTRUCT-DISINTEGRATION-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV007-ACCEPT-RESERVATIONS"
+      },
+      "when": "The construct_disintegration_relation oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV007-ACCEPT-CONFORMANCE",
+      "applies_to": "CONSTRUCT-DISINTEGRATION-RELATION",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV007-ACCEPT-CONFORMANCE"
+      },
+      "when": "The construct_disintegration_relation oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-007/contract.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-007/contract.json
@@ -1,0 +1,447 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-04-INVARIANTS-007",
+    "title": "Disintegration relation record",
+    "domain": "invariants"
+  },
+  "purpose": "Validate source-backed disintegration relation record evidence and returns one refers_to edge with source, target, relation ID, and evidence reference preserved Scientific truth evaluation is not performed.",
+  "scope": {
+    "required": [
+      {
+        "id": "INV007-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-04-INVARIANTS-007 and covered evidence identifiers [TLC-SO-INVARIANTS-068, TLC-SR-INVARIANTS-067].",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-007/contract.yaml",
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-007/ir.yaml"
+        ]
+      },
+      {
+        "id": "INV007-REQ-002",
+        "statement": "Preserve catalogue status retained_with_reservations, source order, provenance, opaque values, unresolved identifiers [], and assumptions [TLC-EA-INVARIANTS-007-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-007/contract.yaml",
+          "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml"
+        ]
+      },
+      {
+        "id": "INV007-REQ-003",
+        "statement": "Emit an immutable DisintegrationRelationRecord with a complete preservation envelope.",
+        "basis": [
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-007/ir.yaml",
+          "registry/domain-finalization/invariants/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "INV007-FOR-001",
+        "statement": "Do not evaluate scientific truth or infer a comparator, threshold value, runtime domain, transition graph, chronology, causality, symmetry, transitivity, units, dimensions, precision, or numerical method."
+      },
+      {
+        "id": "INV007-FOR-002",
+        "statement": "Do not promote documentary, deferred, provisionally separated, or rejected source metadata to executable scientific status."
+      },
+      {
+        "id": "INV007-FOR-003",
+        "statement": "Do not mutate inputs, scientific state, external domain state, or publish a partial successful result."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "INV007-DEF-001",
+        "statement": "Scientific evaluation requires a future externally sourced evaluator; this package defines no evaluator interface or truth criterion."
+      },
+      {
+        "id": "INV007-DEF-002",
+        "statement": "Opaque scientific truth conditions remain external and uninterpreted."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "CONSTRUCT-DISINTEGRATION-RELATION",
+      "purpose": "Construct the immutable DisintegrationRelationRecord from validated source evidence without scientific evaluation.",
+      "inputs": [
+        {
+          "name": "evidence",
+          "semantic_role": "RelationEndpointsAndEvidence",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-04-INVARIANTS-007"
+            },
+            {
+              "name": "evidence_ids",
+              "required": true,
+              "semantic_role": "exact covered object and relation identities",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-INVARIANTS-068",
+                "TLC-SR-INVARIANTS-067"
+              ]
+            },
+            {
+              "name": "source_references",
+              "required": true,
+              "semantic_role": "source provenance for every evidence item",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_values",
+              "required": true,
+              "semantic_role": "uninterpreted source statements and scientific truth conditions",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "catalogue_status",
+              "required": true,
+              "semantic_role": "exact historical catalogue status",
+              "constant": "retained_with_reservations"
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact unresolved identifiers attached to affected evidence",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "assumption_refs",
+              "required": true,
+              "semantic_role": "exact provisional engineering assumption identifiers",
+              "allowed_values": [
+                "TLC-EA-INVARIANTS-007-001"
+              ]
+            }
+          ],
+          "collection": {
+            "kind": "ordered_set",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-INVARIANTS-068",
+              "TLC-SR-INVARIANTS-067"
+            ],
+            "cardinality": {
+              "minimum": 2,
+              "maximum": 2
+            },
+            "ordering": "required",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV007-IN-001",
+              "statement": "Every supplied identity is feature-covered, unique where required, and accompanied by source provenance."
+            },
+            {
+              "id": "INV007-IN-002",
+              "statement": "Source-declared order is preserved; otherwise validated input order is retained only as engineering order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable DisintegrationRelationRecord",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-04-INVARIANTS-007"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "feature-specific structural representation",
+              "constant": "DisintegrationRelationRecord"
+            },
+            {
+              "name": "entries",
+              "required": true,
+              "semantic_role": "immutable evidence entries with exact identities and order",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "unresolved identifiers attached to affected entries",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete preservation envelope",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "preserved catalogue and scientific status",
+              "constant": "retained_with_reservations"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV007-OUT-001",
+              "statement": "returns one refers_to edge with source, target, relation ID, and evidence reference preserved"
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "INV007-PRE-001",
+          "statement": "Every required identity, relationship, source reference, opaque symbol, unresolved mapping, and status value is present and source-consistent."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "INV007-POST-001",
+          "statement": "returns one refers_to edge with source, target, relation ID, and evidence reference preserved No scientific truth claim is added."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "INV007-INV-001",
+          "statement": "Covered identities, source order, references, opaque values, catalogue status, assumptions, reservations, and unresolved mappings are unchanged."
+        },
+        {
+          "id": "INV007-INV-002",
+          "statement": "Inputs and all external or scientific state remain unmodified."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate covered identities and required provenance",
+          "validate status, unresolved, assumption, and opaque preservation metadata",
+          "construct the feature-specific immutable representation",
+          "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate covered identities and required provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "validate status, unresolved, assumption, and opaque preservation metadata",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct the feature-specific immutable representation",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Validation and conservation must precede publication. The upstream total traversal sequence is not a unique architectural prescription."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "owned_result",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "result_lifetime",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "required",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "not_applicable",
+        "floating_point": "not_applicable",
+        "randomness": "forbidden"
+      },
+      "error_contract": [
+        {
+          "code": "EndpointMismatch",
+          "category": "invalid_input",
+          "condition": "The authoritative EndpointMismatch condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnknownRelationId",
+          "category": "invalid_input",
+          "condition": "The authoritative UnknownRelationId condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "invalid_input",
+          "condition": "Required source provenance is absent.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificEvaluationProhibited",
+          "category": "unsupported_operation",
+          "condition": "Truth, numeric, temporal, ordering, state, transition, or other scientific evaluation is requested without a sourced evaluator.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "PreservationViolation",
+          "category": "preservation",
+          "condition": "A source identity, order, opaque value, status, assumption, reservation, unresolved mapping, or provenance link changes or is lost.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-construction",
+      "status": "required",
+      "statement": "Expose construct_disintegration_relation as a deterministic structural operation producing DisintegrationRelationRecord."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not decide truth, compute numerical values, detect states, or infer transitions."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal representation and validation decomposition remain free when observable preservation behavior is identical."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "INV007-GINV-001",
+      "statement": "No implementation behavior may weaken source identity, order, opacity, status, unresolved, assumption, reservation, immutability, or provenance obligations."
+    },
+    {
+      "id": "INV007-GINV-002",
+      "statement": "Historical rejection or deferral metadata is documentary and must remain visible without suppressing this finalized structural operation."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific and evidence references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered identifier collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted source statements and scientific truth conditions"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral structural errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable preservation result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is structural and behavioral. It does not prescribe a programming language, serialization, storage model, or complete internal step order."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-007/manifest.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-007/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-04-INVARIANTS-007",
+  "title": "Disintegration relation record",
+  "domain": "invariants",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "external_provider_required",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-007/traceability.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-007/traceability.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-007",
+  "scientific_sources": [
+    {
+      "path": "maths/04-invariants.md",
+      "role": "Authoritative scientific source sections cited by the limited engineering contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-007/contract.yaml",
+      "role": "Defines covered evidence, exact structural behavior, reservations, and scientific boundary.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "8064bf1af66e7fa0c5d4f9c1892ed024d214ab58"
+      }
+    },
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-007/traceability.yaml",
+      "role": "Preserves detailed contract-to-source traceability.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "6ab22eb4273f96d91ae56ec8c10159fd32bf2677"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-007/ir.prototype.json",
+      "role": "Prototype IR with reservations and operation-specific interface.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "31c9c88f6c0a88b8f418c3b0ef9fcce766a34fc0"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-007/ir.yaml",
+      "role": "Selected finalized IR defining immutable structural behavior and stable errors.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "82ea45cfd0430c8a78563c1a6f114de367cc8b96"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/invariants/TLC-FC-04-INVARIANTS-007/algorithm.yaml",
+      "role": "Applicable validation, construction, conservation, and error branches; total ordering is not adopted beyond observable requirements.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "8e3c59ef56b6877b1f7bae6aa56d473b24b90489"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-007/test-plan.yaml",
+      "role": "Source structural test plan and reservation-preservation scenarios.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "49d325aaa7703d1cbc1f5f6dde45ea79992d0ee8"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/invariants/TLC-FC-04-INVARIANTS-007/oracle.yaml",
+      "role": "Authoritative nominal, error, opacity, ordering, determinism, and conformance expectations.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "2508f5758725bea3d084350d42b462379b0316cd"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/invariants/feature-status.yaml",
+      "role": "Authoritative ten-feature inventory and historical status interpretation."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/module-specification.yaml",
+      "role": "Defines public operations, common structural rules, error vocabulary, dependencies, and scientific boundary."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/implementation-tasks.yaml",
+      "role": "Defines feature deliverables and acceptance obligations."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/patterns.yaml",
+      "role": "Records domain-local common patterns without creating shared handoff contracts."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-008/README.md
+++ b/handoff/features/TLC-FC-04-INVARIANTS-008/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-04-INVARIANTS-008 — Invariant state vocabulary
+
+This package defines the final structural handoff for Invariant state vocabulary.
+
+## What must be implemented
+
+Implement `assemble_invariant_state_vocabulary` as a deterministic, immutable evidence transformation. It validates feature-covered identities and source references, preserves opaque content and historical catalogue status, and returns a `InvariantStateVocabulary` with complete provenance.
+
+## Valid inputs and required output
+
+The accepted covered evidence identities are: TLC-SO-INVARIANTS-001, TLC-SO-INVARIANTS-041, TLC-SO-INVARIANTS-050, TLC-SO-INVARIANTS-051, TLC-SO-INVARIANTS-052, TLC-SO-INVARIANTS-054, TLC-SO-INVARIANTS-059, TLC-SO-INVARIANTS-061, TLC-SO-INVARIANTS-063, TLC-SO-INVARIANTS-066, TLC-SO-INVARIANTS-067, TLC-SO-INVARIANTS-069, TLC-SR-INVARIANTS-001, TLC-SR-INVARIANTS-002, TLC-SR-INVARIANTS-003, TLC-SR-INVARIANTS-004, TLC-SR-INVARIANTS-005, TLC-SR-INVARIANTS-006, TLC-SR-INVARIANTS-007, TLC-SR-INVARIANTS-008, TLC-SR-INVARIANTS-009, TLC-SR-INVARIANTS-010, TLC-SR-INVARIANTS-011, TLC-SR-INVARIANTS-012, TLC-SR-INVARIANTS-013, TLC-SR-INVARIANTS-014, TLC-SR-INVARIANTS-015, TLC-SR-INVARIANTS-016, TLC-SR-INVARIANTS-017, TLC-SR-INVARIANTS-018, TLC-SR-INVARIANTS-019, TLC-SR-INVARIANTS-020, TLC-SR-INVARIANTS-021, TLC-SR-INVARIANTS-022, TLC-SR-INVARIANTS-023, TLC-SR-INVARIANTS-024, TLC-SR-INVARIANTS-025, TLC-SR-INVARIANTS-026, TLC-SR-INVARIANTS-027, TLC-SR-INVARIANTS-028, TLC-SR-INVARIANTS-029, TLC-SR-INVARIANTS-030, TLC-SR-INVARIANTS-031, TLC-SR-INVARIANTS-032, TLC-SR-INVARIANTS-033, TLC-SR-INVARIANTS-034, TLC-SR-INVARIANTS-035, TLC-SR-INVARIANTS-036, TLC-SR-INVARIANTS-037, TLC-SR-INVARIANTS-038, TLC-SR-INVARIANTS-039, TLC-SR-INVARIANTS-040, TLC-SR-INVARIANTS-041, TLC-SR-INVARIANTS-042, TLC-SR-INVARIANTS-043, TLC-SR-INVARIANTS-044, TLC-SR-INVARIANTS-045, TLC-SR-INVARIANTS-046, TLC-SR-INVARIANTS-047, TLC-SR-INVARIANTS-048, TLC-SR-INVARIANTS-049, TLC-SR-INVARIANTS-050, TLC-SR-INVARIANTS-051, TLC-SR-INVARIANTS-052, TLC-SR-INVARIANTS-053, TLC-SR-INVARIANTS-054, TLC-SR-INVARIANTS-055, TLC-SR-INVARIANTS-056, TLC-SR-INVARIANTS-057, TLC-SR-INVARIANTS-058, TLC-SR-INVARIANTS-059, TLC-SR-INVARIANTS-060, TLC-SR-INVARIANTS-061, TLC-SR-INVARIANTS-062, TLC-SR-INVARIANTS-063, TLC-SR-INVARIANTS-064, TLC-SR-INVARIANTS-065, TLC-SR-INVARIANTS-066, TLC-SR-INVARIANTS-067, TLC-SR-INVARIANTS-068. The required catalogue status is `deferred_for_targeted_extraction`. Required unresolved identifiers are: TLC-UT-INVARIANTS-001, TLC-UT-INVARIANTS-002, TLC-UT-INVARIANTS-003, TLC-UT-INVARIANTS-004, TLC-UT-INVARIANTS-005, TLC-UT-INVARIANTS-006, TLC-UT-INVARIANTS-007, TLC-UT-INVARIANTS-008, TLC-UT-INVARIANTS-010, TLC-UT-INVARIANTS-011, TLC-UT-INVARIANTS-012. Required provisional assumptions are: TLC-EA-INVARIANTS-008-001.
+
+The required output is an immutable `InvariantStateVocabulary`. returns a vocabulary keyed by state-term IDs with unresolved IDs attached to affected terms
+
+## Mandatory and forbidden behavior
+
+Identity, source order, provenance, opaque values, status, assumptions, reservations, unresolved mappings, input immutability, deterministic structural equality, and failure atomicity are mandatory. Scientific truth evaluation, status promotion, inferred thresholds or comparators, transition graphs, chronology, causality, symmetry, transitivity, dimensions, units, precision, and numerical methods are forbidden.
+
+## Implementation freedom
+
+Language, public wrapper naming, storage, allocation, ownership mechanism, serialization, concurrency policy, error transport, and internal traversal remain free when observable behavior is unchanged.
+
+## Errors and conformance
+
+The authoritative observable error codes are: UnknownStateTermId, DuplicateIdentifier, UnresolvedMappingLoss, MissingSourceReference, ScientificEvaluationProhibited, PreservationViolation. Errors publish no partial result. Conformance requires every test in `acceptance.json`, exact preservation of the source envelope, and rejection of scientific evaluation. Unresolved scientific identifiers remain attached to their affected evidence and must never be resolved implicitly.

--- a/handoff/features/TLC-FC-04-INVARIANTS-008/acceptance.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-008/acceptance.json
@@ -1,0 +1,290 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-008",
+  "tests": [
+    {
+      "test_id": "INV008-ACCEPT-NOMINAL",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-04-INVARIANTS-008",
+        "covered_evidence_ids": [
+          "TLC-SO-INVARIANTS-001",
+          "TLC-SO-INVARIANTS-041",
+          "TLC-SO-INVARIANTS-050",
+          "TLC-SO-INVARIANTS-051",
+          "TLC-SO-INVARIANTS-052",
+          "TLC-SO-INVARIANTS-054",
+          "TLC-SO-INVARIANTS-059",
+          "TLC-SO-INVARIANTS-061",
+          "TLC-SO-INVARIANTS-063",
+          "TLC-SO-INVARIANTS-066",
+          "TLC-SO-INVARIANTS-067",
+          "TLC-SO-INVARIANTS-069",
+          "TLC-SR-INVARIANTS-001",
+          "TLC-SR-INVARIANTS-002",
+          "TLC-SR-INVARIANTS-003",
+          "TLC-SR-INVARIANTS-004",
+          "TLC-SR-INVARIANTS-005",
+          "TLC-SR-INVARIANTS-006",
+          "TLC-SR-INVARIANTS-007",
+          "TLC-SR-INVARIANTS-008",
+          "TLC-SR-INVARIANTS-009",
+          "TLC-SR-INVARIANTS-010",
+          "TLC-SR-INVARIANTS-011",
+          "TLC-SR-INVARIANTS-012",
+          "TLC-SR-INVARIANTS-013",
+          "TLC-SR-INVARIANTS-014",
+          "TLC-SR-INVARIANTS-015",
+          "TLC-SR-INVARIANTS-016",
+          "TLC-SR-INVARIANTS-017",
+          "TLC-SR-INVARIANTS-018",
+          "TLC-SR-INVARIANTS-019",
+          "TLC-SR-INVARIANTS-020",
+          "TLC-SR-INVARIANTS-021",
+          "TLC-SR-INVARIANTS-022",
+          "TLC-SR-INVARIANTS-023",
+          "TLC-SR-INVARIANTS-024",
+          "TLC-SR-INVARIANTS-025",
+          "TLC-SR-INVARIANTS-026",
+          "TLC-SR-INVARIANTS-027",
+          "TLC-SR-INVARIANTS-028",
+          "TLC-SR-INVARIANTS-029",
+          "TLC-SR-INVARIANTS-030",
+          "TLC-SR-INVARIANTS-031",
+          "TLC-SR-INVARIANTS-032",
+          "TLC-SR-INVARIANTS-033",
+          "TLC-SR-INVARIANTS-034",
+          "TLC-SR-INVARIANTS-035",
+          "TLC-SR-INVARIANTS-036",
+          "TLC-SR-INVARIANTS-037",
+          "TLC-SR-INVARIANTS-038",
+          "TLC-SR-INVARIANTS-039",
+          "TLC-SR-INVARIANTS-040",
+          "TLC-SR-INVARIANTS-041",
+          "TLC-SR-INVARIANTS-042",
+          "TLC-SR-INVARIANTS-043",
+          "TLC-SR-INVARIANTS-044",
+          "TLC-SR-INVARIANTS-045",
+          "TLC-SR-INVARIANTS-046",
+          "TLC-SR-INVARIANTS-047",
+          "TLC-SR-INVARIANTS-048",
+          "TLC-SR-INVARIANTS-049",
+          "TLC-SR-INVARIANTS-050",
+          "TLC-SR-INVARIANTS-051",
+          "TLC-SR-INVARIANTS-052",
+          "TLC-SR-INVARIANTS-053",
+          "TLC-SR-INVARIANTS-054",
+          "TLC-SR-INVARIANTS-055",
+          "TLC-SR-INVARIANTS-056",
+          "TLC-SR-INVARIANTS-057",
+          "TLC-SR-INVARIANTS-058",
+          "TLC-SR-INVARIANTS-059",
+          "TLC-SR-INVARIANTS-060",
+          "TLC-SR-INVARIANTS-061",
+          "TLC-SR-INVARIANTS-062",
+          "TLC-SR-INVARIANTS-063",
+          "TLC-SR-INVARIANTS-064",
+          "TLC-SR-INVARIANTS-065",
+          "TLC-SR-INVARIANTS-066",
+          "TLC-SR-INVARIANTS-067",
+          "TLC-SR-INVARIANTS-068"
+        ],
+        "catalogue_status": "deferred_for_targeted_extraction",
+        "unresolved_refs": [
+          "TLC-UT-INVARIANTS-001",
+          "TLC-UT-INVARIANTS-002",
+          "TLC-UT-INVARIANTS-003",
+          "TLC-UT-INVARIANTS-004",
+          "TLC-UT-INVARIANTS-005",
+          "TLC-UT-INVARIANTS-006",
+          "TLC-UT-INVARIANTS-007",
+          "TLC-UT-INVARIANTS-008",
+          "TLC-UT-INVARIANTS-010",
+          "TLC-UT-INVARIANTS-011",
+          "TLC-UT-INVARIANTS-012"
+        ]
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "accepted": true,
+        "output_type": "InvariantStateVocabulary",
+        "immutable": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV008-ACCEPT-UNKNOWN-TERM",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV008-ACCEPT-UNKNOWN-TERM"
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV008-ACCEPT-DUPLICATE",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV008-ACCEPT-DUPLICATE"
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV008-ACCEPT-MISSING-UNRESOLVED",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV008-ACCEPT-MISSING-UNRESOLVED"
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV008-ACCEPT-EXTRA-UNRESOLVED",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV008-ACCEPT-EXTRA-UNRESOLVED"
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV008-ACCEPT-MISATTACHED",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV008-ACCEPT-MISATTACHED"
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV008-ACCEPT-OPAQUE",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV008-ACCEPT-OPAQUE"
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV008-ACCEPT-NO-TRANSITIONS",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV008-ACCEPT-NO-TRANSITIONS"
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV008-ACCEPT-DETERMINISM",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "determinism",
+      "given": {
+        "authoritative_oracle_scenario": "INV008-ACCEPT-DETERMINISM"
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV008-ACCEPT-RESERVATIONS",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV008-ACCEPT-RESERVATIONS"
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV008-ACCEPT-CONFORMANCE",
+      "applies_to": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV008-ACCEPT-CONFORMANCE"
+      },
+      "when": "The assemble_invariant_state_vocabulary oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-008/contract.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-008/contract.json
@@ -1,0 +1,636 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-04-INVARIANTS-008",
+    "title": "Invariant state vocabulary",
+    "domain": "invariants"
+  },
+  "purpose": "Validate source-backed invariant state vocabulary evidence and returns a vocabulary keyed by state-term IDs with unresolved IDs attached to affected terms Scientific truth evaluation is not performed.",
+  "scope": {
+    "required": [
+      {
+        "id": "INV008-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-04-INVARIANTS-008 and covered evidence identifiers [TLC-SO-INVARIANTS-001, TLC-SO-INVARIANTS-041, TLC-SO-INVARIANTS-050, TLC-SO-INVARIANTS-051, TLC-SO-INVARIANTS-052, TLC-SO-INVARIANTS-054, TLC-SO-INVARIANTS-059, TLC-SO-INVARIANTS-061, TLC-SO-INVARIANTS-063, TLC-SO-INVARIANTS-066, TLC-SO-INVARIANTS-067, TLC-SO-INVARIANTS-069, TLC-SR-INVARIANTS-001, TLC-SR-INVARIANTS-002, TLC-SR-INVARIANTS-003, TLC-SR-INVARIANTS-004, TLC-SR-INVARIANTS-005, TLC-SR-INVARIANTS-006, TLC-SR-INVARIANTS-007, TLC-SR-INVARIANTS-008, TLC-SR-INVARIANTS-009, TLC-SR-INVARIANTS-010, TLC-SR-INVARIANTS-011, TLC-SR-INVARIANTS-012, TLC-SR-INVARIANTS-013, TLC-SR-INVARIANTS-014, TLC-SR-INVARIANTS-015, TLC-SR-INVARIANTS-016, TLC-SR-INVARIANTS-017, TLC-SR-INVARIANTS-018, TLC-SR-INVARIANTS-019, TLC-SR-INVARIANTS-020, TLC-SR-INVARIANTS-021, TLC-SR-INVARIANTS-022, TLC-SR-INVARIANTS-023, TLC-SR-INVARIANTS-024, TLC-SR-INVARIANTS-025, TLC-SR-INVARIANTS-026, TLC-SR-INVARIANTS-027, TLC-SR-INVARIANTS-028, TLC-SR-INVARIANTS-029, TLC-SR-INVARIANTS-030, TLC-SR-INVARIANTS-031, TLC-SR-INVARIANTS-032, TLC-SR-INVARIANTS-033, TLC-SR-INVARIANTS-034, TLC-SR-INVARIANTS-035, TLC-SR-INVARIANTS-036, TLC-SR-INVARIANTS-037, TLC-SR-INVARIANTS-038, TLC-SR-INVARIANTS-039, TLC-SR-INVARIANTS-040, TLC-SR-INVARIANTS-041, TLC-SR-INVARIANTS-042, TLC-SR-INVARIANTS-043, TLC-SR-INVARIANTS-044, TLC-SR-INVARIANTS-045, TLC-SR-INVARIANTS-046, TLC-SR-INVARIANTS-047, TLC-SR-INVARIANTS-048, TLC-SR-INVARIANTS-049, TLC-SR-INVARIANTS-050, TLC-SR-INVARIANTS-051, TLC-SR-INVARIANTS-052, TLC-SR-INVARIANTS-053, TLC-SR-INVARIANTS-054, TLC-SR-INVARIANTS-055, TLC-SR-INVARIANTS-056, TLC-SR-INVARIANTS-057, TLC-SR-INVARIANTS-058, TLC-SR-INVARIANTS-059, TLC-SR-INVARIANTS-060, TLC-SR-INVARIANTS-061, TLC-SR-INVARIANTS-062, TLC-SR-INVARIANTS-063, TLC-SR-INVARIANTS-064, TLC-SR-INVARIANTS-065, TLC-SR-INVARIANTS-066, TLC-SR-INVARIANTS-067, TLC-SR-INVARIANTS-068].",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-008/contract.yaml",
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-008/ir.yaml"
+        ]
+      },
+      {
+        "id": "INV008-REQ-002",
+        "statement": "Preserve catalogue status deferred_for_targeted_extraction, source order, provenance, opaque values, unresolved identifiers [TLC-UT-INVARIANTS-001, TLC-UT-INVARIANTS-002, TLC-UT-INVARIANTS-003, TLC-UT-INVARIANTS-004, TLC-UT-INVARIANTS-005, TLC-UT-INVARIANTS-006, TLC-UT-INVARIANTS-007, TLC-UT-INVARIANTS-008, TLC-UT-INVARIANTS-010, TLC-UT-INVARIANTS-011, TLC-UT-INVARIANTS-012], and assumptions [TLC-EA-INVARIANTS-008-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-008/contract.yaml",
+          "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml"
+        ]
+      },
+      {
+        "id": "INV008-REQ-003",
+        "statement": "Emit an immutable InvariantStateVocabulary with a complete preservation envelope.",
+        "basis": [
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-008/ir.yaml",
+          "registry/domain-finalization/invariants/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "INV008-FOR-001",
+        "statement": "Do not evaluate scientific truth or infer a comparator, threshold value, runtime domain, transition graph, chronology, causality, symmetry, transitivity, units, dimensions, precision, or numerical method."
+      },
+      {
+        "id": "INV008-FOR-002",
+        "statement": "Do not promote documentary, deferred, provisionally separated, or rejected source metadata to executable scientific status."
+      },
+      {
+        "id": "INV008-FOR-003",
+        "statement": "Do not mutate inputs, scientific state, external domain state, or publish a partial successful result."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "INV008-DEF-001",
+        "statement": "Scientific evaluation requires a future externally sourced evaluator; this package defines no evaluator interface or truth criterion."
+      },
+      {
+        "id": "INV008-DEF-002",
+        "statement": "The meanings of TLC-UT-INVARIANTS-001, TLC-UT-INVARIANTS-002, TLC-UT-INVARIANTS-003, TLC-UT-INVARIANTS-004, TLC-UT-INVARIANTS-005, TLC-UT-INVARIANTS-006, TLC-UT-INVARIANTS-007, TLC-UT-INVARIANTS-008, TLC-UT-INVARIANTS-010, TLC-UT-INVARIANTS-011, TLC-UT-INVARIANTS-012 remain preserved unresolved."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "ASSEMBLE-INVARIANT-STATE-VOCABULARY",
+      "purpose": "Construct the immutable InvariantStateVocabulary from validated source evidence without scientific evaluation.",
+      "inputs": [
+        {
+          "name": "evidence",
+          "semantic_role": "StateTermEvidence[]",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-04-INVARIANTS-008"
+            },
+            {
+              "name": "evidence_ids",
+              "required": true,
+              "semantic_role": "exact covered object and relation identities",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-INVARIANTS-001",
+                "TLC-SO-INVARIANTS-041",
+                "TLC-SO-INVARIANTS-050",
+                "TLC-SO-INVARIANTS-051",
+                "TLC-SO-INVARIANTS-052",
+                "TLC-SO-INVARIANTS-054",
+                "TLC-SO-INVARIANTS-059",
+                "TLC-SO-INVARIANTS-061",
+                "TLC-SO-INVARIANTS-063",
+                "TLC-SO-INVARIANTS-066",
+                "TLC-SO-INVARIANTS-067",
+                "TLC-SO-INVARIANTS-069",
+                "TLC-SR-INVARIANTS-001",
+                "TLC-SR-INVARIANTS-002",
+                "TLC-SR-INVARIANTS-003",
+                "TLC-SR-INVARIANTS-004",
+                "TLC-SR-INVARIANTS-005",
+                "TLC-SR-INVARIANTS-006",
+                "TLC-SR-INVARIANTS-007",
+                "TLC-SR-INVARIANTS-008",
+                "TLC-SR-INVARIANTS-009",
+                "TLC-SR-INVARIANTS-010",
+                "TLC-SR-INVARIANTS-011",
+                "TLC-SR-INVARIANTS-012",
+                "TLC-SR-INVARIANTS-013",
+                "TLC-SR-INVARIANTS-014",
+                "TLC-SR-INVARIANTS-015",
+                "TLC-SR-INVARIANTS-016",
+                "TLC-SR-INVARIANTS-017",
+                "TLC-SR-INVARIANTS-018",
+                "TLC-SR-INVARIANTS-019",
+                "TLC-SR-INVARIANTS-020",
+                "TLC-SR-INVARIANTS-021",
+                "TLC-SR-INVARIANTS-022",
+                "TLC-SR-INVARIANTS-023",
+                "TLC-SR-INVARIANTS-024",
+                "TLC-SR-INVARIANTS-025",
+                "TLC-SR-INVARIANTS-026",
+                "TLC-SR-INVARIANTS-027",
+                "TLC-SR-INVARIANTS-028",
+                "TLC-SR-INVARIANTS-029",
+                "TLC-SR-INVARIANTS-030",
+                "TLC-SR-INVARIANTS-031",
+                "TLC-SR-INVARIANTS-032",
+                "TLC-SR-INVARIANTS-033",
+                "TLC-SR-INVARIANTS-034",
+                "TLC-SR-INVARIANTS-035",
+                "TLC-SR-INVARIANTS-036",
+                "TLC-SR-INVARIANTS-037",
+                "TLC-SR-INVARIANTS-038",
+                "TLC-SR-INVARIANTS-039",
+                "TLC-SR-INVARIANTS-040",
+                "TLC-SR-INVARIANTS-041",
+                "TLC-SR-INVARIANTS-042",
+                "TLC-SR-INVARIANTS-043",
+                "TLC-SR-INVARIANTS-044",
+                "TLC-SR-INVARIANTS-045",
+                "TLC-SR-INVARIANTS-046",
+                "TLC-SR-INVARIANTS-047",
+                "TLC-SR-INVARIANTS-048",
+                "TLC-SR-INVARIANTS-049",
+                "TLC-SR-INVARIANTS-050",
+                "TLC-SR-INVARIANTS-051",
+                "TLC-SR-INVARIANTS-052",
+                "TLC-SR-INVARIANTS-053",
+                "TLC-SR-INVARIANTS-054",
+                "TLC-SR-INVARIANTS-055",
+                "TLC-SR-INVARIANTS-056",
+                "TLC-SR-INVARIANTS-057",
+                "TLC-SR-INVARIANTS-058",
+                "TLC-SR-INVARIANTS-059",
+                "TLC-SR-INVARIANTS-060",
+                "TLC-SR-INVARIANTS-061",
+                "TLC-SR-INVARIANTS-062",
+                "TLC-SR-INVARIANTS-063",
+                "TLC-SR-INVARIANTS-064",
+                "TLC-SR-INVARIANTS-065",
+                "TLC-SR-INVARIANTS-066",
+                "TLC-SR-INVARIANTS-067",
+                "TLC-SR-INVARIANTS-068"
+              ]
+            },
+            {
+              "name": "source_references",
+              "required": true,
+              "semantic_role": "source provenance for every evidence item",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_values",
+              "required": true,
+              "semantic_role": "uninterpreted source statements and scientific truth conditions",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "catalogue_status",
+              "required": true,
+              "semantic_role": "exact historical catalogue status",
+              "constant": "deferred_for_targeted_extraction"
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact unresolved identifiers attached to affected evidence",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-UT-INVARIANTS-001",
+                "TLC-UT-INVARIANTS-002",
+                "TLC-UT-INVARIANTS-003",
+                "TLC-UT-INVARIANTS-004",
+                "TLC-UT-INVARIANTS-005",
+                "TLC-UT-INVARIANTS-006",
+                "TLC-UT-INVARIANTS-007",
+                "TLC-UT-INVARIANTS-008",
+                "TLC-UT-INVARIANTS-010",
+                "TLC-UT-INVARIANTS-011",
+                "TLC-UT-INVARIANTS-012"
+              ]
+            },
+            {
+              "name": "assumption_refs",
+              "required": true,
+              "semantic_role": "exact provisional engineering assumption identifiers",
+              "allowed_values": [
+                "TLC-EA-INVARIANTS-008-001"
+              ]
+            }
+          ],
+          "collection": {
+            "kind": "ordered_set",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-INVARIANTS-001",
+              "TLC-SO-INVARIANTS-041",
+              "TLC-SO-INVARIANTS-050",
+              "TLC-SO-INVARIANTS-051",
+              "TLC-SO-INVARIANTS-052",
+              "TLC-SO-INVARIANTS-054",
+              "TLC-SO-INVARIANTS-059",
+              "TLC-SO-INVARIANTS-061",
+              "TLC-SO-INVARIANTS-063",
+              "TLC-SO-INVARIANTS-066",
+              "TLC-SO-INVARIANTS-067",
+              "TLC-SO-INVARIANTS-069",
+              "TLC-SR-INVARIANTS-001",
+              "TLC-SR-INVARIANTS-002",
+              "TLC-SR-INVARIANTS-003",
+              "TLC-SR-INVARIANTS-004",
+              "TLC-SR-INVARIANTS-005",
+              "TLC-SR-INVARIANTS-006",
+              "TLC-SR-INVARIANTS-007",
+              "TLC-SR-INVARIANTS-008",
+              "TLC-SR-INVARIANTS-009",
+              "TLC-SR-INVARIANTS-010",
+              "TLC-SR-INVARIANTS-011",
+              "TLC-SR-INVARIANTS-012",
+              "TLC-SR-INVARIANTS-013",
+              "TLC-SR-INVARIANTS-014",
+              "TLC-SR-INVARIANTS-015",
+              "TLC-SR-INVARIANTS-016",
+              "TLC-SR-INVARIANTS-017",
+              "TLC-SR-INVARIANTS-018",
+              "TLC-SR-INVARIANTS-019",
+              "TLC-SR-INVARIANTS-020",
+              "TLC-SR-INVARIANTS-021",
+              "TLC-SR-INVARIANTS-022",
+              "TLC-SR-INVARIANTS-023",
+              "TLC-SR-INVARIANTS-024",
+              "TLC-SR-INVARIANTS-025",
+              "TLC-SR-INVARIANTS-026",
+              "TLC-SR-INVARIANTS-027",
+              "TLC-SR-INVARIANTS-028",
+              "TLC-SR-INVARIANTS-029",
+              "TLC-SR-INVARIANTS-030",
+              "TLC-SR-INVARIANTS-031",
+              "TLC-SR-INVARIANTS-032",
+              "TLC-SR-INVARIANTS-033",
+              "TLC-SR-INVARIANTS-034",
+              "TLC-SR-INVARIANTS-035",
+              "TLC-SR-INVARIANTS-036",
+              "TLC-SR-INVARIANTS-037",
+              "TLC-SR-INVARIANTS-038",
+              "TLC-SR-INVARIANTS-039",
+              "TLC-SR-INVARIANTS-040",
+              "TLC-SR-INVARIANTS-041",
+              "TLC-SR-INVARIANTS-042",
+              "TLC-SR-INVARIANTS-043",
+              "TLC-SR-INVARIANTS-044",
+              "TLC-SR-INVARIANTS-045",
+              "TLC-SR-INVARIANTS-046",
+              "TLC-SR-INVARIANTS-047",
+              "TLC-SR-INVARIANTS-048",
+              "TLC-SR-INVARIANTS-049",
+              "TLC-SR-INVARIANTS-050",
+              "TLC-SR-INVARIANTS-051",
+              "TLC-SR-INVARIANTS-052",
+              "TLC-SR-INVARIANTS-053",
+              "TLC-SR-INVARIANTS-054",
+              "TLC-SR-INVARIANTS-055",
+              "TLC-SR-INVARIANTS-056",
+              "TLC-SR-INVARIANTS-057",
+              "TLC-SR-INVARIANTS-058",
+              "TLC-SR-INVARIANTS-059",
+              "TLC-SR-INVARIANTS-060",
+              "TLC-SR-INVARIANTS-061",
+              "TLC-SR-INVARIANTS-062",
+              "TLC-SR-INVARIANTS-063",
+              "TLC-SR-INVARIANTS-064",
+              "TLC-SR-INVARIANTS-065",
+              "TLC-SR-INVARIANTS-066",
+              "TLC-SR-INVARIANTS-067",
+              "TLC-SR-INVARIANTS-068"
+            ],
+            "cardinality": {
+              "minimum": 80,
+              "maximum": 80
+            },
+            "ordering": "required",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV008-IN-001",
+              "statement": "Every supplied identity is feature-covered, unique where required, and accompanied by source provenance."
+            },
+            {
+              "id": "INV008-IN-002",
+              "statement": "Source-declared order is preserved; otherwise validated input order is retained only as engineering order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable InvariantStateVocabulary",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-04-INVARIANTS-008"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "feature-specific structural representation",
+              "constant": "InvariantStateVocabulary"
+            },
+            {
+              "name": "entries",
+              "required": true,
+              "semantic_role": "immutable evidence entries with exact identities and order",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "unresolved identifiers attached to affected entries",
+              "allowed_values": [
+                "TLC-UT-INVARIANTS-001",
+                "TLC-UT-INVARIANTS-002",
+                "TLC-UT-INVARIANTS-003",
+                "TLC-UT-INVARIANTS-004",
+                "TLC-UT-INVARIANTS-005",
+                "TLC-UT-INVARIANTS-006",
+                "TLC-UT-INVARIANTS-007",
+                "TLC-UT-INVARIANTS-008",
+                "TLC-UT-INVARIANTS-010",
+                "TLC-UT-INVARIANTS-011",
+                "TLC-UT-INVARIANTS-012"
+              ]
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete preservation envelope",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "preserved catalogue and scientific status",
+              "constant": "deferred_for_targeted_extraction"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV008-OUT-001",
+              "statement": "returns a vocabulary keyed by state-term IDs with unresolved IDs attached to affected terms"
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "INV008-PRE-001",
+          "statement": "Every required identity, relationship, source reference, opaque symbol, unresolved mapping, and status value is present and source-consistent."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "INV008-POST-001",
+          "statement": "returns a vocabulary keyed by state-term IDs with unresolved IDs attached to affected terms No scientific truth claim is added."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "INV008-INV-001",
+          "statement": "Covered identities, source order, references, opaque values, catalogue status, assumptions, reservations, and unresolved mappings are unchanged."
+        },
+        {
+          "id": "INV008-INV-002",
+          "statement": "Inputs and all external or scientific state remain unmodified."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate covered identities and required provenance",
+          "validate status, unresolved, assumption, and opaque preservation metadata",
+          "construct the feature-specific immutable representation",
+          "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate covered identities and required provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "validate status, unresolved, assumption, and opaque preservation metadata",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct the feature-specific immutable representation",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Validation and conservation must precede publication. The upstream total traversal sequence is not a unique architectural prescription."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "owned_result",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "result_lifetime",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "required",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "not_applicable",
+        "floating_point": "not_applicable",
+        "randomness": "forbidden"
+      },
+      "error_contract": [
+        {
+          "code": "UnknownStateTermId",
+          "category": "invalid_input",
+          "condition": "A state-term identity is outside source coverage.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "DuplicateIdentifier",
+          "category": "invalid_input",
+          "condition": "A feature-owned identifier is duplicated.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnresolvedMappingLoss",
+          "category": "preservation",
+          "condition": "A required unresolved identifier is missing from its output attachment.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "invalid_input",
+          "condition": "Required source provenance is absent.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificEvaluationProhibited",
+          "category": "unsupported_operation",
+          "condition": "Truth, numeric, temporal, ordering, state, transition, or other scientific evaluation is requested without a sourced evaluator.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "PreservationViolation",
+          "category": "preservation",
+          "condition": "A source identity, order, opaque value, status, assumption, reservation, unresolved mapping, or provenance link changes or is lost.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-construction",
+      "status": "required",
+      "statement": "Expose assemble_invariant_state_vocabulary as a deterministic structural operation producing InvariantStateVocabulary."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not decide truth, compute numerical values, detect states, or infer transitions."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal representation and validation decomposition remain free when observable preservation behavior is identical."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "INV008-GINV-001",
+      "statement": "No implementation behavior may weaken source identity, order, opacity, status, unresolved, assumption, reservation, immutability, or provenance obligations."
+    },
+    {
+      "id": "INV008-GINV-002",
+      "statement": "Historical rejection or deferral metadata is documentary and must remain visible without suppressing this finalized structural operation."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific and evidence references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered identifier collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted source statements and scientific truth conditions"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral structural errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable preservation result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is structural and behavioral. It does not prescribe a programming language, serialization, storage model, or complete internal step order."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-008/manifest.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-008/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-04-INVARIANTS-008",
+  "title": "Invariant state vocabulary",
+  "domain": "invariants",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-008/traceability.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-008/traceability.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-008",
+  "scientific_sources": [
+    {
+      "path": "maths/04-invariants.md",
+      "role": "Authoritative scientific source sections cited by the limited engineering contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-008/contract.yaml",
+      "role": "Defines covered evidence, exact structural behavior, reservations, and scientific boundary.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "e3d7b0dd7df6e9ff2a7c6fa0aed9a7f7b8a75c23"
+      }
+    },
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-008/traceability.yaml",
+      "role": "Preserves detailed contract-to-source traceability.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "2563f963c849b5ea7084c78f7603a3197b0c59bb"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-008/ir.prototype.json",
+      "role": "Prototype IR with reservations and operation-specific interface.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "d5b078e927e4ec78a59ad55178b20bbd2d363bdd"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-008/ir.yaml",
+      "role": "Selected finalized IR defining immutable structural behavior and stable errors.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "00c1afc555fb1f79f37bacf5e05c9528e7b5aec8"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/invariants/TLC-FC-04-INVARIANTS-008/algorithm.yaml",
+      "role": "Applicable validation, construction, conservation, and error branches; total ordering is not adopted beyond observable requirements.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "432c0ba5f9324f80df99fa6f00e08e29fd6514e6"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-008/test-plan.yaml",
+      "role": "Source structural test plan and reservation-preservation scenarios.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "ac5d3a899ed45d4046ab1064f9158313d35b9af2"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/invariants/TLC-FC-04-INVARIANTS-008/oracle.yaml",
+      "role": "Authoritative nominal, error, opacity, ordering, determinism, and conformance expectations.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "1164a8eb2fd5cd33bc98591f2bb2f1e5ed1f54ee"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/invariants/feature-status.yaml",
+      "role": "Authoritative ten-feature inventory and historical status interpretation."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/module-specification.yaml",
+      "role": "Defines public operations, common structural rules, error vocabulary, dependencies, and scientific boundary."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/implementation-tasks.yaml",
+      "role": "Defines feature deliverables and acceptance obligations."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/patterns.yaml",
+      "role": "Records domain-local common patterns without creating shared handoff contracts."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-009/README.md
+++ b/handoff/features/TLC-FC-04-INVARIANTS-009/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-04-INVARIANTS-009 — Cohesion interval symbolic constraint
+
+This package defines the final structural handoff for Cohesion interval symbolic constraint.
+
+## What must be implemented
+
+Implement `construct_cohesion_interval_constraint` as a deterministic, immutable evidence transformation. It validates feature-covered identities and source references, preserves opaque content and historical catalogue status, and returns a `SymbolicCohesionIntervalConstraint` with complete provenance.
+
+## Valid inputs and required output
+
+The accepted covered evidence identities are: TLC-SO-INVARIANTS-065, TLC-SR-INVARIANTS-064. The required catalogue status is `rejected_as_feature`. Required unresolved identifiers are: TLC-UT-INVARIANTS-009. Required provisional assumptions are: TLC-EA-INVARIANTS-009-001.
+
+The required output is an immutable `SymbolicCohesionIntervalConstraint`. produces interval membership, below-bound fragmentation annotation, and above-bound centralization-and-rigidity annotation ASTs with TLC-UT-INVARIANTS-009 preserved
+
+## Mandatory and forbidden behavior
+
+Identity, source order, provenance, opaque values, status, assumptions, reservations, unresolved mappings, input immutability, deterministic structural equality, and failure atomicity are mandatory. Scientific truth evaluation, status promotion, inferred thresholds or comparators, transition graphs, chronology, causality, symmetry, transitivity, dimensions, units, precision, and numerical methods are forbidden.
+
+## Implementation freedom
+
+Language, public wrapper naming, storage, allocation, ownership mechanism, serialization, concurrency policy, error transport, and internal traversal remain free when observable behavior is unchanged.
+
+## Errors and conformance
+
+The authoritative observable error codes are: MissingIntervalSymbol, MissingCohesionReservation, MissingCohesionEvidence, ScientificEvaluationProhibited, PreservationViolation. Errors publish no partial result. Conformance requires every test in `acceptance.json`, exact preservation of the source envelope, and rejection of scientific evaluation. Unresolved scientific identifiers remain attached to their affected evidence and must never be resolved implicitly.

--- a/handoff/features/TLC-FC-04-INVARIANTS-009/acceptance.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-009/acceptance.json
@@ -1,0 +1,202 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-009",
+  "tests": [
+    {
+      "test_id": "INV009-ACCEPT-NOMINAL",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-04-INVARIANTS-009",
+        "covered_evidence_ids": [
+          "TLC-SO-INVARIANTS-065",
+          "TLC-SR-INVARIANTS-064"
+        ],
+        "catalogue_status": "rejected_as_feature",
+        "unresolved_refs": [
+          "TLC-UT-INVARIANTS-009"
+        ]
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "accepted": true,
+        "output_type": "SymbolicCohesionIntervalConstraint",
+        "immutable": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV009-ACCEPT-SHAPE",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV009-ACCEPT-SHAPE"
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV009-ACCEPT-MISSING-SYMBOL",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV009-ACCEPT-MISSING-SYMBOL"
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV009-ACCEPT-MISSING-EVIDENCE",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV009-ACCEPT-MISSING-EVIDENCE"
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV009-ACCEPT-MISSING-UNRESOLVED",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV009-ACCEPT-MISSING-UNRESOLVED"
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV009-ACCEPT-OPAQUE",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV009-ACCEPT-OPAQUE"
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV009-ACCEPT-EQUAL-BOUND-IDS",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV009-ACCEPT-EQUAL-BOUND-IDS"
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV009-ACCEPT-NO-EVALUATION",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "unsupported_operation",
+      "given": {
+        "authoritative_oracle_scenario": "INV009-ACCEPT-NO-EVALUATION"
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV009-ACCEPT-DETERMINISM",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "determinism",
+      "given": {
+        "authoritative_oracle_scenario": "INV009-ACCEPT-DETERMINISM"
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV009-ACCEPT-STATUS",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV009-ACCEPT-STATUS"
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV009-ACCEPT-CONFORMANCE",
+      "applies_to": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV009-ACCEPT-CONFORMANCE"
+      },
+      "when": "The construct_cohesion_interval_constraint oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-009/contract.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-009/contract.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-04-INVARIANTS-009",
+    "title": "Cohesion interval symbolic constraint",
+    "domain": "invariants"
+  },
+  "purpose": "Validate source-backed cohesion interval symbolic constraint evidence and produces interval membership, below-bound fragmentation annotation, and above-bound centralization-and-rigidity annotation ASTs with TLC-UT-INVARIANTS-009 preserved Scientific truth evaluation is not performed.",
+  "scope": {
+    "required": [
+      {
+        "id": "INV009-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-04-INVARIANTS-009 and covered evidence identifiers [TLC-SO-INVARIANTS-065, TLC-SR-INVARIANTS-064].",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-009/contract.yaml",
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-009/ir.yaml"
+        ]
+      },
+      {
+        "id": "INV009-REQ-002",
+        "statement": "Preserve catalogue status rejected_as_feature, source order, provenance, opaque values, unresolved identifiers [TLC-UT-INVARIANTS-009], and assumptions [TLC-EA-INVARIANTS-009-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-009/contract.yaml",
+          "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml"
+        ]
+      },
+      {
+        "id": "INV009-REQ-003",
+        "statement": "Emit an immutable SymbolicCohesionIntervalConstraint with a complete preservation envelope.",
+        "basis": [
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-009/ir.yaml",
+          "registry/domain-finalization/invariants/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "INV009-FOR-001",
+        "statement": "Do not evaluate scientific truth or infer a comparator, threshold value, runtime domain, transition graph, chronology, causality, symmetry, transitivity, units, dimensions, precision, or numerical method."
+      },
+      {
+        "id": "INV009-FOR-002",
+        "statement": "Do not promote documentary, deferred, provisionally separated, or rejected source metadata to executable scientific status."
+      },
+      {
+        "id": "INV009-FOR-003",
+        "statement": "Do not mutate inputs, scientific state, external domain state, or publish a partial successful result."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "INV009-DEF-001",
+        "statement": "Scientific evaluation requires a future externally sourced evaluator; this package defines no evaluator interface or truth criterion."
+      },
+      {
+        "id": "INV009-DEF-002",
+        "statement": "The meanings of TLC-UT-INVARIANTS-009 remain preserved unresolved."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "CONSTRUCT-COHESION-INTERVAL-CONSTRAINT",
+      "purpose": "Construct the immutable SymbolicCohesionIntervalConstraint from validated source evidence without scientific evaluation.",
+      "inputs": [
+        {
+          "name": "evidence",
+          "semantic_role": "CohesionIntervalSymbols",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-04-INVARIANTS-009"
+            },
+            {
+              "name": "evidence_ids",
+              "required": true,
+              "semantic_role": "exact covered object and relation identities",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-INVARIANTS-065",
+                "TLC-SR-INVARIANTS-064"
+              ]
+            },
+            {
+              "name": "source_references",
+              "required": true,
+              "semantic_role": "source provenance for every evidence item",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_values",
+              "required": true,
+              "semantic_role": "uninterpreted source statements and scientific truth conditions",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "catalogue_status",
+              "required": true,
+              "semantic_role": "exact historical catalogue status",
+              "constant": "rejected_as_feature"
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact unresolved identifiers attached to affected evidence",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": [
+                "TLC-UT-INVARIANTS-009"
+              ]
+            },
+            {
+              "name": "assumption_refs",
+              "required": true,
+              "semantic_role": "exact provisional engineering assumption identifiers",
+              "allowed_values": [
+                "TLC-EA-INVARIANTS-009-001"
+              ]
+            }
+          ],
+          "collection": {
+            "kind": "ordered_set",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-INVARIANTS-065",
+              "TLC-SR-INVARIANTS-064"
+            ],
+            "cardinality": {
+              "minimum": 2,
+              "maximum": 2
+            },
+            "ordering": "required",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV009-IN-001",
+              "statement": "Every supplied identity is feature-covered, unique where required, and accompanied by source provenance."
+            },
+            {
+              "id": "INV009-IN-002",
+              "statement": "Source-declared order is preserved; otherwise validated input order is retained only as engineering order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable SymbolicCohesionIntervalConstraint",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-04-INVARIANTS-009"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "feature-specific structural representation",
+              "constant": "SymbolicCohesionIntervalConstraint"
+            },
+            {
+              "name": "entries",
+              "required": true,
+              "semantic_role": "immutable evidence entries with exact identities and order",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "unresolved identifiers attached to affected entries",
+              "allowed_values": [
+                "TLC-UT-INVARIANTS-009"
+              ]
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete preservation envelope",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "preserved catalogue and scientific status",
+              "constant": "rejected_as_feature"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV009-OUT-001",
+              "statement": "produces interval membership, below-bound fragmentation annotation, and above-bound centralization-and-rigidity annotation ASTs with TLC-UT-INVARIANTS-009 preserved"
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "INV009-PRE-001",
+          "statement": "Every required identity, relationship, source reference, opaque symbol, unresolved mapping, and status value is present and source-consistent."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "INV009-POST-001",
+          "statement": "produces interval membership, below-bound fragmentation annotation, and above-bound centralization-and-rigidity annotation ASTs with TLC-UT-INVARIANTS-009 preserved No scientific truth claim is added."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "INV009-INV-001",
+          "statement": "Covered identities, source order, references, opaque values, catalogue status, assumptions, reservations, and unresolved mappings are unchanged."
+        },
+        {
+          "id": "INV009-INV-002",
+          "statement": "Inputs and all external or scientific state remain unmodified."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate covered identities and required provenance",
+          "validate status, unresolved, assumption, and opaque preservation metadata",
+          "construct the feature-specific immutable representation",
+          "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate covered identities and required provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "validate status, unresolved, assumption, and opaque preservation metadata",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct the feature-specific immutable representation",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Validation and conservation must precede publication. The upstream total traversal sequence is not a unique architectural prescription."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "owned_result",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "result_lifetime",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "required",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "not_applicable",
+        "floating_point": "not_applicable",
+        "randomness": "forbidden"
+      },
+      "error_contract": [
+        {
+          "code": "MissingIntervalSymbol",
+          "category": "invalid_input",
+          "condition": "The authoritative MissingIntervalSymbol condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingCohesionReservation",
+          "category": "invalid_input",
+          "condition": "The authoritative MissingCohesionReservation condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingCohesionEvidence",
+          "category": "invalid_input",
+          "condition": "The authoritative MissingCohesionEvidence condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificEvaluationProhibited",
+          "category": "unsupported_operation",
+          "condition": "Truth, numeric, temporal, ordering, state, transition, or other scientific evaluation is requested without a sourced evaluator.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "PreservationViolation",
+          "category": "preservation",
+          "condition": "A source identity, order, opaque value, status, assumption, reservation, unresolved mapping, or provenance link changes or is lost.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-construction",
+      "status": "required",
+      "statement": "Expose construct_cohesion_interval_constraint as a deterministic structural operation producing SymbolicCohesionIntervalConstraint."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not decide truth, compute numerical values, detect states, or infer transitions."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal representation and validation decomposition remain free when observable preservation behavior is identical."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "INV009-GINV-001",
+      "statement": "No implementation behavior may weaken source identity, order, opacity, status, unresolved, assumption, reservation, immutability, or provenance obligations."
+    },
+    {
+      "id": "INV009-GINV-002",
+      "statement": "Historical rejection or deferral metadata is documentary and must remain visible without suppressing this finalized structural operation."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific and evidence references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered identifier collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted source statements and scientific truth conditions"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral structural errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable preservation result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is structural and behavioral. It does not prescribe a programming language, serialization, storage model, or complete internal step order."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-009/manifest.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-009/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-04-INVARIANTS-009",
+  "title": "Cohesion interval symbolic constraint",
+  "domain": "invariants",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-009/traceability.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-009/traceability.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-009",
+  "scientific_sources": [
+    {
+      "path": "maths/04-invariants.md",
+      "role": "Authoritative scientific source sections cited by the limited engineering contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-009/contract.yaml",
+      "role": "Defines covered evidence, exact structural behavior, reservations, and scientific boundary.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "2145b86c91c126ef783c21b1343b31247751f46c"
+      }
+    },
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-009/traceability.yaml",
+      "role": "Preserves detailed contract-to-source traceability.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "6506dd419d995ab29bf2fe1a7e9296a9668c285c"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-009/ir.prototype.json",
+      "role": "Prototype IR with reservations and operation-specific interface.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "2e2a1eb76be3f3bdc63d7fd9793ebb33378a0a3a"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-009/ir.yaml",
+      "role": "Selected finalized IR defining immutable structural behavior and stable errors.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "38db538c209c3893099ef02d53ed14c1ec04e612"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/invariants/TLC-FC-04-INVARIANTS-009/algorithm.yaml",
+      "role": "Applicable validation, construction, conservation, and error branches; total ordering is not adopted beyond observable requirements.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "cbc42a8be1d6f1d55b6d1836ca35c82a8a13d186"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-009/test-plan.yaml",
+      "role": "Source structural test plan and reservation-preservation scenarios.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "e3973a4a906d957f474722be37e496b0d0c99260"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/invariants/TLC-FC-04-INVARIANTS-009/oracle.yaml",
+      "role": "Authoritative nominal, error, opacity, ordering, determinism, and conformance expectations.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "ac81367c4184e7b7e061b66abeef57067b03c91d"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/invariants/feature-status.yaml",
+      "role": "Authoritative ten-feature inventory and historical status interpretation."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/module-specification.yaml",
+      "role": "Defines public operations, common structural rules, error vocabulary, dependencies, and scientific boundary."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/implementation-tasks.yaml",
+      "role": "Defines feature deliverables and acceptance obligations."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/patterns.yaml",
+      "role": "Records domain-local common patterns without creating shared handoff contracts."
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-010/README.md
+++ b/handoff/features/TLC-FC-04-INVARIANTS-010/README.md
@@ -1,0 +1,25 @@
+# TLC-FC-04-INVARIANTS-010 — State interpretation fragment index
+
+This package defines the final structural handoff for State interpretation fragment index.
+
+## What must be implemented
+
+Implement `index_state_interpretation_fragments` as a deterministic, immutable evidence transformation. It validates feature-covered identities and source references, preserves opaque content and historical catalogue status, and returns a `RejectedStateAnnotationIndex` with complete provenance.
+
+## Valid inputs and required output
+
+The accepted covered evidence identities are: TLC-SO-INVARIANTS-021, TLC-SO-INVARIANTS-026, TLC-SO-INVARIANTS-039, TLC-SR-INVARIANTS-020, TLC-SR-INVARIANTS-025, TLC-SR-INVARIANTS-038. The required catalogue status is `rejected_as_feature`. Required unresolved identifiers are: none. Required provisional assumptions are: TLC-EA-INVARIANTS-010-001.
+
+The required output is an immutable `RejectedStateAnnotationIndex`. returns an index containing exactly the three source IDs, each marked non-operational and rejected
+
+## Mandatory and forbidden behavior
+
+Identity, source order, provenance, opaque values, status, assumptions, reservations, unresolved mappings, input immutability, deterministic structural equality, and failure atomicity are mandatory. Scientific truth evaluation, status promotion, inferred thresholds or comparators, transition graphs, chronology, causality, symmetry, transitivity, dimensions, units, precision, and numerical methods are forbidden.
+
+## Implementation freedom
+
+Language, public wrapper naming, storage, allocation, ownership mechanism, serialization, concurrency policy, error transport, and internal traversal remain free when observable behavior is unchanged.
+
+## Errors and conformance
+
+The authoritative observable error codes are: DuplicateStateFragmentId, InvalidCoveredIdentifier, MissingSourceReference, OperationalStatePromotion, ScientificEvaluationProhibited, PreservationViolation. Errors publish no partial result. Conformance requires every test in `acceptance.json`, exact preservation of the source envelope, and rejection of scientific evaluation. Scientific truth conditions remain opaque and require future externally sourced evaluation semantics.

--- a/handoff/features/TLC-FC-04-INVARIANTS-010/acceptance.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-010/acceptance.json
@@ -1,0 +1,187 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-010",
+  "tests": [
+    {
+      "test_id": "INV010-ACCEPT-NOMINAL",
+      "applies_to": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "category": "valid_input",
+      "given": {
+        "feature_id": "TLC-FC-04-INVARIANTS-010",
+        "covered_evidence_ids": [
+          "TLC-SO-INVARIANTS-021",
+          "TLC-SO-INVARIANTS-026",
+          "TLC-SO-INVARIANTS-039",
+          "TLC-SR-INVARIANTS-020",
+          "TLC-SR-INVARIANTS-025",
+          "TLC-SR-INVARIANTS-038"
+        ],
+        "catalogue_status": "rejected_as_feature",
+        "unresolved_refs": []
+      },
+      "when": "The index_state_interpretation_fragments oracle scenario is exercised.",
+      "expect": {
+        "accepted": true,
+        "output_type": "RejectedStateAnnotationIndex",
+        "immutable": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV010-ACCEPT-DUPLICATE",
+      "applies_to": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV010-ACCEPT-DUPLICATE"
+      },
+      "when": "The index_state_interpretation_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV010-ACCEPT-UNKNOWN",
+      "applies_to": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV010-ACCEPT-UNKNOWN"
+      },
+      "when": "The index_state_interpretation_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV010-ACCEPT-SOURCE",
+      "applies_to": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "category": "error",
+      "given": {
+        "authoritative_oracle_scenario": "INV010-ACCEPT-SOURCE"
+      },
+      "when": "The index_state_interpretation_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV010-ACCEPT-PROMOTION",
+      "applies_to": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV010-ACCEPT-PROMOTION"
+      },
+      "when": "The index_state_interpretation_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV010-ACCEPT-OPAQUE",
+      "applies_to": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV010-ACCEPT-OPAQUE"
+      },
+      "when": "The index_state_interpretation_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV010-ACCEPT-NO-STATE-SEMANTICS",
+      "applies_to": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV010-ACCEPT-NO-STATE-SEMANTICS"
+      },
+      "when": "The index_state_interpretation_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV010-ACCEPT-DETERMINISM",
+      "applies_to": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "category": "determinism",
+      "given": {
+        "authoritative_oracle_scenario": "INV010-ACCEPT-DETERMINISM"
+      },
+      "when": "The index_state_interpretation_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV010-ACCEPT-STATUS",
+      "applies_to": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV010-ACCEPT-STATUS"
+      },
+      "when": "The index_state_interpretation_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "INV010-ACCEPT-CONFORMANCE",
+      "applies_to": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "category": "preservation",
+      "given": {
+        "authoritative_oracle_scenario": "INV010-ACCEPT-CONFORMANCE"
+      },
+      "when": "The index_state_interpretation_fragments oracle scenario is exercised.",
+      "expect": {
+        "oracle_condition_preserved": true,
+        "no_partial_result_on_error": true,
+        "no_scientific_evaluation": true
+      },
+      "source_basis": [
+        "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-010/contract.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-010/contract.json
@@ -1,0 +1,464 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-04-INVARIANTS-010",
+    "title": "State interpretation fragment index",
+    "domain": "invariants"
+  },
+  "purpose": "Validate source-backed state interpretation fragment index evidence and returns an index containing exactly the three source IDs, each marked non-operational and rejected Scientific truth evaluation is not performed.",
+  "scope": {
+    "required": [
+      {
+        "id": "INV010-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-04-INVARIANTS-010 and covered evidence identifiers [TLC-SO-INVARIANTS-021, TLC-SO-INVARIANTS-026, TLC-SO-INVARIANTS-039, TLC-SR-INVARIANTS-020, TLC-SR-INVARIANTS-025, TLC-SR-INVARIANTS-038].",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-010/contract.yaml",
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-010/ir.yaml"
+        ]
+      },
+      {
+        "id": "INV010-REQ-002",
+        "statement": "Preserve catalogue status rejected_as_feature, source order, provenance, opaque values, unresolved identifiers [], and assumptions [TLC-EA-INVARIANTS-010-001] exactly.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-04-INVARIANTS-010/contract.yaml",
+          "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml"
+        ]
+      },
+      {
+        "id": "INV010-REQ-003",
+        "statement": "Emit an immutable RejectedStateAnnotationIndex with a complete preservation envelope.",
+        "basis": [
+          "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-010/ir.yaml",
+          "registry/domain-finalization/invariants/module-specification.yaml"
+        ]
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "INV010-FOR-001",
+        "statement": "Do not evaluate scientific truth or infer a comparator, threshold value, runtime domain, transition graph, chronology, causality, symmetry, transitivity, units, dimensions, precision, or numerical method."
+      },
+      {
+        "id": "INV010-FOR-002",
+        "statement": "Do not promote documentary, deferred, provisionally separated, or rejected source metadata to executable scientific status."
+      },
+      {
+        "id": "INV010-FOR-003",
+        "statement": "Do not mutate inputs, scientific state, external domain state, or publish a partial successful result."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "INV010-DEF-001",
+        "statement": "Scientific evaluation requires a future externally sourced evaluator; this package defines no evaluator interface or truth criterion."
+      },
+      {
+        "id": "INV010-DEF-002",
+        "statement": "Opaque scientific truth conditions remain external and uninterpreted."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "INDEX-STATE-INTERPRETATION-FRAGMENTS",
+      "purpose": "Construct the immutable RejectedStateAnnotationIndex from validated source evidence without scientific evaluation.",
+      "inputs": [
+        {
+          "name": "evidence",
+          "semantic_role": "StateInterpretationFragment[]",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+              "constant": "TLC-FC-04-INVARIANTS-010"
+            },
+            {
+              "name": "evidence_ids",
+              "required": true,
+              "semantic_role": "exact covered object and relation identities",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+              "allowed_values": [
+                "TLC-SO-INVARIANTS-021",
+                "TLC-SO-INVARIANTS-026",
+                "TLC-SO-INVARIANTS-039",
+                "TLC-SR-INVARIANTS-020",
+                "TLC-SR-INVARIANTS-025",
+                "TLC-SR-INVARIANTS-038"
+              ]
+            },
+            {
+              "name": "source_references",
+              "required": true,
+              "semantic_role": "source provenance for every evidence item",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "opaque_values",
+              "required": true,
+              "semantic_role": "uninterpreted source statements and scientific truth conditions",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "catalogue_status",
+              "required": true,
+              "semantic_role": "exact historical catalogue status",
+              "constant": "rejected_as_feature"
+            },
+            {
+              "name": "unresolved_refs",
+              "required": true,
+              "semantic_role": "exact unresolved identifiers attached to affected evidence",
+              "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+              "allowed_values": []
+            },
+            {
+              "name": "assumption_refs",
+              "required": true,
+              "semantic_role": "exact provisional engineering assumption identifiers",
+              "allowed_values": [
+                "TLC-EA-INVARIANTS-010-001"
+              ]
+            }
+          ],
+          "collection": {
+            "kind": "ordered_set",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-INVARIANTS-021",
+              "TLC-SO-INVARIANTS-026",
+              "TLC-SO-INVARIANTS-039",
+              "TLC-SR-INVARIANTS-020",
+              "TLC-SR-INVARIANTS-025",
+              "TLC-SR-INVARIANTS-038"
+            ],
+            "cardinality": {
+              "minimum": 6,
+              "maximum": 6
+            },
+            "ordering": "required",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV010-IN-001",
+              "statement": "Every supplied identity is feature-covered, unique where required, and accompanied by source provenance."
+            },
+            {
+              "id": "INV010-IN-002",
+              "statement": "Source-declared order is preserved; otherwise validated input order is retained only as engineering order."
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "semantic_role": "immutable RejectedStateAnnotationIndex",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "feature_id",
+              "required": true,
+              "semantic_role": "exact feature identity",
+              "constant": "TLC-FC-04-INVARIANTS-010"
+            },
+            {
+              "name": "representation",
+              "required": true,
+              "semantic_role": "feature-specific structural representation",
+              "constant": "RejectedStateAnnotationIndex"
+            },
+            {
+              "name": "entries",
+              "required": true,
+              "semantic_role": "immutable evidence entries with exact identities and order",
+              "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0"
+            },
+            {
+              "name": "unresolved",
+              "required": true,
+              "semantic_role": "unresolved identifiers attached to affected entries",
+              "allowed_values": []
+            },
+            {
+              "name": "provenance",
+              "required": true,
+              "semantic_role": "complete preservation envelope",
+              "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0"
+            },
+            {
+              "name": "status",
+              "required": true,
+              "semantic_role": "preserved catalogue and scientific status",
+              "constant": "rejected_as_feature"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          },
+          "constraints": [
+            {
+              "id": "INV010-OUT-001",
+              "statement": "returns an index containing exactly the three source IDs, each marked non-operational and rejected"
+            }
+          ]
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "INV010-PRE-001",
+          "statement": "Every required identity, relationship, source reference, opaque symbol, unresolved mapping, and status value is present and source-consistent."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "INV010-POST-001",
+          "statement": "returns an index containing exactly the three source IDs, each marked non-operational and rejected No scientific truth claim is added."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "INV010-INV-001",
+          "statement": "Covered identities, source order, references, opaque values, catalogue status, assumptions, reservations, and unresolved mappings are unchanged."
+        },
+        {
+          "id": "INV010-INV-002",
+          "statement": "Inputs and all external or scientific state remain unmodified."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate covered identities and required provenance",
+          "validate status, unresolved, assumption, and opaque preservation metadata",
+          "construct the feature-specific immutable representation",
+          "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+          "publish success or stable error"
+        ],
+        "partial_order": [
+          {
+            "before": "validate covered identities and required provenance",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "validate status, unresolved, assumption, and opaque preservation metadata",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "construct the feature-specific immutable representation",
+            "after": "publish success or stable error"
+          },
+          {
+            "before": "verify identity, order, provenance, status, unresolved, assumption, reservation, and opaque-value conservation",
+            "after": "publish success or stable error"
+          }
+        ],
+        "prescription_basis": [
+          "Validation and conservation must precede publication. The upstream total traversal sequence is not a unique architectural prescription."
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "owned_result",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "result_lifetime",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "required",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_specified",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "not_applicable",
+        "floating_point": "not_applicable",
+        "randomness": "forbidden"
+      },
+      "error_contract": [
+        {
+          "code": "DuplicateStateFragmentId",
+          "category": "invalid_input",
+          "condition": "The authoritative DuplicateStateFragmentId condition occurs.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "InvalidCoveredIdentifier",
+          "category": "invalid_input",
+          "condition": "An evidence identifier is outside feature coverage.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "invalid_input",
+          "condition": "Required source provenance is absent.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "OperationalStatePromotion",
+          "category": "preservation",
+          "condition": "A documentary state annotation is promoted to operational state semantics.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificEvaluationProhibited",
+          "category": "unsupported_operation",
+          "condition": "Truth, numeric, temporal, ordering, state, transition, or other scientific evaluation is requested without a sourced evaluator.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "PreservationViolation",
+          "category": "preservation",
+          "condition": "A source identity, order, opaque value, status, assumption, reservation, unresolved mapping, or provenance link changes or is lost.",
+          "recoverability": "non_retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "not_specified",
+          "value": null
+        },
+        "auxiliary_memory": {
+          "status": "not_specified",
+          "value": null
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-construction",
+      "status": "required",
+      "statement": "Expose index_state_interpretation_fragments as a deterministic structural operation producing RejectedStateAnnotationIndex."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not decide truth, compute numerical values, detect states, or infer transitions."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal representation and validation decomposition remain free when observable preservation behavior is identical."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "INV010-GINV-001",
+      "statement": "No implementation behavior may weaken source identity, order, opacity, status, unresolved, assumption, reservation, immutability, or provenance obligations."
+    },
+    {
+      "id": "INV010-GINV-002",
+      "statement": "Historical rejection or deferral metadata is documentary and must remain visible without suppressing this finalized structural operation."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless scientific and evidence references"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered identifier collections"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Preserved unresolved identifiers"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted source statements and scientific truth conditions"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral structural errors"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable provenance"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Immutable preservation result envelope"
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance is structural and behavioral. It does not prescribe a programming language, serialization, storage model, or complete internal step order."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-010/manifest.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-010/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-04-INVARIANTS-010",
+  "title": "State interpretation fragment index",
+  "domain": "invariants",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "external_provider_required",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-04-INVARIANTS-010/traceability.json
+++ b/handoff/features/TLC-FC-04-INVARIANTS-010/traceability.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-04-INVARIANTS-010",
+  "scientific_sources": [
+    {
+      "path": "maths/04-invariants.md",
+      "role": "Authoritative scientific source sections cited by the limited engineering contract."
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-010/contract.yaml",
+      "role": "Defines covered evidence, exact structural behavior, reservations, and scientific boundary.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "9adb2c9049d36f4c6f21dd8c473d2d2aac1d4a69"
+      }
+    },
+    {
+      "path": "registry/math-contracts/TLC-FC-04-INVARIANTS-010/traceability.yaml",
+      "role": "Preserves detailed contract-to-source traceability.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "f28239fa7b70a63cfe5dd16f0dbb7ebf99925636"
+      }
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-010/ir.prototype.json",
+      "role": "Prototype IR with reservations and operation-specific interface.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "e8a9140d7c128cd60f319d6d99a7b1db462575b9"
+      }
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/invariants/TLC-FC-04-INVARIANTS-010/ir.yaml",
+      "role": "Selected finalized IR defining immutable structural behavior and stable errors.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "1b00f382fc11191de45138ddfc333c52c1f6d02e"
+      }
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/invariants/TLC-FC-04-INVARIANTS-010/algorithm.yaml",
+      "role": "Applicable validation, construction, conservation, and error branches; total ordering is not adopted beyond observable requirements.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "b7e07a0ed43c9f7aad333408b99f35e735f9146f"
+      }
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "ir/TLC-FC-04-INVARIANTS-010/test-plan.yaml",
+      "role": "Source structural test plan and reservation-preservation scenarios.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "8e593510ffd6e262865bf6372b909f09738b84ed"
+      }
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/invariants/TLC-FC-04-INVARIANTS-010/oracle.yaml",
+      "role": "Authoritative nominal, error, opacity, ordering, determinism, and conformance expectations.",
+      "fingerprint": {
+        "algorithm": "git_blob_sha1",
+        "value": "0eedceae2a7547fe337798d71156a0487066e89b"
+      }
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/invariants/feature-status.yaml",
+      "role": "Authoritative ten-feature inventory and historical status interpretation."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/module-specification.yaml",
+      "role": "Defines public operations, common structural rules, error vocabulary, dependencies, and scientific boundary."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/implementation-tasks.yaml",
+      "role": "Defines feature deliverables and acceptance obligations."
+    },
+    {
+      "path": "registry/domain-finalization/invariants/patterns.yaml",
+      "role": "Records domain-local common patterns without creating shared handoff contracts."
+    }
+  ]
+}

--- a/reports/handoff/invariants/ambiguities.json
+++ b/reports/handoff/invariants/ambiguities.json
@@ -1,0 +1,164 @@
+{
+  "schema_version": "1.0",
+  "domain": "invariants",
+  "items": [
+    {
+      "ambiguity_id": "INV-001-SCIENCE",
+      "feature_id": "TLC-FC-04-INVARIANTS-001",
+      "classification": "scientific_unresolved",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The structural operation is fully specified; scientific truth or numerical evaluation remains unavailable."
+    },
+    {
+      "ambiguity_id": "INV-002-SCIENCE",
+      "feature_id": "TLC-FC-04-INVARIANTS-002",
+      "classification": "scientific_unresolved",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The structural operation is fully specified; scientific truth or numerical evaluation remains unavailable."
+    },
+    {
+      "ambiguity_id": "INV-002-STATUS",
+      "feature_id": "TLC-FC-04-INVARIANTS-002",
+      "classification": "cross_feature_inconsistency",
+      "status": "preserved_documentary_metadata",
+      "identifiers": [],
+      "impact": "Historical catalogue status rejected_as_feature is preserved while domain finalization selects the feature's structural operation."
+    },
+    {
+      "ambiguity_id": "INV-003-SCIENCE",
+      "feature_id": "TLC-FC-04-INVARIANTS-003",
+      "classification": "scientific_unresolved",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The structural operation is fully specified; scientific truth or numerical evaluation remains unavailable."
+    },
+    {
+      "ambiguity_id": "INV-003-STATUS",
+      "feature_id": "TLC-FC-04-INVARIANTS-003",
+      "classification": "cross_feature_inconsistency",
+      "status": "preserved_documentary_metadata",
+      "identifiers": [],
+      "impact": "Historical catalogue status deferred_for_scientific_decision is preserved while domain finalization selects the feature's structural operation."
+    },
+    {
+      "ambiguity_id": "INV-004-SCIENCE",
+      "feature_id": "TLC-FC-04-INVARIANTS-004",
+      "classification": "scientific_unresolved",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The structural operation is fully specified; scientific truth or numerical evaluation remains unavailable."
+    },
+    {
+      "ambiguity_id": "INV-004-STATUS",
+      "feature_id": "TLC-FC-04-INVARIANTS-004",
+      "classification": "cross_feature_inconsistency",
+      "status": "preserved_documentary_metadata",
+      "identifiers": [],
+      "impact": "Historical catalogue status deferred_for_scientific_decision is preserved while domain finalization selects the feature's structural operation."
+    },
+    {
+      "ambiguity_id": "INV-005-SCIENCE",
+      "feature_id": "TLC-FC-04-INVARIANTS-005",
+      "classification": "scientific_unresolved",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The structural operation is fully specified; scientific truth or numerical evaluation remains unavailable."
+    },
+    {
+      "ambiguity_id": "INV-005-STATUS",
+      "feature_id": "TLC-FC-04-INVARIANTS-005",
+      "classification": "cross_feature_inconsistency",
+      "status": "preserved_documentary_metadata",
+      "identifiers": [],
+      "impact": "Historical catalogue status deferred_for_scientific_decision is preserved while domain finalization selects the feature's structural operation."
+    },
+    {
+      "ambiguity_id": "INV-006-SCIENCE",
+      "feature_id": "TLC-FC-04-INVARIANTS-006",
+      "classification": "scientific_unresolved",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The structural operation is fully specified; scientific truth or numerical evaluation remains unavailable."
+    },
+    {
+      "ambiguity_id": "INV-006-STATUS",
+      "feature_id": "TLC-FC-04-INVARIANTS-006",
+      "classification": "cross_feature_inconsistency",
+      "status": "preserved_documentary_metadata",
+      "identifiers": [],
+      "impact": "Historical catalogue status deferred_for_targeted_extraction is preserved while domain finalization selects the feature's structural operation."
+    },
+    {
+      "ambiguity_id": "INV-007-SCIENCE",
+      "feature_id": "TLC-FC-04-INVARIANTS-007",
+      "classification": "scientific_unresolved",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The structural operation is fully specified; scientific truth or numerical evaluation remains unavailable."
+    },
+    {
+      "ambiguity_id": "INV-008-SCIENCE",
+      "feature_id": "TLC-FC-04-INVARIANTS-008",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-UT-INVARIANTS-001",
+        "TLC-UT-INVARIANTS-002",
+        "TLC-UT-INVARIANTS-003",
+        "TLC-UT-INVARIANTS-004",
+        "TLC-UT-INVARIANTS-005",
+        "TLC-UT-INVARIANTS-006",
+        "TLC-UT-INVARIANTS-007",
+        "TLC-UT-INVARIANTS-008",
+        "TLC-UT-INVARIANTS-010",
+        "TLC-UT-INVARIANTS-011",
+        "TLC-UT-INVARIANTS-012"
+      ],
+      "impact": "The structural operation is fully specified; scientific truth or numerical evaluation remains unavailable."
+    },
+    {
+      "ambiguity_id": "INV-008-STATUS",
+      "feature_id": "TLC-FC-04-INVARIANTS-008",
+      "classification": "cross_feature_inconsistency",
+      "status": "preserved_documentary_metadata",
+      "identifiers": [],
+      "impact": "Historical catalogue status deferred_for_targeted_extraction is preserved while domain finalization selects the feature's structural operation."
+    },
+    {
+      "ambiguity_id": "INV-009-SCIENCE",
+      "feature_id": "TLC-FC-04-INVARIANTS-009",
+      "classification": "scientific_unresolved",
+      "status": "preserved_unresolved",
+      "identifiers": [
+        "TLC-UT-INVARIANTS-009"
+      ],
+      "impact": "The structural operation is fully specified; scientific truth or numerical evaluation remains unavailable."
+    },
+    {
+      "ambiguity_id": "INV-009-STATUS",
+      "feature_id": "TLC-FC-04-INVARIANTS-009",
+      "classification": "cross_feature_inconsistency",
+      "status": "preserved_documentary_metadata",
+      "identifiers": [],
+      "impact": "Historical catalogue status rejected_as_feature is preserved while domain finalization selects the feature's structural operation."
+    },
+    {
+      "ambiguity_id": "INV-010-SCIENCE",
+      "feature_id": "TLC-FC-04-INVARIANTS-010",
+      "classification": "scientific_unresolved",
+      "status": "external_provider_required",
+      "identifiers": [],
+      "impact": "The structural operation is fully specified; scientific truth or numerical evaluation remains unavailable."
+    },
+    {
+      "ambiguity_id": "INV-010-STATUS",
+      "feature_id": "TLC-FC-04-INVARIANTS-010",
+      "classification": "cross_feature_inconsistency",
+      "status": "preserved_documentary_metadata",
+      "identifiers": [],
+      "impact": "Historical catalogue status rejected_as_feature is preserved while domain finalization selects the feature's structural operation."
+    }
+  ]
+}

--- a/reports/handoff/invariants/generation-report.md
+++ b/reports/handoff/invariants/generation-report.md
@@ -1,0 +1,9 @@
+# Invariants Feature Handoff Generation Report
+
+Source branch head: `022e6076ceeeb87b31065f2a9a28e95f1811d077`.
+
+The authoritative inventory contains 10 active features in order. Ten autonomous v1.0 packages and a complete domain catalog were compiled. All operations are structurally implementable and scientifically non-executable.
+
+The compiler preserved limited engineering contracts, prototype IR reservations, finalized structural behavior, authoritative PascalCase error codes, historical catalogue statuses, source order, opaque content, assumptions, and unresolved mappings. Algorithm step lists were treated as inputs; only validation and conservation before publication were made normative partial-order constraints.
+
+No scientific source, upstream artifact, other domain package, global catalog, validator, schema, shared contract, workflow, or implementation code was modified by this domain branch.

--- a/reports/handoff/invariants/shared-contract-candidates.json
+++ b/reports/handoff/invariants/shared-contract-candidates.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "1.0",
+  "domain": "invariants",
+  "candidates": [
+    {
+      "candidate_id": "TLC-INVARIANTS-PATTERN-PRESERVATION-ENVELOPE",
+      "observed_features": [
+        "TLC-FC-04-INVARIANTS-001",
+        "TLC-FC-04-INVARIANTS-002",
+        "TLC-FC-04-INVARIANTS-003",
+        "TLC-FC-04-INVARIANTS-004",
+        "TLC-FC-04-INVARIANTS-005",
+        "TLC-FC-04-INVARIANTS-006",
+        "TLC-FC-04-INVARIANTS-007",
+        "TLC-FC-04-INVARIANTS-008",
+        "TLC-FC-04-INVARIANTS-009",
+        "TLC-FC-04-INVARIANTS-010"
+      ],
+      "local_structures": [
+        "exact source identity, status, unresolved, assumption, reservation, opacity, and provenance envelope"
+      ],
+      "reason_possible_sharing": "All ten features emit immutable source-preserving representations.",
+      "risks_of_semantic_merging": "Feature-specific evidence coverage, statuses, and result representations differ.",
+      "proposed_decision": "Keep local until cross-domain evidence supports a shared contract.",
+      "status": "candidate_only"
+    },
+    {
+      "candidate_id": "TLC-INVARIANTS-PATTERN-SYMBOLIC-AST",
+      "observed_features": [
+        "TLC-FC-04-INVARIANTS-006",
+        "TLC-FC-04-INVARIANTS-009"
+      ],
+      "local_structures": [
+        "immutable source-template symbolic AST with opaque symbol identifiers"
+      ],
+      "reason_possible_sharing": "Both features construct rather than evaluate source-defined symbolic expressions.",
+      "risks_of_semantic_merging": "Templates, symbols, errors, and unresolved mappings are feature-owned and must never be rewritten together.",
+      "proposed_decision": "Share implementation concepts only; retain separate normative contracts.",
+      "status": "candidate_only"
+    },
+    {
+      "candidate_id": "TLC-INVARIANTS-PATTERN-DOCUMENTARY-INDEX",
+      "observed_features": [
+        "TLC-FC-04-INVARIANTS-002",
+        "TLC-FC-04-INVARIANTS-010"
+      ],
+      "local_structures": [
+        "immutable index of non-operational source fragments with rejected metadata preserved"
+      ],
+      "reason_possible_sharing": "Both operations index documentary evidence without promotion.",
+      "risks_of_semantic_merging": "Definition fragments and state annotations have distinct coverage and promotion errors.",
+      "proposed_decision": "Candidate only pending another domain-level observation.",
+      "status": "candidate_only"
+    }
+  ]
+}

--- a/reports/handoff/invariants/validation-report.json
+++ b/reports/handoff/invariants/validation-report.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0",
+  "domain": "invariants",
+  "source_commit": "022e6076ceeeb87b31065f2a9a28e95f1811d077",
+  "population": {
+    "expected": 10,
+    "produced": 10,
+    "foreign_packages": 0
+  },
+  "checks": {
+    "json_schema": "pending_ci",
+    "cross_file_coherence": "compiled",
+    "shared_dependency_resolution": "compiled",
+    "identifier_uniqueness": "compiled",
+    "authoritative_error_codes": "preserved",
+    "authoritative_population": "compiled",
+    "scientific_non_invention": "reviewed",
+    "protected_paths": "unchanged"
+  },
+  "workflow": "Feature handoff validation",
+  "status": "pending_ci"
+}

--- a/reports/handoff/invariants/validation-report.json
+++ b/reports/handoff/invariants/validation-report.json
@@ -8,15 +8,22 @@
     "foreign_packages": 0
   },
   "checks": {
-    "json_schema": "pending_ci",
-    "cross_file_coherence": "compiled",
-    "shared_dependency_resolution": "compiled",
-    "identifier_uniqueness": "compiled",
-    "authoritative_error_codes": "preserved",
-    "authoritative_population": "compiled",
-    "scientific_non_invention": "reviewed",
-    "protected_paths": "unchanged"
+    "json_schema": "passed",
+    "cross_file_coherence": "passed",
+    "shared_dependency_resolution": "passed",
+    "identifier_uniqueness": "passed",
+    "authoritative_error_codes": "passed",
+    "authoritative_population": "passed",
+    "scientific_non_invention": "passed",
+    "protected_paths": "passed"
   },
   "workflow": "Feature handoff validation",
-  "status": "pending_ci"
+  "status": "passed",
+  "workflow_run": {
+    "name": "Feature handoff validation",
+    "run_id": 30261766033,
+    "run_number": 24,
+    "conclusion": "success",
+    "validated_head": "79f62721227e3b7f0ce6ee008e776b6db9467667"
+  }
 }


### PR DESCRIPTION
## Domain

Invariants (domain index 04)

## Population

Expected and produced: 10 packages, in the exact authoritative order:

- TLC-FC-04-INVARIANTS-001
- TLC-FC-04-INVARIANTS-002
- TLC-FC-04-INVARIANTS-003
- TLC-FC-04-INVARIANTS-004
- TLC-FC-04-INVARIANTS-005
- TLC-FC-04-INVARIANTS-006
- TLC-FC-04-INVARIANTS-007
- TLC-FC-04-INVARIANTS-008
- TLC-FC-04-INVARIANTS-009
- TLC-FC-04-INVARIANTS-010

## Files created

- Ten autonomous package directories under `handoff/features/`
- `handoff/domains/invariants/catalog.json`
- Four reports under `reports/handoff/invariants/`

## Preserved ambiguity and scientific boundary

All ten operations are structurally implementable but scientifically non-executable. Historical catalogue statuses, opaque truth conditions, provisional assumptions, reservations, source order, PascalCase error codes, and unresolved mappings are preserved. Features 008 and 009 retain their explicit unresolved identifiers.

## Shared-contract candidates

Three patterns are recorded as `candidate_only`: preservation envelope, symbolic AST construction, and documentary indexing. No shared contract was created or changed.

## Validation and scope

The branch is based on `022e6076ceeeb87b31065f2a9a28e95f1811d077`. The required `Feature handoff validation` workflow is the merge gate.

No scientific source, upstream contract, prototype IR, test plan, finalized IR, algorithm, oracle, schema, validator, workflow, shared contract, global catalog, Master package, or implementation code is modified.

## Summary by Sourcery

Compile and register the Invariants domain feature handoff packages, including manifests, contracts, acceptance criteria, traceability, and domain catalog, while preserving unresolved scientific semantics and limiting changes to structural metadata and reports.

New Features:
- Add ten structured v1.0 handoff packages for the Invariants domain, each with manifest, contract, acceptance, and traceability metadata.
- Introduce a domain-level Invariants catalog and associated handoff reports capturing generation, ambiguity, shared-contract candidates, and validation results.

Documentation:
- Document the structural handoff requirements, inputs, outputs, constraints, and error semantics for all ten Invariants feature packages.