### PR TITLE
fix(handoff): accept expected_count inventory alias

### DIFF
--- a/tools/handoff/validate_handoff_compat.py
+++ b/tools/handoff/validate_handoff_compat.py
@@ -52,7 +52,7 @@ def validate_authoritative_inventory(domain: str, catalog: dict[str, Any]) -> No
 
     declared_counts = [
         inventory[key]
-        for key in ("feature_count", "population_count", "active_feature_count")
+        for key in ("feature_count", "population_count", "active_feature_count", "expected_count")
         if key in inventory
     ]
     summary = inventory.get("summary")


### PR DESCRIPTION
## Purpose

Extend the existing compatibility validator to recognize `expected_count` as an established non-scientific authoritative-inventory count alias.

## Scope

- One-line alias addition in `tools/handoff/validate_handoff_compat.py`
- No schema change
- No scientific source or registry change
- No feature package or domain catalog change
- No validator bypass: the declared value must still equal the exact authoritative feature population

## Evidence

Values uses `expected_count: 14` in its authoritative `feature-status.yaml`. The current compatibility validator already accepts `feature_count`, `population_count`, `active_feature_count`, and `summary.active_features`; omission of `expected_count` causes `authoritative inventory feature count mismatch for domain values` before package validation begins.

## Summary by Sourcery

Bug Fixes:
- Allow `expected_count` to be treated as a valid authoritative inventory count alias during handoff validation to prevent false mismatches.