### PR TITLE
fix(handoff): accept authoritative feature count alias

### DIFF
--- a/reports/handoff/infrastructure/authoritative-feature-count-alias.md
+++ b/reports/handoff/infrastructure/authoritative-feature-count-alias.md
@@ -1,0 +1,5 @@
+# Authoritative feature-count alias
+
+Some finalized domain inventories name their authoritative population total `authoritative_feature_count`. Progressive validation now accepts this established key alongside `feature_count` and `population_count`.
+
+When multiple aliases are present, every declared value must equal the actual ordered feature population. Missing counts and conflicting or inaccurate values remain validation failures. No inventory, scientific artifact, package, schema, shared contract, or domain semantics is changed.

--- a/tools/handoff/validate_handoff.py
+++ b/tools/handoff/validate_handoff.py
@@ -256,7 +256,11 @@ def validate_authoritative_inventory(domain: str, catalog: dict[str, Any]) -> No
     if len(authoritative_ids) != len(authoritative_features) or any(not isinstance(item, str) for item in authoritative_ids):
         fail(f"authoritative inventory contains an invalid feature entry for domain {domain}")
 
-    declared_counts = [\n        inventory[key]\n        for key in ("feature_count", "population_count", "authoritative_feature_count")\n        if key in inventory\n    ]
+    declared_counts = [
+        inventory[key]
+        for key in ("feature_count", "population_count", "authoritative_feature_count")
+        if key in inventory
+    ]
     if not declared_counts or any(value != len(authoritative_ids) for value in declared_counts):
         fail(f"authoritative inventory feature count mismatch for domain {domain}")
 

--- a/tools/handoff/validate_handoff.py
+++ b/tools/handoff/validate_handoff.py
@@ -256,7 +256,7 @@ def validate_authoritative_inventory(domain: str, catalog: dict[str, Any]) -> No
     if len(authoritative_ids) != len(authoritative_features) or any(not isinstance(item, str) for item in authoritative_ids):
         fail(f"authoritative inventory contains an invalid feature entry for domain {domain}")
 
-    declared_counts = [inventory[key] for key in ("feature_count", "population_count") if key in inventory]
+    declared_counts = [\n        inventory[key]\n        for key in ("feature_count", "population_count", "authoritative_feature_count")\n        if key in inventory\n    ]
     if not declared_counts or any(value != len(authoritative_ids) for value in declared_counts):
         fail(f"authoritative inventory feature count mismatch for domain {domain}")
 


### PR DESCRIPTION
Accept the established `authoritative_feature_count` inventory key alongside `feature_count` and `population_count`. Every present alias must still equal the actual ordered feature population. This preserves the Relations inventory without renaming its authoritative metadata. No science, package, schema, shared contract, or domain artifact is modified.

## Summary by Sourcery

Accept an additional authoritative feature-count alias in handoff validation while documenting the behavior change.

New Features:
- Allow authoritative inventory validation to recognize `authoritative_feature_count` as a valid feature count alias alongside existing keys.

Documentation:
- Add handoff infrastructure documentation describing acceptance rules for the `authoritative_feature_count` alias and its consistency requirements with other count fields.