### PR TITLE
feat(handoff): compile Relations feature packages

### DIFF
--- a/handoff/domains/relations/catalog.json
+++ b/handoff/domains/relations/catalog.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "1.0",
+  "package_model_version": "1.0.0",
+  "domain": "relations",
+  "domain_index": 15,
+  "expected_feature_count": 5,
+  "ordered_feature_ids": [
+    "TLC-FC-15-RELATIONS-002",
+    "TLC-FC-15-RELATIONS-003",
+    "TLC-FC-15-RELATIONS-004",
+    "TLC-FC-15-RELATIONS-007",
+    "TLC-FC-15-RELATIONS-008"
+  ],
+  "feature_packages": [
+    {
+      "feature_id": "TLC-FC-15-RELATIONS-002",
+      "path": "handoff/features/TLC-FC-15-RELATIONS-002",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-15-RELATIONS-003",
+      "path": "handoff/features/TLC-FC-15-RELATIONS-003",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-15-RELATIONS-004",
+      "path": "handoff/features/TLC-FC-15-RELATIONS-004",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-15-RELATIONS-007",
+      "path": "handoff/features/TLC-FC-15-RELATIONS-007",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    },
+    {
+      "feature_id": "TLC-FC-15-RELATIONS-008",
+      "path": "handoff/features/TLC-FC-15-RELATIONS-008",
+      "package_version": "1.0.0",
+      "status": "finalized"
+    }
+  ],
+  "statuses": {
+    "population": "complete",
+    "validation": "pending"
+  },
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "metadata": {
+    "authoritative_inventory": "registry/domain-finalization/relations/feature-status.yaml",
+    "generated_by": "ChatGPT GitHub connector domain compiler",
+    "validation_tool": "tools/handoff/validate_handoff.py",
+    "source_commit": "f3f4881cf6de85e6b09b4be65dde34f253bd1b04"
+  }
+}

--- a/handoff/domains/relations/catalog.json
+++ b/handoff/domains/relations/catalog.json
@@ -45,7 +45,7 @@
   ],
   "statuses": {
     "population": "complete",
-    "validation": "pending"
+    "validation": "passed"
   },
   "shared_dependencies": [
     {
@@ -85,6 +85,6 @@
     "authoritative_inventory": "registry/domain-finalization/relations/feature-status.yaml",
     "generated_by": "ChatGPT GitHub connector domain compiler",
     "validation_tool": "tools/handoff/validate_handoff.py",
-    "source_commit": "f3f4881cf6de85e6b09b4be65dde34f253bd1b04"
+    "source_commit": "7ed8d26d2e014e65ea06eec9c2337d9f4a7ef905"
   }
 }

--- a/handoff/domains/relations/catalog.json
+++ b/handoff/domains/relations/catalog.json
@@ -45,7 +45,7 @@
   ],
   "statuses": {
     "population": "complete",
-    "validation": "passed"
+    "validation": "validated"
   },
   "shared_dependencies": [
     {

--- a/handoff/features/TLC-FC-15-RELATIONS-002/README.md
+++ b/handoff/features/TLC-FC-15-RELATIONS-002/README.md
@@ -1,0 +1,29 @@
+# TLC-FC-15-RELATIONS-002 — Blocked equation bundle structural record
+
+## What is this feature?
+
+This package defines the final implementable structural behavior for the Relations equation classified as `blocked_locally`. It does not define executable scientific relation semantics.
+
+## What must be implemented?
+
+Implement exact validation and guarded construction of an immutable structural record. Preserve the feature identity, the 6 participant reference(s) in the declared order, scope `relations_002_source_equation_bundle`, context `master_message_virtue_value_capacity_competence_formalizations`, opaque source material, and all 5 unresolved items.
+
+## Valid inputs and required output
+
+A valid request contains the exact feature ID, the exact ordered participants (TLC-SO-RELATIONS-047, TLC-SO-RELATIONS-048, TLC-SO-RELATIONS-064, TLC-SO-RELATIONS-077, TLC-SO-RELATIONS-088, TLC-SO-RELATIONS-100), resolvable source references, unchanged opaque values, complete unresolved metadata, and no request for semantic evaluation. Success returns a deterministic structural record with the non-execution guard enabled.
+
+## Mandatory and forbidden behavior
+
+Mandatory behavior is exact preservation, deterministic structural validation, stable errors, and rejection of unsupported evaluation. It is forbidden to invent endpoints, direction, runtime arity, relation properties, types, dimensions, thresholds, numeric methods, graphs, membership, composition, inversion, projection, deduction, or causality.
+
+## Implementation freedom
+
+Internal data structures, programming language, allocation, ownership transport, concurrency policy, and serialization format are implementation-defined provided observable preservation and error behavior remain conforming.
+
+## Observable errors
+
+The contract preserves the authoritative PascalCase errors, including `FeatureIdentityMismatch`, participant and preservation errors, `ScientificPropertyInvented`, and `ExternalRelationEvaluatorRequired`.
+
+## Conformance and unresolved science
+
+All acceptance tests in `acceptance.json` must pass. Scientific evaluation remains `external_provider_required`; TLC-HR-0054 stays unresolved evidence and is not converted into a default.

--- a/handoff/features/TLC-FC-15-RELATIONS-002/acceptance.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-002/acceptance.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-15-RELATIONS-002",
+  "tests": [
+    {
+      "test_id": "TLC-FC-15-RELATIONS-002-AT-001",
+      "applies_to": "BUILD-RELATIONS-002-RECORD",
+      "category": "valid_input",
+      "given": "Exact identity, exact ordered participants, preserved opaque values, scope, context, and all unresolved items.",
+      "when": "The structural record operation is invoked.",
+      "expect": "A deterministic guarded record is returned with 6 participants and 5 unresolved items.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-002-AT-002",
+      "applies_to": "BUILD-RELATIONS-002-RECORD",
+      "category": "invalid_input",
+      "given": "A mismatched feature identity.",
+      "when": "Validation runs.",
+      "expect": "FeatureIdentityMismatch and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-002-AT-003",
+      "applies_to": "BUILD-RELATIONS-002-RECORD",
+      "category": "preservation",
+      "given": "A participant is missing, extra, duplicated, or reordered.",
+      "when": "Participant validation runs.",
+      "expect": "The corresponding authoritative participant error and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-002-AT-004",
+      "applies_to": "BUILD-RELATIONS-002-RECORD",
+      "category": "preservation",
+      "given": "Opaque values, scope, context, or source references are altered.",
+      "when": "Preservation validation runs.",
+      "expect": "The corresponding preservation error and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-002-AT-005",
+      "applies_to": "BUILD-RELATIONS-002-RECORD",
+      "category": "unsupported_operation",
+      "given": "A scientific evaluation, composition, inversion, projection, membership, graph, numeric, temporal, or causal operation is requested.",
+      "when": "The non-execution guard runs.",
+      "expect": "ExternalRelationEvaluatorRequired and no scientific output.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-002-AT-006",
+      "applies_to": "BUILD-RELATIONS-002-RECORD",
+      "category": "invariant",
+      "given": "An endpoint, direction, runtime arity, relation property, type, dimension, or causal meaning is inferred.",
+      "when": "The record is validated.",
+      "expect": "ScientificPropertyInvented and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-002-AT-007",
+      "applies_to": "BUILD-RELATIONS-002-RECORD",
+      "category": "determinism",
+      "given": "Byte-equivalent valid structural inputs are supplied repeatedly.",
+      "when": "Construction is repeated.",
+      "expect": "Structurally identical outputs with identical participant and unresolved ordering.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-002/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-002-AT-008",
+      "applies_to": "BUILD-RELATIONS-002-RECORD",
+      "category": "preservation",
+      "given": "One of the 5 unresolved items is removed, altered, or defaulted.",
+      "when": "Unresolved propagation is validated.",
+      "expect": "UnresolvedPropagationLoss and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-002/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-002/contract.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-002/contract.json
@@ -1,0 +1,534 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-15-RELATIONS-002",
+    "title": "Blocked equation bundle structural record",
+    "domain": "relations"
+  },
+  "purpose": "Build and validate a deterministic structural record for the equation (blocked_locally) while preserving scientific material as opaque and refusing relation evaluation.",
+  "scope": {
+    "required": [
+      {
+        "id": "R002-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-15-RELATIONS-002.",
+        "basis": [
+          "registry/optimized-ir/relations/TLC-FC-15-RELATIONS-002/ir.yaml"
+        ]
+      },
+      {
+        "id": "R002-REQ-002",
+        "statement": "Preserve exactly these participant identities in order: TLC-SO-RELATIONS-047, TLC-SO-RELATIONS-048, TLC-SO-RELATIONS-064, TLC-SO-RELATIONS-077, TLC-SO-RELATIONS-088, TLC-SO-RELATIONS-100.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-15-RELATIONS-002/contract.yaml",
+          "registry/oracles/relations/TLC-FC-15-RELATIONS-002/oracle.yaml"
+        ]
+      },
+      {
+        "id": "R002-REQ-003",
+        "statement": "Preserve scope relations_002_source_equation_bundle, context master_message_virtue_value_capacity_competence_formalizations, opaque source values, and exactly 5 unresolved items."
+      },
+      {
+        "id": "R002-REQ-004",
+        "statement": "Reject every request for scientific evaluation with ExternalRelationEvaluatorRequired."
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "R002-FOR-001",
+        "statement": "Do not create or evaluate a scientific relation, equation, invariant, operator, graph, membership, composition, inversion, projection, deduction, or causal result."
+      },
+      {
+        "id": "R002-FOR-002",
+        "statement": "Do not infer source, target, direction, runtime arity, properties, types, dimensions, thresholds, or numerical methods."
+      },
+      {
+        "id": "R002-FOR-003",
+        "statement": "Do not mutate opaque source values, reorder participants, or replace unresolved items with defaults."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "R002-DEF-001",
+        "statement": "Scientific relation semantics remain unresolved; external scientific decision evidence is TLC-HR-0054."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "BUILD-RELATIONS-002-RECORD",
+      "purpose": "Validate the exact structural inputs and emit a non-executable record guarded against scientific evaluation.",
+      "inputs": [
+        {
+          "name": "feature_id",
+          "semantic_role": "exact requested feature identity",
+          "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [
+              "TLC-FC-15-RELATIONS-002"
+            ],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          },
+          "constraints": [
+            {
+              "id": "R002-IN-001",
+              "statement": "Identity equals TLC-FC-15-RELATIONS-002."
+            }
+          ]
+        },
+        {
+          "name": "participants",
+          "semantic_role": "opaque scientific participants in authoritative order",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-RELATIONS-047",
+              "TLC-SO-RELATIONS-048",
+              "TLC-SO-RELATIONS-064",
+              "TLC-SO-RELATIONS-077",
+              "TLC-SO-RELATIONS-088",
+              "TLC-SO-RELATIONS-100"
+            ],
+            "cardinality": {
+              "minimum": 6,
+              "maximum": 6
+            },
+            "ordering": "preserved",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          }
+        },
+        {
+          "name": "opaque_source_values",
+          "semantic_role": "uninterpreted source equations, tuples, functions, or names",
+          "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "constrained",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": null
+            },
+            "ordering": "preserved",
+            "duplicates": "significant",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "unresolved_items",
+          "semantic_role": "exact 5-item unresolved set in authoritative order",
+          "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 5,
+              "maximum": 5
+            },
+            "ordering": "preserved",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "traceability",
+          "semantic_role": "complete upstream provenance",
+          "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0",
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "evaluation_request",
+          "semantic_role": "optional request that must be rejected when present",
+          "collection": {
+            "kind": "optional",
+            "membership": "open",
+            "cardinality": {
+              "minimum": 0,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "record",
+          "semantic_role": "validated non-executable Relations structural record",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "scope_id",
+              "required": true,
+              "semantic_role": "authoritative scope",
+              "constant": "relations_002_source_equation_bundle"
+            },
+            {
+              "name": "context_id",
+              "required": true,
+              "semantic_role": "authoritative context",
+              "constant": "master_message_virtue_value_capacity_competence_formalizations"
+            },
+            {
+              "name": "opaque_payload",
+              "required": true,
+              "semantic_role": "uninterpreted preserved scientific material",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "non_execution_guard",
+              "required": true,
+              "semantic_role": "scientific evaluation prohibition",
+              "constant": "enabled"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "error",
+          "semantic_role": "stable transport-neutral failure",
+          "shared_contract_ref": "TLC-HC-STRUCTURED-ERROR@1.0.0",
+          "collection": {
+            "kind": "optional",
+            "membership": "constrained",
+            "cardinality": {
+              "minimum": 0,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "R002-PRE-001",
+          "statement": "Feature identity, participant references, scope, context, opaque values, and unresolved metadata are available."
+        },
+        {
+          "id": "R002-PRE-002",
+          "statement": "The caller requests structural construction or validation only."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "R002-POST-001",
+          "statement": "Successful output preserves identity, participants, order, scope, context, opaque values, and unresolved metadata exactly."
+        },
+        {
+          "id": "R002-POST-002",
+          "statement": "Successful output contains no scientific result and has the non-execution guard enabled."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "R002-INV-001",
+          "statement": "No source, target, direction, arity, relation property, or causality is added."
+        },
+        {
+          "id": "R002-INV-002",
+          "statement": "No observable partial record is published on failure."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact structural identity and preservation constraints",
+          "reject unsupported scientific evaluation",
+          "emit the guarded structural record"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact structural identity and preservation constraints",
+            "after": "emit the guarded structural record"
+          },
+          {
+            "before": "reject unsupported scientific evaluation",
+            "after": "emit the guarded structural record"
+          }
+        ],
+        "prescription_basis": [
+          "registry/algorithms/relations/TLC-FC-15-RELATIONS-002/algorithm.yaml"
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_required",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "FeatureIdentityMismatch",
+          "category": "identity",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingCoveredObject",
+          "category": "participants",
+          "condition": "A required participant is missing.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnexpectedCoveredObject",
+          "category": "participants",
+          "condition": "An undeclared participant is present.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "DuplicateCoveredObject",
+          "category": "participants",
+          "condition": "A participant identity is duplicated.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ObjectOrderMismatch",
+          "category": "participants",
+          "condition": "The participant order differs from the authoritative order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "source",
+          "condition": "A required participant source reference is unavailable.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScopeMismatch",
+          "category": "scope",
+          "condition": "The scope identifier differs from the authoritative scope.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ContextMismatch",
+          "category": "context",
+          "condition": "The context identifier differs from the authoritative context.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "OpaqueValueMutation",
+          "category": "preservation",
+          "condition": "Opaque source material differs in value or order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnresolvedPropagationLoss",
+          "category": "preservation",
+          "condition": "One or more unresolved items are absent or altered.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificPropertyInvented",
+          "category": "scientific",
+          "condition": "A relation property, arity, direction, endpoint, or causal meaning is asserted without authority.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ExternalRelationEvaluatorRequired",
+          "category": "unsupported",
+          "condition": "Scientific evaluation is requested from this structural-only package.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "informative",
+          "value": "O(n) over participants, opaque values, and unresolved items"
+        },
+        "auxiliary_memory": {
+          "status": "informative",
+          "value": "O(n) for the preserved structural record"
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-record",
+      "status": "required",
+      "statement": "Expose exact validation, preservation, inspection, and guarded record construction."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not produce scientific relation semantics or results."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal architecture is free when all observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "R002-GINV-001",
+      "statement": "Unresolved scientific semantics remain explicit and never become implementation defaults."
+    },
+    {
+      "id": "R002-GINV-002",
+      "statement": "The scientific source and all registry artifacts remain read-only provenance."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity."
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless participant references."
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered participant collection."
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Explicit unresolved reservations."
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific payloads."
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral failures."
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable upstream provenance."
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Observable structural record shape."
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance covers structural behavior only; semantic evaluation requires an external provider."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-002/manifest.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-002/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-15-RELATIONS-002",
+  "title": "Blocked equation bundle structural record",
+  "domain": "relations",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-002/traceability.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-002/traceability.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-15-RELATIONS-002",
+  "scientific_sources": [
+    {
+      "path": "maths/15-relations.md",
+      "role": "authoritative Relations scientific source"
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-15-RELATIONS-002/contract.yaml",
+      "role": "validated mathematical contract"
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-15-RELATIONS-002/ir.yaml",
+      "role": "canonical declarative source IR"
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/relations/TLC-FC-15-RELATIONS-002/ir.yaml",
+      "role": "selected structural implementation IR"
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/relations/TLC-FC-15-RELATIONS-002/algorithm.yaml",
+      "role": "structural algorithm input; total listed order is not imposed beyond observable constraints"
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-15-RELATIONS-002/test-plan.yaml",
+      "role": "upstream structural test plan"
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/relations/TLC-FC-15-RELATIONS-002/oracle.yaml",
+      "role": "structural acceptance oracle"
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/relations/feature-status.yaml",
+      "role": "authoritative domain finalization inventory; preserves TLC-HR-0054"
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-003/README.md
+++ b/handoff/features/TLC-FC-15-RELATIONS-003/README.md
@@ -1,0 +1,29 @@
+# TLC-FC-15-RELATIONS-003 — Provisional invariant tuple structural record
+
+## What is this feature?
+
+This package defines the final implementable structural behavior for the Relations invariant classified as `provisionally_separated`. It does not define executable scientific relation semantics.
+
+## What must be implemented?
+
+Implement exact validation and guarded construction of an immutable structural record. Preserve the feature identity, the 1 participant reference(s) in the declared order, scope `relations_003_master_message_tuple_record`, context `master_message_formalization`, opaque source material, and all 5 unresolved items.
+
+## Valid inputs and required output
+
+A valid request contains the exact feature ID, the exact ordered participants (TLC-SO-RELATIONS-008), resolvable source references, unchanged opaque values, complete unresolved metadata, and no request for semantic evaluation. Success returns a deterministic structural record with the non-execution guard enabled.
+
+## Mandatory and forbidden behavior
+
+Mandatory behavior is exact preservation, deterministic structural validation, stable errors, and rejection of unsupported evaluation. It is forbidden to invent endpoints, direction, runtime arity, relation properties, types, dimensions, thresholds, numeric methods, graphs, membership, composition, inversion, projection, deduction, or causality.
+
+## Implementation freedom
+
+Internal data structures, programming language, allocation, ownership transport, concurrency policy, and serialization format are implementation-defined provided observable preservation and error behavior remain conforming.
+
+## Observable errors
+
+The contract preserves the authoritative PascalCase errors, including `FeatureIdentityMismatch`, participant and preservation errors, `ScientificPropertyInvented`, and `ExternalRelationEvaluatorRequired`.
+
+## Conformance and unresolved science
+
+All acceptance tests in `acceptance.json` must pass. Scientific evaluation remains `external_provider_required`; TLC-HR-0074 stays unresolved evidence and is not converted into a default.

--- a/handoff/features/TLC-FC-15-RELATIONS-003/acceptance.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-003/acceptance.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-15-RELATIONS-003",
+  "tests": [
+    {
+      "test_id": "TLC-FC-15-RELATIONS-003-AT-001",
+      "applies_to": "BUILD-RELATIONS-003-RECORD",
+      "category": "valid_input",
+      "given": "Exact identity, exact ordered participants, preserved opaque values, scope, context, and all unresolved items.",
+      "when": "The structural record operation is invoked.",
+      "expect": "A deterministic guarded record is returned with 1 participants and 5 unresolved items.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-003-AT-002",
+      "applies_to": "BUILD-RELATIONS-003-RECORD",
+      "category": "invalid_input",
+      "given": "A mismatched feature identity.",
+      "when": "Validation runs.",
+      "expect": "FeatureIdentityMismatch and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-003-AT-003",
+      "applies_to": "BUILD-RELATIONS-003-RECORD",
+      "category": "preservation",
+      "given": "A participant is missing, extra, duplicated, or reordered.",
+      "when": "Participant validation runs.",
+      "expect": "The corresponding authoritative participant error and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-003-AT-004",
+      "applies_to": "BUILD-RELATIONS-003-RECORD",
+      "category": "preservation",
+      "given": "Opaque values, scope, context, or source references are altered.",
+      "when": "Preservation validation runs.",
+      "expect": "The corresponding preservation error and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-003-AT-005",
+      "applies_to": "BUILD-RELATIONS-003-RECORD",
+      "category": "unsupported_operation",
+      "given": "A scientific evaluation, composition, inversion, projection, membership, graph, numeric, temporal, or causal operation is requested.",
+      "when": "The non-execution guard runs.",
+      "expect": "ExternalRelationEvaluatorRequired and no scientific output.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-003-AT-006",
+      "applies_to": "BUILD-RELATIONS-003-RECORD",
+      "category": "invariant",
+      "given": "An endpoint, direction, runtime arity, relation property, type, dimension, or causal meaning is inferred.",
+      "when": "The record is validated.",
+      "expect": "ScientificPropertyInvented and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-003-AT-007",
+      "applies_to": "BUILD-RELATIONS-003-RECORD",
+      "category": "determinism",
+      "given": "Byte-equivalent valid structural inputs are supplied repeatedly.",
+      "when": "Construction is repeated.",
+      "expect": "Structurally identical outputs with identical participant and unresolved ordering.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-003/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-003-AT-008",
+      "applies_to": "BUILD-RELATIONS-003-RECORD",
+      "category": "preservation",
+      "given": "One of the 5 unresolved items is removed, altered, or defaulted.",
+      "when": "Unresolved propagation is validated.",
+      "expect": "UnresolvedPropagationLoss and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-003/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-003/contract.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-003/contract.json
@@ -1,0 +1,529 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-15-RELATIONS-003",
+    "title": "Provisional invariant tuple structural record",
+    "domain": "relations"
+  },
+  "purpose": "Build and validate a deterministic structural record for the invariant (provisionally_separated) while preserving scientific material as opaque and refusing relation evaluation.",
+  "scope": {
+    "required": [
+      {
+        "id": "R003-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-15-RELATIONS-003.",
+        "basis": [
+          "registry/optimized-ir/relations/TLC-FC-15-RELATIONS-003/ir.yaml"
+        ]
+      },
+      {
+        "id": "R003-REQ-002",
+        "statement": "Preserve exactly these participant identities in order: TLC-SO-RELATIONS-008.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-15-RELATIONS-003/contract.yaml",
+          "registry/oracles/relations/TLC-FC-15-RELATIONS-003/oracle.yaml"
+        ]
+      },
+      {
+        "id": "R003-REQ-003",
+        "statement": "Preserve scope relations_003_master_message_tuple_record, context master_message_formalization, opaque source values, and exactly 5 unresolved items."
+      },
+      {
+        "id": "R003-REQ-004",
+        "statement": "Reject every request for scientific evaluation with ExternalRelationEvaluatorRequired."
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "R003-FOR-001",
+        "statement": "Do not create or evaluate a scientific relation, equation, invariant, operator, graph, membership, composition, inversion, projection, deduction, or causal result."
+      },
+      {
+        "id": "R003-FOR-002",
+        "statement": "Do not infer source, target, direction, runtime arity, properties, types, dimensions, thresholds, or numerical methods."
+      },
+      {
+        "id": "R003-FOR-003",
+        "statement": "Do not mutate opaque source values, reorder participants, or replace unresolved items with defaults."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "R003-DEF-001",
+        "statement": "Scientific relation semantics remain unresolved; external scientific decision evidence is TLC-HR-0074."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "BUILD-RELATIONS-003-RECORD",
+      "purpose": "Validate the exact structural inputs and emit a non-executable record guarded against scientific evaluation.",
+      "inputs": [
+        {
+          "name": "feature_id",
+          "semantic_role": "exact requested feature identity",
+          "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [
+              "TLC-FC-15-RELATIONS-003"
+            ],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          },
+          "constraints": [
+            {
+              "id": "R003-IN-001",
+              "statement": "Identity equals TLC-FC-15-RELATIONS-003."
+            }
+          ]
+        },
+        {
+          "name": "participants",
+          "semantic_role": "opaque scientific participants in authoritative order",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-RELATIONS-008"
+            ],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "preserved",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          }
+        },
+        {
+          "name": "opaque_source_values",
+          "semantic_role": "uninterpreted source equations, tuples, functions, or names",
+          "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "constrained",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": null
+            },
+            "ordering": "preserved",
+            "duplicates": "significant",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "unresolved_items",
+          "semantic_role": "exact 5-item unresolved set in authoritative order",
+          "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 5,
+              "maximum": 5
+            },
+            "ordering": "preserved",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "traceability",
+          "semantic_role": "complete upstream provenance",
+          "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0",
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "evaluation_request",
+          "semantic_role": "optional request that must be rejected when present",
+          "collection": {
+            "kind": "optional",
+            "membership": "open",
+            "cardinality": {
+              "minimum": 0,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "record",
+          "semantic_role": "validated non-executable Relations structural record",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "scope_id",
+              "required": true,
+              "semantic_role": "authoritative scope",
+              "constant": "relations_003_master_message_tuple_record"
+            },
+            {
+              "name": "context_id",
+              "required": true,
+              "semantic_role": "authoritative context",
+              "constant": "master_message_formalization"
+            },
+            {
+              "name": "opaque_payload",
+              "required": true,
+              "semantic_role": "uninterpreted preserved scientific material",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "non_execution_guard",
+              "required": true,
+              "semantic_role": "scientific evaluation prohibition",
+              "constant": "enabled"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "error",
+          "semantic_role": "stable transport-neutral failure",
+          "shared_contract_ref": "TLC-HC-STRUCTURED-ERROR@1.0.0",
+          "collection": {
+            "kind": "optional",
+            "membership": "constrained",
+            "cardinality": {
+              "minimum": 0,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "R003-PRE-001",
+          "statement": "Feature identity, participant references, scope, context, opaque values, and unresolved metadata are available."
+        },
+        {
+          "id": "R003-PRE-002",
+          "statement": "The caller requests structural construction or validation only."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "R003-POST-001",
+          "statement": "Successful output preserves identity, participants, order, scope, context, opaque values, and unresolved metadata exactly."
+        },
+        {
+          "id": "R003-POST-002",
+          "statement": "Successful output contains no scientific result and has the non-execution guard enabled."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "R003-INV-001",
+          "statement": "No source, target, direction, arity, relation property, or causality is added."
+        },
+        {
+          "id": "R003-INV-002",
+          "statement": "No observable partial record is published on failure."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact structural identity and preservation constraints",
+          "reject unsupported scientific evaluation",
+          "emit the guarded structural record"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact structural identity and preservation constraints",
+            "after": "emit the guarded structural record"
+          },
+          {
+            "before": "reject unsupported scientific evaluation",
+            "after": "emit the guarded structural record"
+          }
+        ],
+        "prescription_basis": [
+          "registry/algorithms/relations/TLC-FC-15-RELATIONS-003/algorithm.yaml"
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_required",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "FeatureIdentityMismatch",
+          "category": "identity",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingCoveredObject",
+          "category": "participants",
+          "condition": "A required participant is missing.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnexpectedCoveredObject",
+          "category": "participants",
+          "condition": "An undeclared participant is present.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "DuplicateCoveredObject",
+          "category": "participants",
+          "condition": "A participant identity is duplicated.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ObjectOrderMismatch",
+          "category": "participants",
+          "condition": "The participant order differs from the authoritative order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "source",
+          "condition": "A required participant source reference is unavailable.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScopeMismatch",
+          "category": "scope",
+          "condition": "The scope identifier differs from the authoritative scope.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ContextMismatch",
+          "category": "context",
+          "condition": "The context identifier differs from the authoritative context.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "OpaqueValueMutation",
+          "category": "preservation",
+          "condition": "Opaque source material differs in value or order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnresolvedPropagationLoss",
+          "category": "preservation",
+          "condition": "One or more unresolved items are absent or altered.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificPropertyInvented",
+          "category": "scientific",
+          "condition": "A relation property, arity, direction, endpoint, or causal meaning is asserted without authority.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ExternalRelationEvaluatorRequired",
+          "category": "unsupported",
+          "condition": "Scientific evaluation is requested from this structural-only package.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "informative",
+          "value": "O(n) over participants, opaque values, and unresolved items"
+        },
+        "auxiliary_memory": {
+          "status": "informative",
+          "value": "O(n) for the preserved structural record"
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-record",
+      "status": "required",
+      "statement": "Expose exact validation, preservation, inspection, and guarded record construction."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not produce scientific relation semantics or results."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal architecture is free when all observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "R003-GINV-001",
+      "statement": "Unresolved scientific semantics remain explicit and never become implementation defaults."
+    },
+    {
+      "id": "R003-GINV-002",
+      "statement": "The scientific source and all registry artifacts remain read-only provenance."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity."
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless participant references."
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered participant collection."
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Explicit unresolved reservations."
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific payloads."
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral failures."
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable upstream provenance."
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Observable structural record shape."
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance covers structural behavior only; semantic evaluation requires an external provider."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-003/manifest.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-003/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-15-RELATIONS-003",
+  "title": "Provisional invariant tuple structural record",
+  "domain": "relations",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-003/traceability.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-003/traceability.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-15-RELATIONS-003",
+  "scientific_sources": [
+    {
+      "path": "maths/15-relations.md",
+      "role": "authoritative Relations scientific source"
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-15-RELATIONS-003/contract.yaml",
+      "role": "validated mathematical contract"
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-15-RELATIONS-003/ir.yaml",
+      "role": "canonical declarative source IR"
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/relations/TLC-FC-15-RELATIONS-003/ir.yaml",
+      "role": "selected structural implementation IR"
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/relations/TLC-FC-15-RELATIONS-003/algorithm.yaml",
+      "role": "structural algorithm input; total listed order is not imposed beyond observable constraints"
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-15-RELATIONS-003/test-plan.yaml",
+      "role": "upstream structural test plan"
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/relations/TLC-FC-15-RELATIONS-003/oracle.yaml",
+      "role": "structural acceptance oracle"
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/relations/feature-status.yaml",
+      "role": "authoritative domain finalization inventory; preserves TLC-HR-0074"
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-004/README.md
+++ b/handoff/features/TLC-FC-15-RELATIONS-004/README.md
@@ -1,0 +1,29 @@
+# TLC-FC-15-RELATIONS-004 — Opaque operator bundle structural record
+
+## What is this feature?
+
+This package defines the final implementable structural behavior for the Relations operator classified as `admissible`. It does not define executable scientific relation semantics.
+
+## What must be implemented?
+
+Implement exact validation and guarded construction of an immutable structural record. Preserve the feature identity, the 3 participant reference(s) in the declared order, scope `relations_004_three_function_blocks`, context `master_message_value_capacity_essential_functions`, opaque source material, and all 31 unresolved items.
+
+## Valid inputs and required output
+
+A valid request contains the exact feature ID, the exact ordered participants (TLC-SO-RELATIONS-004, TLC-SO-RELATIONS-017, TLC-SO-RELATIONS-023), resolvable source references, unchanged opaque values, complete unresolved metadata, and no request for semantic evaluation. Success returns a deterministic structural record with the non-execution guard enabled.
+
+## Mandatory and forbidden behavior
+
+Mandatory behavior is exact preservation, deterministic structural validation, stable errors, and rejection of unsupported evaluation. It is forbidden to invent endpoints, direction, runtime arity, relation properties, types, dimensions, thresholds, numeric methods, graphs, membership, composition, inversion, projection, deduction, or causality.
+
+## Implementation freedom
+
+Internal data structures, programming language, allocation, ownership transport, concurrency policy, and serialization format are implementation-defined provided observable preservation and error behavior remain conforming.
+
+## Observable errors
+
+The contract preserves the authoritative PascalCase errors, including `FeatureIdentityMismatch`, participant and preservation errors, `ScientificPropertyInvented`, and `ExternalRelationEvaluatorRequired`, plus `IdentityMergeProhibited`.
+
+## Conformance and unresolved science
+
+All acceptance tests in `acceptance.json` must pass. Scientific evaluation remains `external_provider_required`; TLC-DUP-RELATIONS-002 and TLC-GCYCLE-DOMAIN-001 stays unresolved evidence and is not converted into a default.

--- a/handoff/features/TLC-FC-15-RELATIONS-004/acceptance.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-004/acceptance.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-15-RELATIONS-004",
+  "tests": [
+    {
+      "test_id": "TLC-FC-15-RELATIONS-004-AT-001",
+      "applies_to": "BUILD-RELATIONS-004-RECORD",
+      "category": "valid_input",
+      "given": "Exact identity, exact ordered participants, preserved opaque values, scope, context, and all unresolved items.",
+      "when": "The structural record operation is invoked.",
+      "expect": "A deterministic guarded record is returned with 3 participants and 31 unresolved items.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-004-AT-002",
+      "applies_to": "BUILD-RELATIONS-004-RECORD",
+      "category": "invalid_input",
+      "given": "A mismatched feature identity.",
+      "when": "Validation runs.",
+      "expect": "FeatureIdentityMismatch and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-004-AT-003",
+      "applies_to": "BUILD-RELATIONS-004-RECORD",
+      "category": "preservation",
+      "given": "A participant is missing, extra, duplicated, or reordered.",
+      "when": "Participant validation runs.",
+      "expect": "The corresponding authoritative participant error and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-004-AT-004",
+      "applies_to": "BUILD-RELATIONS-004-RECORD",
+      "category": "preservation",
+      "given": "Opaque values, scope, context, or source references are altered.",
+      "when": "Preservation validation runs.",
+      "expect": "The corresponding preservation error and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-004-AT-005",
+      "applies_to": "BUILD-RELATIONS-004-RECORD",
+      "category": "unsupported_operation",
+      "given": "A scientific evaluation, composition, inversion, projection, membership, graph, numeric, temporal, or causal operation is requested.",
+      "when": "The non-execution guard runs.",
+      "expect": "ExternalRelationEvaluatorRequired and no scientific output.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-004-AT-006",
+      "applies_to": "BUILD-RELATIONS-004-RECORD",
+      "category": "invariant",
+      "given": "An endpoint, direction, runtime arity, relation property, type, dimension, or causal meaning is inferred.",
+      "when": "The record is validated.",
+      "expect": "ScientificPropertyInvented and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-004-AT-007",
+      "applies_to": "BUILD-RELATIONS-004-RECORD",
+      "category": "determinism",
+      "given": "Byte-equivalent valid structural inputs are supplied repeatedly.",
+      "when": "Construction is repeated.",
+      "expect": "Structurally identical outputs with identical participant and unresolved ordering.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-004-AT-008",
+      "applies_to": "BUILD-RELATIONS-004-RECORD",
+      "category": "preservation",
+      "given": "One of the 31 unresolved items is removed, altered, or defaulted.",
+      "when": "Unresolved propagation is validated.",
+      "expect": "UnresolvedPropagationLoss and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-004-AT-009",
+      "applies_to": "BUILD-RELATIONS-004-RECORD",
+      "category": "invariant",
+      "given": "Distinct or unresolved-review identities are fused.",
+      "when": "Identity preservation is validated.",
+      "expect": "IdentityMergeProhibited and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-004/contract.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-004/contract.json
@@ -1,0 +1,540 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-15-RELATIONS-004",
+    "title": "Opaque operator bundle structural record",
+    "domain": "relations"
+  },
+  "purpose": "Build and validate a deterministic structural record for the operator (admissible) while preserving scientific material as opaque and refusing relation evaluation.",
+  "scope": {
+    "required": [
+      {
+        "id": "R004-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-15-RELATIONS-004.",
+        "basis": [
+          "registry/optimized-ir/relations/TLC-FC-15-RELATIONS-004/ir.yaml"
+        ]
+      },
+      {
+        "id": "R004-REQ-002",
+        "statement": "Preserve exactly these participant identities in order: TLC-SO-RELATIONS-004, TLC-SO-RELATIONS-017, TLC-SO-RELATIONS-023.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-15-RELATIONS-004/contract.yaml",
+          "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml"
+        ]
+      },
+      {
+        "id": "R004-REQ-003",
+        "statement": "Preserve scope relations_004_three_function_blocks, context master_message_value_capacity_essential_functions, opaque source values, and exactly 31 unresolved items."
+      },
+      {
+        "id": "R004-REQ-004",
+        "statement": "Reject every request for scientific evaluation with ExternalRelationEvaluatorRequired."
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "R004-FOR-001",
+        "statement": "Do not create or evaluate a scientific relation, equation, invariant, operator, graph, membership, composition, inversion, projection, deduction, or causal result."
+      },
+      {
+        "id": "R004-FOR-002",
+        "statement": "Do not infer source, target, direction, runtime arity, properties, types, dimensions, thresholds, or numerical methods."
+      },
+      {
+        "id": "R004-FOR-003",
+        "statement": "Do not mutate opaque source values, reorder participants, or replace unresolved items with defaults."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "R004-DEF-001",
+        "statement": "Scientific relation semantics remain unresolved; external scientific decision evidence is TLC-DUP-RELATIONS-002 and TLC-GCYCLE-DOMAIN-001."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "BUILD-RELATIONS-004-RECORD",
+      "purpose": "Validate the exact structural inputs and emit a non-executable record guarded against scientific evaluation.",
+      "inputs": [
+        {
+          "name": "feature_id",
+          "semantic_role": "exact requested feature identity",
+          "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [
+              "TLC-FC-15-RELATIONS-004"
+            ],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          },
+          "constraints": [
+            {
+              "id": "R004-IN-001",
+              "statement": "Identity equals TLC-FC-15-RELATIONS-004."
+            }
+          ]
+        },
+        {
+          "name": "participants",
+          "semantic_role": "opaque scientific participants in authoritative order",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-RELATIONS-004",
+              "TLC-SO-RELATIONS-017",
+              "TLC-SO-RELATIONS-023"
+            ],
+            "cardinality": {
+              "minimum": 3,
+              "maximum": 3
+            },
+            "ordering": "preserved",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          }
+        },
+        {
+          "name": "opaque_source_values",
+          "semantic_role": "uninterpreted source equations, tuples, functions, or names",
+          "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "constrained",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": null
+            },
+            "ordering": "preserved",
+            "duplicates": "significant",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "unresolved_items",
+          "semantic_role": "exact 31-item unresolved set in authoritative order",
+          "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 31,
+              "maximum": 31
+            },
+            "ordering": "preserved",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "traceability",
+          "semantic_role": "complete upstream provenance",
+          "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0",
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "evaluation_request",
+          "semantic_role": "optional request that must be rejected when present",
+          "collection": {
+            "kind": "optional",
+            "membership": "open",
+            "cardinality": {
+              "minimum": 0,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "record",
+          "semantic_role": "validated non-executable Relations structural record",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "scope_id",
+              "required": true,
+              "semantic_role": "authoritative scope",
+              "constant": "relations_004_three_function_blocks"
+            },
+            {
+              "name": "context_id",
+              "required": true,
+              "semantic_role": "authoritative context",
+              "constant": "master_message_value_capacity_essential_functions"
+            },
+            {
+              "name": "opaque_payload",
+              "required": true,
+              "semantic_role": "uninterpreted preserved scientific material",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "non_execution_guard",
+              "required": true,
+              "semantic_role": "scientific evaluation prohibition",
+              "constant": "enabled"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "error",
+          "semantic_role": "stable transport-neutral failure",
+          "shared_contract_ref": "TLC-HC-STRUCTURED-ERROR@1.0.0",
+          "collection": {
+            "kind": "optional",
+            "membership": "constrained",
+            "cardinality": {
+              "minimum": 0,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "R004-PRE-001",
+          "statement": "Feature identity, participant references, scope, context, opaque values, and unresolved metadata are available."
+        },
+        {
+          "id": "R004-PRE-002",
+          "statement": "The caller requests structural construction or validation only."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "R004-POST-001",
+          "statement": "Successful output preserves identity, participants, order, scope, context, opaque values, and unresolved metadata exactly."
+        },
+        {
+          "id": "R004-POST-002",
+          "statement": "Successful output contains no scientific result and has the non-execution guard enabled."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "R004-INV-001",
+          "statement": "No source, target, direction, arity, relation property, or causality is added."
+        },
+        {
+          "id": "R004-INV-002",
+          "statement": "No observable partial record is published on failure."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact structural identity and preservation constraints",
+          "reject unsupported scientific evaluation",
+          "emit the guarded structural record"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact structural identity and preservation constraints",
+            "after": "emit the guarded structural record"
+          },
+          {
+            "before": "reject unsupported scientific evaluation",
+            "after": "emit the guarded structural record"
+          }
+        ],
+        "prescription_basis": [
+          "registry/algorithms/relations/TLC-FC-15-RELATIONS-004/algorithm.yaml"
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_required",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "FeatureIdentityMismatch",
+          "category": "identity",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingCoveredObject",
+          "category": "participants",
+          "condition": "A required participant is missing.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnexpectedCoveredObject",
+          "category": "participants",
+          "condition": "An undeclared participant is present.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "DuplicateCoveredObject",
+          "category": "participants",
+          "condition": "A participant identity is duplicated.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ObjectOrderMismatch",
+          "category": "participants",
+          "condition": "The participant order differs from the authoritative order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "source",
+          "condition": "A required participant source reference is unavailable.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScopeMismatch",
+          "category": "scope",
+          "condition": "The scope identifier differs from the authoritative scope.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ContextMismatch",
+          "category": "context",
+          "condition": "The context identifier differs from the authoritative context.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "OpaqueValueMutation",
+          "category": "preservation",
+          "condition": "Opaque source material differs in value or order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnresolvedPropagationLoss",
+          "category": "preservation",
+          "condition": "One or more unresolved items are absent or altered.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "IdentityMergeProhibited",
+          "category": "identity",
+          "condition": "Provisionally separated or duplicate-review identities are fused.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificPropertyInvented",
+          "category": "scientific",
+          "condition": "A relation property, arity, direction, endpoint, or causal meaning is asserted without authority.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ExternalRelationEvaluatorRequired",
+          "category": "unsupported",
+          "condition": "Scientific evaluation is requested from this structural-only package.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "informative",
+          "value": "O(n) over participants, opaque values, and unresolved items"
+        },
+        "auxiliary_memory": {
+          "status": "informative",
+          "value": "O(n) for the preserved structural record"
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-record",
+      "status": "required",
+      "statement": "Expose exact validation, preservation, inspection, and guarded record construction."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not produce scientific relation semantics or results."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal architecture is free when all observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "R004-GINV-001",
+      "statement": "Unresolved scientific semantics remain explicit and never become implementation defaults."
+    },
+    {
+      "id": "R004-GINV-002",
+      "statement": "The scientific source and all registry artifacts remain read-only provenance."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity."
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless participant references."
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered participant collection."
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Explicit unresolved reservations."
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific payloads."
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral failures."
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable upstream provenance."
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Observable structural record shape."
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance covers structural behavior only; semantic evaluation requires an external provider."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-004/manifest.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-004/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-15-RELATIONS-004",
+  "title": "Opaque operator bundle structural record",
+  "domain": "relations",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-004/traceability.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-004/traceability.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-15-RELATIONS-004",
+  "scientific_sources": [
+    {
+      "path": "maths/15-relations.md",
+      "role": "authoritative Relations scientific source"
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-15-RELATIONS-004/contract.yaml",
+      "role": "validated mathematical contract"
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-15-RELATIONS-004/ir.yaml",
+      "role": "canonical declarative source IR"
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/relations/TLC-FC-15-RELATIONS-004/ir.yaml",
+      "role": "selected structural implementation IR"
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/relations/TLC-FC-15-RELATIONS-004/algorithm.yaml",
+      "role": "structural algorithm input; total listed order is not imposed beyond observable constraints"
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-15-RELATIONS-004/test-plan.yaml",
+      "role": "upstream structural test plan"
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/relations/TLC-FC-15-RELATIONS-004/oracle.yaml",
+      "role": "structural acceptance oracle"
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/relations/feature-status.yaml",
+      "role": "authoritative domain finalization inventory; preserves TLC-DUP-RELATIONS-002 and TLC-GCYCLE-DOMAIN-001"
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-007/README.md
+++ b/handoff/features/TLC-FC-15-RELATIONS-007/README.md
@@ -1,0 +1,29 @@
+# TLC-FC-15-RELATIONS-007 — Opaque named-relation bundle structural record
+
+## What is this feature?
+
+This package defines the final implementable structural behavior for the Relations relation classified as `admissible`. It does not define executable scientific relation semantics.
+
+## What must be implemented?
+
+Implement exact validation and guarded construction of an immutable structural record. Preserve the feature identity, the 5 participant reference(s) in the declared order, scope `relations_007_five_named_relation_objects`, context `master_message_virtue_value_capacity_competence_relation_names`, opaque source material, and all 12 unresolved items.
+
+## Valid inputs and required output
+
+A valid request contains the exact feature ID, the exact ordered participants (TLC-SO-RELATIONS-002, TLC-SO-RELATIONS-009, TLC-SO-RELATIONS-015, TLC-SO-RELATIONS-021, TLC-SO-RELATIONS-027), resolvable source references, unchanged opaque values, complete unresolved metadata, and no request for semantic evaluation. Success returns a deterministic structural record with the non-execution guard enabled.
+
+## Mandatory and forbidden behavior
+
+Mandatory behavior is exact preservation, deterministic structural validation, stable errors, and rejection of unsupported evaluation. It is forbidden to invent endpoints, direction, runtime arity, relation properties, types, dimensions, thresholds, numeric methods, graphs, membership, composition, inversion, projection, deduction, or causality.
+
+## Implementation freedom
+
+Internal data structures, programming language, allocation, ownership transport, concurrency policy, and serialization format are implementation-defined provided observable preservation and error behavior remain conforming.
+
+## Observable errors
+
+The contract preserves the authoritative PascalCase errors, including `FeatureIdentityMismatch`, participant and preservation errors, `ScientificPropertyInvented`, and `ExternalRelationEvaluatorRequired`, plus `EndpointInferenceProhibited`.
+
+## Conformance and unresolved science
+
+All acceptance tests in `acceptance.json` must pass. Scientific evaluation remains `external_provider_required`; TLC-GCYCLE-DOMAIN-001 stays unresolved evidence and is not converted into a default.

--- a/handoff/features/TLC-FC-15-RELATIONS-007/acceptance.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-007/acceptance.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-15-RELATIONS-007",
+  "tests": [
+    {
+      "test_id": "TLC-FC-15-RELATIONS-007-AT-001",
+      "applies_to": "BUILD-RELATIONS-007-RECORD",
+      "category": "valid_input",
+      "given": "Exact identity, exact ordered participants, preserved opaque values, scope, context, and all unresolved items.",
+      "when": "The structural record operation is invoked.",
+      "expect": "A deterministic guarded record is returned with 5 participants and 12 unresolved items.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-007-AT-002",
+      "applies_to": "BUILD-RELATIONS-007-RECORD",
+      "category": "invalid_input",
+      "given": "A mismatched feature identity.",
+      "when": "Validation runs.",
+      "expect": "FeatureIdentityMismatch and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-007-AT-003",
+      "applies_to": "BUILD-RELATIONS-007-RECORD",
+      "category": "preservation",
+      "given": "A participant is missing, extra, duplicated, or reordered.",
+      "when": "Participant validation runs.",
+      "expect": "The corresponding authoritative participant error and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-007-AT-004",
+      "applies_to": "BUILD-RELATIONS-007-RECORD",
+      "category": "preservation",
+      "given": "Opaque values, scope, context, or source references are altered.",
+      "when": "Preservation validation runs.",
+      "expect": "The corresponding preservation error and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-007-AT-005",
+      "applies_to": "BUILD-RELATIONS-007-RECORD",
+      "category": "unsupported_operation",
+      "given": "A scientific evaluation, composition, inversion, projection, membership, graph, numeric, temporal, or causal operation is requested.",
+      "when": "The non-execution guard runs.",
+      "expect": "ExternalRelationEvaluatorRequired and no scientific output.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-007-AT-006",
+      "applies_to": "BUILD-RELATIONS-007-RECORD",
+      "category": "invariant",
+      "given": "An endpoint, direction, runtime arity, relation property, type, dimension, or causal meaning is inferred.",
+      "when": "The record is validated.",
+      "expect": "ScientificPropertyInvented and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-007-AT-007",
+      "applies_to": "BUILD-RELATIONS-007-RECORD",
+      "category": "determinism",
+      "given": "Byte-equivalent valid structural inputs are supplied repeatedly.",
+      "when": "Construction is repeated.",
+      "expect": "Structurally identical outputs with identical participant and unresolved ordering.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-007-AT-008",
+      "applies_to": "BUILD-RELATIONS-007-RECORD",
+      "category": "preservation",
+      "given": "One of the 12 unresolved items is removed, altered, or defaulted.",
+      "when": "Unresolved propagation is validated.",
+      "expect": "UnresolvedPropagationLoss and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-007-AT-009",
+      "applies_to": "BUILD-RELATIONS-007-RECORD",
+      "category": "unsupported_operation",
+      "given": "Endpoint identity is inferred from a name or participant position.",
+      "when": "Endpoint constraints are validated.",
+      "expect": "EndpointInferenceProhibited and no endpoint-bearing result.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-007/contract.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-007/contract.json
@@ -1,0 +1,542 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-15-RELATIONS-007",
+    "title": "Opaque named-relation bundle structural record",
+    "domain": "relations"
+  },
+  "purpose": "Build and validate a deterministic structural record for the relation (admissible) while preserving scientific material as opaque and refusing relation evaluation.",
+  "scope": {
+    "required": [
+      {
+        "id": "R007-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-15-RELATIONS-007.",
+        "basis": [
+          "registry/optimized-ir/relations/TLC-FC-15-RELATIONS-007/ir.yaml"
+        ]
+      },
+      {
+        "id": "R007-REQ-002",
+        "statement": "Preserve exactly these participant identities in order: TLC-SO-RELATIONS-002, TLC-SO-RELATIONS-009, TLC-SO-RELATIONS-015, TLC-SO-RELATIONS-021, TLC-SO-RELATIONS-027.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-15-RELATIONS-007/contract.yaml",
+          "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml"
+        ]
+      },
+      {
+        "id": "R007-REQ-003",
+        "statement": "Preserve scope relations_007_five_named_relation_objects, context master_message_virtue_value_capacity_competence_relation_names, opaque source values, and exactly 12 unresolved items."
+      },
+      {
+        "id": "R007-REQ-004",
+        "statement": "Reject every request for scientific evaluation with ExternalRelationEvaluatorRequired."
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "R007-FOR-001",
+        "statement": "Do not create or evaluate a scientific relation, equation, invariant, operator, graph, membership, composition, inversion, projection, deduction, or causal result."
+      },
+      {
+        "id": "R007-FOR-002",
+        "statement": "Do not infer source, target, direction, runtime arity, properties, types, dimensions, thresholds, or numerical methods."
+      },
+      {
+        "id": "R007-FOR-003",
+        "statement": "Do not mutate opaque source values, reorder participants, or replace unresolved items with defaults."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "R007-DEF-001",
+        "statement": "Scientific relation semantics remain unresolved; external scientific decision evidence is TLC-GCYCLE-DOMAIN-001."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "BUILD-RELATIONS-007-RECORD",
+      "purpose": "Validate the exact structural inputs and emit a non-executable record guarded against scientific evaluation.",
+      "inputs": [
+        {
+          "name": "feature_id",
+          "semantic_role": "exact requested feature identity",
+          "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [
+              "TLC-FC-15-RELATIONS-007"
+            ],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          },
+          "constraints": [
+            {
+              "id": "R007-IN-001",
+              "statement": "Identity equals TLC-FC-15-RELATIONS-007."
+            }
+          ]
+        },
+        {
+          "name": "participants",
+          "semantic_role": "opaque scientific participants in authoritative order",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-RELATIONS-002",
+              "TLC-SO-RELATIONS-009",
+              "TLC-SO-RELATIONS-015",
+              "TLC-SO-RELATIONS-021",
+              "TLC-SO-RELATIONS-027"
+            ],
+            "cardinality": {
+              "minimum": 5,
+              "maximum": 5
+            },
+            "ordering": "preserved",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          }
+        },
+        {
+          "name": "opaque_source_values",
+          "semantic_role": "uninterpreted source equations, tuples, functions, or names",
+          "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "constrained",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": null
+            },
+            "ordering": "preserved",
+            "duplicates": "significant",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "unresolved_items",
+          "semantic_role": "exact 12-item unresolved set in authoritative order",
+          "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 12,
+              "maximum": 12
+            },
+            "ordering": "preserved",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "traceability",
+          "semantic_role": "complete upstream provenance",
+          "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0",
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "evaluation_request",
+          "semantic_role": "optional request that must be rejected when present",
+          "collection": {
+            "kind": "optional",
+            "membership": "open",
+            "cardinality": {
+              "minimum": 0,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "record",
+          "semantic_role": "validated non-executable Relations structural record",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "scope_id",
+              "required": true,
+              "semantic_role": "authoritative scope",
+              "constant": "relations_007_five_named_relation_objects"
+            },
+            {
+              "name": "context_id",
+              "required": true,
+              "semantic_role": "authoritative context",
+              "constant": "master_message_virtue_value_capacity_competence_relation_names"
+            },
+            {
+              "name": "opaque_payload",
+              "required": true,
+              "semantic_role": "uninterpreted preserved scientific material",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "non_execution_guard",
+              "required": true,
+              "semantic_role": "scientific evaluation prohibition",
+              "constant": "enabled"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "error",
+          "semantic_role": "stable transport-neutral failure",
+          "shared_contract_ref": "TLC-HC-STRUCTURED-ERROR@1.0.0",
+          "collection": {
+            "kind": "optional",
+            "membership": "constrained",
+            "cardinality": {
+              "minimum": 0,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "R007-PRE-001",
+          "statement": "Feature identity, participant references, scope, context, opaque values, and unresolved metadata are available."
+        },
+        {
+          "id": "R007-PRE-002",
+          "statement": "The caller requests structural construction or validation only."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "R007-POST-001",
+          "statement": "Successful output preserves identity, participants, order, scope, context, opaque values, and unresolved metadata exactly."
+        },
+        {
+          "id": "R007-POST-002",
+          "statement": "Successful output contains no scientific result and has the non-execution guard enabled."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "R007-INV-001",
+          "statement": "No source, target, direction, arity, relation property, or causality is added."
+        },
+        {
+          "id": "R007-INV-002",
+          "statement": "No observable partial record is published on failure."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact structural identity and preservation constraints",
+          "reject unsupported scientific evaluation",
+          "emit the guarded structural record"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact structural identity and preservation constraints",
+            "after": "emit the guarded structural record"
+          },
+          {
+            "before": "reject unsupported scientific evaluation",
+            "after": "emit the guarded structural record"
+          }
+        ],
+        "prescription_basis": [
+          "registry/algorithms/relations/TLC-FC-15-RELATIONS-007/algorithm.yaml"
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_required",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "FeatureIdentityMismatch",
+          "category": "identity",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingCoveredObject",
+          "category": "participants",
+          "condition": "A required participant is missing.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnexpectedCoveredObject",
+          "category": "participants",
+          "condition": "An undeclared participant is present.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "DuplicateCoveredObject",
+          "category": "participants",
+          "condition": "A participant identity is duplicated.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ObjectOrderMismatch",
+          "category": "participants",
+          "condition": "The participant order differs from the authoritative order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "source",
+          "condition": "A required participant source reference is unavailable.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScopeMismatch",
+          "category": "scope",
+          "condition": "The scope identifier differs from the authoritative scope.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ContextMismatch",
+          "category": "context",
+          "condition": "The context identifier differs from the authoritative context.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "OpaqueValueMutation",
+          "category": "preservation",
+          "condition": "Opaque source material differs in value or order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnresolvedPropagationLoss",
+          "category": "preservation",
+          "condition": "One or more unresolved items are absent or altered.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "EndpointInferenceProhibited",
+          "category": "scientific",
+          "condition": "Source or target identity is inferred from names or ordering.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificPropertyInvented",
+          "category": "scientific",
+          "condition": "A relation property, arity, direction, endpoint, or causal meaning is asserted without authority.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ExternalRelationEvaluatorRequired",
+          "category": "unsupported",
+          "condition": "Scientific evaluation is requested from this structural-only package.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "informative",
+          "value": "O(n) over participants, opaque values, and unresolved items"
+        },
+        "auxiliary_memory": {
+          "status": "informative",
+          "value": "O(n) for the preserved structural record"
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-record",
+      "status": "required",
+      "statement": "Expose exact validation, preservation, inspection, and guarded record construction."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not produce scientific relation semantics or results."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal architecture is free when all observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "R007-GINV-001",
+      "statement": "Unresolved scientific semantics remain explicit and never become implementation defaults."
+    },
+    {
+      "id": "R007-GINV-002",
+      "statement": "The scientific source and all registry artifacts remain read-only provenance."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity."
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless participant references."
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered participant collection."
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Explicit unresolved reservations."
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific payloads."
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral failures."
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable upstream provenance."
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Observable structural record shape."
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance covers structural behavior only; semantic evaluation requires an external provider."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-007/manifest.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-007/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-15-RELATIONS-007",
+  "title": "Opaque named-relation bundle structural record",
+  "domain": "relations",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-007/traceability.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-007/traceability.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-15-RELATIONS-007",
+  "scientific_sources": [
+    {
+      "path": "maths/15-relations.md",
+      "role": "authoritative Relations scientific source"
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-15-RELATIONS-007/contract.yaml",
+      "role": "validated mathematical contract"
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-15-RELATIONS-007/ir.yaml",
+      "role": "canonical declarative source IR"
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/relations/TLC-FC-15-RELATIONS-007/ir.yaml",
+      "role": "selected structural implementation IR"
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/relations/TLC-FC-15-RELATIONS-007/algorithm.yaml",
+      "role": "structural algorithm input; total listed order is not imposed beyond observable constraints"
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-15-RELATIONS-007/test-plan.yaml",
+      "role": "upstream structural test plan"
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/relations/TLC-FC-15-RELATIONS-007/oracle.yaml",
+      "role": "structural acceptance oracle"
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/relations/feature-status.yaml",
+      "role": "authoritative domain finalization inventory; preserves TLC-GCYCLE-DOMAIN-001"
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-008/README.md
+++ b/handoff/features/TLC-FC-15-RELATIONS-008/README.md
@@ -1,0 +1,29 @@
+# TLC-FC-15-RELATIONS-008 — Provisional relation tuple bundle structural record
+
+## What is this feature?
+
+This package defines the final implementable structural behavior for the Relations relation classified as `provisionally_separated`. It does not define executable scientific relation semantics.
+
+## What must be implemented?
+
+Implement exact validation and guarded construction of an immutable structural record. Preserve the feature identity, the 2 participant reference(s) in the declared order, scope `relations_008_virtue_value_tuple_records`, context `master_virtue_and_master_value_formalizations`, opaque source material, and all 5 unresolved items.
+
+## Valid inputs and required output
+
+A valid request contains the exact feature ID, the exact ordered participants (TLC-SO-RELATIONS-014, TLC-SO-RELATIONS-020), resolvable source references, unchanged opaque values, complete unresolved metadata, and no request for semantic evaluation. Success returns a deterministic structural record with the non-execution guard enabled.
+
+## Mandatory and forbidden behavior
+
+Mandatory behavior is exact preservation, deterministic structural validation, stable errors, and rejection of unsupported evaluation. It is forbidden to invent endpoints, direction, runtime arity, relation properties, types, dimensions, thresholds, numeric methods, graphs, membership, composition, inversion, projection, deduction, or causality.
+
+## Implementation freedom
+
+Internal data structures, programming language, allocation, ownership transport, concurrency policy, and serialization format are implementation-defined provided observable preservation and error behavior remain conforming.
+
+## Observable errors
+
+The contract preserves the authoritative PascalCase errors, including `FeatureIdentityMismatch`, participant and preservation errors, `ScientificPropertyInvented`, and `ExternalRelationEvaluatorRequired`, plus `IdentityMergeProhibited`.
+
+## Conformance and unresolved science
+
+All acceptance tests in `acceptance.json` must pass. Scientific evaluation remains `external_provider_required`; TLC-HR-0074 stays unresolved evidence and is not converted into a default.

--- a/handoff/features/TLC-FC-15-RELATIONS-008/acceptance.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-008/acceptance.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-15-RELATIONS-008",
+  "tests": [
+    {
+      "test_id": "TLC-FC-15-RELATIONS-008-AT-001",
+      "applies_to": "BUILD-RELATIONS-008-RECORD",
+      "category": "valid_input",
+      "given": "Exact identity, exact ordered participants, preserved opaque values, scope, context, and all unresolved items.",
+      "when": "The structural record operation is invoked.",
+      "expect": "A deterministic guarded record is returned with 2 participants and 5 unresolved items.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-008-AT-002",
+      "applies_to": "BUILD-RELATIONS-008-RECORD",
+      "category": "invalid_input",
+      "given": "A mismatched feature identity.",
+      "when": "Validation runs.",
+      "expect": "FeatureIdentityMismatch and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-008-AT-003",
+      "applies_to": "BUILD-RELATIONS-008-RECORD",
+      "category": "preservation",
+      "given": "A participant is missing, extra, duplicated, or reordered.",
+      "when": "Participant validation runs.",
+      "expect": "The corresponding authoritative participant error and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-008-AT-004",
+      "applies_to": "BUILD-RELATIONS-008-RECORD",
+      "category": "preservation",
+      "given": "Opaque values, scope, context, or source references are altered.",
+      "when": "Preservation validation runs.",
+      "expect": "The corresponding preservation error and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-008-AT-005",
+      "applies_to": "BUILD-RELATIONS-008-RECORD",
+      "category": "unsupported_operation",
+      "given": "A scientific evaluation, composition, inversion, projection, membership, graph, numeric, temporal, or causal operation is requested.",
+      "when": "The non-execution guard runs.",
+      "expect": "ExternalRelationEvaluatorRequired and no scientific output.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-008-AT-006",
+      "applies_to": "BUILD-RELATIONS-008-RECORD",
+      "category": "invariant",
+      "given": "An endpoint, direction, runtime arity, relation property, type, dimension, or causal meaning is inferred.",
+      "when": "The record is validated.",
+      "expect": "ScientificPropertyInvented and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-008-AT-007",
+      "applies_to": "BUILD-RELATIONS-008-RECORD",
+      "category": "determinism",
+      "given": "Byte-equivalent valid structural inputs are supplied repeatedly.",
+      "when": "Construction is repeated.",
+      "expect": "Structurally identical outputs with identical participant and unresolved ordering.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-008-AT-008",
+      "applies_to": "BUILD-RELATIONS-008-RECORD",
+      "category": "preservation",
+      "given": "One of the 5 unresolved items is removed, altered, or defaulted.",
+      "when": "Unresolved propagation is validated.",
+      "expect": "UnresolvedPropagationLoss and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml"
+      ]
+    },
+    {
+      "test_id": "TLC-FC-15-RELATIONS-008-AT-009",
+      "applies_to": "BUILD-RELATIONS-008-RECORD",
+      "category": "invariant",
+      "given": "Distinct or unresolved-review identities are fused.",
+      "when": "Identity preservation is validated.",
+      "expect": "IdentityMergeProhibited and no partial record.",
+      "source_basis": [
+        "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml"
+      ]
+    }
+  ]
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-008/contract.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-008/contract.json
@@ -1,0 +1,539 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature": {
+    "feature_id": "TLC-FC-15-RELATIONS-008",
+    "title": "Provisional relation tuple bundle structural record",
+    "domain": "relations"
+  },
+  "purpose": "Build and validate a deterministic structural record for the relation (provisionally_separated) while preserving scientific material as opaque and refusing relation evaluation.",
+  "scope": {
+    "required": [
+      {
+        "id": "R008-REQ-001",
+        "statement": "Accept only feature identity TLC-FC-15-RELATIONS-008.",
+        "basis": [
+          "registry/optimized-ir/relations/TLC-FC-15-RELATIONS-008/ir.yaml"
+        ]
+      },
+      {
+        "id": "R008-REQ-002",
+        "statement": "Preserve exactly these participant identities in order: TLC-SO-RELATIONS-014, TLC-SO-RELATIONS-020.",
+        "basis": [
+          "registry/math-contracts/TLC-FC-15-RELATIONS-008/contract.yaml",
+          "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml"
+        ]
+      },
+      {
+        "id": "R008-REQ-003",
+        "statement": "Preserve scope relations_008_virtue_value_tuple_records, context master_virtue_and_master_value_formalizations, opaque source values, and exactly 5 unresolved items."
+      },
+      {
+        "id": "R008-REQ-004",
+        "statement": "Reject every request for scientific evaluation with ExternalRelationEvaluatorRequired."
+      }
+    ],
+    "forbidden": [
+      {
+        "id": "R008-FOR-001",
+        "statement": "Do not create or evaluate a scientific relation, equation, invariant, operator, graph, membership, composition, inversion, projection, deduction, or causal result."
+      },
+      {
+        "id": "R008-FOR-002",
+        "statement": "Do not infer source, target, direction, runtime arity, properties, types, dimensions, thresholds, or numerical methods."
+      },
+      {
+        "id": "R008-FOR-003",
+        "statement": "Do not mutate opaque source values, reorder participants, or replace unresolved items with defaults."
+      }
+    ],
+    "deferred": [
+      {
+        "id": "R008-DEF-001",
+        "statement": "Scientific relation semantics remain unresolved; external scientific decision evidence is TLC-HR-0074."
+      }
+    ]
+  },
+  "operations": [
+    {
+      "operation_id": "BUILD-RELATIONS-008-RECORD",
+      "purpose": "Validate the exact structural inputs and emit a non-executable record guarded against scientific evaluation.",
+      "inputs": [
+        {
+          "name": "feature_id",
+          "semantic_role": "exact requested feature identity",
+          "shared_contract_ref": "TLC-HC-FEATURE-ID@1.0.0",
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "members": [
+              "TLC-FC-15-RELATIONS-008"
+            ],
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          },
+          "constraints": [
+            {
+              "id": "R008-IN-001",
+              "statement": "Identity equals TLC-FC-15-RELATIONS-008."
+            }
+          ]
+        },
+        {
+          "name": "participants",
+          "semantic_role": "opaque scientific participants in authoritative order",
+          "shared_contract_ref": "TLC-HC-REFERENCE-COLLECTION@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "exact",
+            "members": [
+              "TLC-SO-RELATIONS-014",
+              "TLC-SO-RELATIONS-020"
+            ],
+            "cardinality": {
+              "minimum": 2,
+              "maximum": 2
+            },
+            "ordering": "preserved",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": {
+              "shared_contract_ref": "TLC-HC-SCIENTIFIC-REFERENCE@1.0.0"
+            }
+          }
+        },
+        {
+          "name": "opaque_source_values",
+          "semantic_role": "uninterpreted source equations, tuples, functions, or names",
+          "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "constrained",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": null
+            },
+            "ordering": "preserved",
+            "duplicates": "significant",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "unresolved_items",
+          "semantic_role": "exact 5-item unresolved set in authoritative order",
+          "shared_contract_ref": "TLC-HC-UNRESOLVED-ITEM@1.0.0",
+          "collection": {
+            "kind": "sequence",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 5,
+              "maximum": 5
+            },
+            "ordering": "preserved",
+            "duplicates": "forbidden",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "traceability",
+          "semantic_role": "complete upstream provenance",
+          "shared_contract_ref": "TLC-HC-TRACEABILITY@1.0.0",
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "evaluation_request",
+          "semantic_role": "optional request that must be rejected when present",
+          "collection": {
+            "kind": "optional",
+            "membership": "open",
+            "cardinality": {
+              "minimum": 0,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "record",
+          "semantic_role": "validated non-executable Relations structural record",
+          "shared_contract_ref": "TLC-HC-DESCRIPTOR-ENVELOPE@1.0.0",
+          "fields": [
+            {
+              "name": "scope_id",
+              "required": true,
+              "semantic_role": "authoritative scope",
+              "constant": "relations_008_virtue_value_tuple_records"
+            },
+            {
+              "name": "context_id",
+              "required": true,
+              "semantic_role": "authoritative context",
+              "constant": "master_virtue_and_master_value_formalizations"
+            },
+            {
+              "name": "opaque_payload",
+              "required": true,
+              "semantic_role": "uninterpreted preserved scientific material",
+              "shared_contract_ref": "TLC-HC-OPAQUE-VALUE@1.0.0"
+            },
+            {
+              "name": "non_execution_guard",
+              "required": true,
+              "semantic_role": "scientific evaluation prohibition",
+              "constant": "enabled"
+            }
+          ],
+          "collection": {
+            "kind": "scalar",
+            "membership": "exact",
+            "cardinality": {
+              "minimum": 1,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        },
+        {
+          "name": "error",
+          "semantic_role": "stable transport-neutral failure",
+          "shared_contract_ref": "TLC-HC-STRUCTURED-ERROR@1.0.0",
+          "collection": {
+            "kind": "optional",
+            "membership": "constrained",
+            "cardinality": {
+              "minimum": 0,
+              "maximum": 1
+            },
+            "ordering": "not_applicable",
+            "duplicates": "not_applicable",
+            "key_contract": null,
+            "value_contract": null
+          }
+        }
+      ],
+      "preconditions": [
+        {
+          "id": "R008-PRE-001",
+          "statement": "Feature identity, participant references, scope, context, opaque values, and unresolved metadata are available."
+        },
+        {
+          "id": "R008-PRE-002",
+          "statement": "The caller requests structural construction or validation only."
+        }
+      ],
+      "postconditions": [
+        {
+          "id": "R008-POST-001",
+          "statement": "Successful output preserves identity, participants, order, scope, context, opaque values, and unresolved metadata exactly."
+        },
+        {
+          "id": "R008-POST-002",
+          "statement": "Successful output contains no scientific result and has the non-execution guard enabled."
+        }
+      ],
+      "invariants": [
+        {
+          "id": "R008-INV-001",
+          "statement": "No source, target, direction, arity, relation property, or causality is added."
+        },
+        {
+          "id": "R008-INV-002",
+          "statement": "No observable partial record is published on failure."
+        }
+      ],
+      "strategy_contract": {
+        "mode": "partially_constrained",
+        "steps": [
+          "validate exact structural identity and preservation constraints",
+          "reject unsupported scientific evaluation",
+          "emit the guarded structural record"
+        ],
+        "partial_order": [
+          {
+            "before": "validate exact structural identity and preservation constraints",
+            "after": "emit the guarded structural record"
+          },
+          {
+            "before": "reject unsupported scientific evaluation",
+            "after": "emit the guarded structural record"
+          }
+        ],
+        "prescription_basis": [
+          "registry/algorithms/relations/TLC-FC-15-RELATIONS-008/algorithm.yaml"
+        ]
+      },
+      "runtime_contract": {
+        "mutability": "immutable",
+        "result_ownership": "implementation_defined",
+        "input_retention": "not_required",
+        "input_change_visibility": "not_visible",
+        "lifetime": "implementation_defined",
+        "aliasing": "not_constrained",
+        "layout": "not_constrained",
+        "contiguity": "not_required",
+        "alignment": "not_required",
+        "address_stability": "not_required",
+        "copy_semantics": "not_constrained",
+        "move_semantics": "not_constrained",
+        "allocation": "implementation_defined",
+        "zero_copy": "not_required",
+        "thread_safety": "implementation_defined",
+        "reentrancy": "implementation_defined",
+        "failure_atomicity": "no_observable_partial_result"
+      },
+      "determinism": {
+        "semantic_output": "required",
+        "field_presence": "required",
+        "collection_order": "required",
+        "canonical_serialization": "not_required",
+        "binary_layout": "not_constrained",
+        "memory_address": "not_constrained",
+        "allocation_pattern": "not_constrained",
+        "concurrent_scheduling": "implementation_defined",
+        "floating_point": "not_applicable",
+        "randomness": "not_applicable"
+      },
+      "error_contract": [
+        {
+          "code": "FeatureIdentityMismatch",
+          "category": "identity",
+          "condition": "The feature identity is not the exact package identity.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingCoveredObject",
+          "category": "participants",
+          "condition": "A required participant is missing.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnexpectedCoveredObject",
+          "category": "participants",
+          "condition": "An undeclared participant is present.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "DuplicateCoveredObject",
+          "category": "participants",
+          "condition": "A participant identity is duplicated.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ObjectOrderMismatch",
+          "category": "participants",
+          "condition": "The participant order differs from the authoritative order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "MissingSourceReference",
+          "category": "source",
+          "condition": "A required participant source reference is unavailable.",
+          "recoverability": "retryable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScopeMismatch",
+          "category": "scope",
+          "condition": "The scope identifier differs from the authoritative scope.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ContextMismatch",
+          "category": "context",
+          "condition": "The context identifier differs from the authoritative context.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "OpaqueValueMutation",
+          "category": "preservation",
+          "condition": "Opaque source material differs in value or order.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "UnresolvedPropagationLoss",
+          "category": "preservation",
+          "condition": "One or more unresolved items are absent or altered.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "IdentityMergeProhibited",
+          "category": "identity",
+          "condition": "Provisionally separated or duplicate-review identities are fused.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ScientificPropertyInvented",
+          "category": "scientific",
+          "condition": "A relation property, arity, direction, endpoint, or causal meaning is asserted without authority.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        },
+        {
+          "code": "ExternalRelationEvaluatorRequired",
+          "category": "unsupported",
+          "condition": "Scientific evaluation is requested from this structural-only package.",
+          "recoverability": "recoverable",
+          "public_result": "no_partial_result",
+          "failure_atomicity": "no_observable_partial_result",
+          "transport": "implementation_defined"
+        }
+      ],
+      "resource_contract": {
+        "time_complexity": {
+          "status": "informative",
+          "value": "O(n) over participants, opaque values, and unresolved items"
+        },
+        "auxiliary_memory": {
+          "status": "informative",
+          "value": "O(n) for the preserved structural record"
+        },
+        "allocations": {
+          "status": "implementation_defined",
+          "value": null
+        },
+        "maximum_input_size": {
+          "status": "not_constrained",
+          "value": null
+        }
+      }
+    }
+  ],
+  "implementation_modes": [
+    {
+      "mode_id": "structural-record",
+      "status": "required",
+      "statement": "Expose exact validation, preservation, inspection, and guarded record construction."
+    },
+    {
+      "mode_id": "scientific-evaluation",
+      "status": "forbidden",
+      "statement": "Do not produce scientific relation semantics or results."
+    },
+    {
+      "mode_id": "alternative-internal-architecture",
+      "status": "allowed",
+      "statement": "Internal architecture is free when all observable obligations remain satisfied."
+    }
+  ],
+  "global_invariants": [
+    {
+      "id": "R008-GINV-001",
+      "statement": "Unresolved scientific semantics remain explicit and never become implementation defaults."
+    },
+    {
+      "id": "R008-GINV-002",
+      "statement": "The scientific source and all registry artifacts remain read-only provenance."
+    }
+  ],
+  "dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0",
+      "purpose": "Exact feature identity."
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0",
+      "purpose": "Lossless participant references."
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0",
+      "purpose": "Exact ordered participant collection."
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0",
+      "purpose": "Explicit unresolved reservations."
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0",
+      "purpose": "Uninterpreted scientific payloads."
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0",
+      "purpose": "Stable transport-neutral failures."
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0",
+      "purpose": "Resolvable upstream provenance."
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0",
+      "purpose": "Observable structural record shape."
+    }
+  ],
+  "conformance": {
+    "acceptance_required": true,
+    "all_required_tests_must_pass": true,
+    "forbidden_behavior_is_nonconforming": true,
+    "notes": [
+      "Conformance covers structural behavior only; semantic evaluation requires an external provider."
+    ]
+  }
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-008/manifest.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-008/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "feature_id": "TLC-FC-15-RELATIONS-008",
+  "title": "Provisional relation tuple bundle structural record",
+  "domain": "relations",
+  "statuses": {
+    "package": "finalized",
+    "scientific": "preserved_unresolved",
+    "execution": "structural_only"
+  },
+  "files": [
+    "README.md",
+    "manifest.json",
+    "contract.json",
+    "acceptance.json",
+    "traceability.json"
+  ],
+  "shared_dependencies": [
+    {
+      "shared_contract_id": "TLC-HC-FEATURE-ID",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-SCIENTIFIC-REFERENCE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-REFERENCE-COLLECTION",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-UNRESOLVED-ITEM",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-OPAQUE-VALUE",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-STRUCTURED-ERROR",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-TRACEABILITY",
+      "version": "1.0.0"
+    },
+    {
+      "shared_contract_id": "TLC-HC-DESCRIPTOR-ENVELOPE",
+      "version": "1.0.0"
+    }
+  ],
+  "examples": {
+    "present": false,
+    "file": null
+  },
+  "reference_integrity": {
+    "repository_relative_paths_only": true,
+    "all_declared_files_required": true,
+    "dependency_resolution_required": true
+  }
+}

--- a/handoff/features/TLC-FC-15-RELATIONS-008/traceability.json
+++ b/handoff/features/TLC-FC-15-RELATIONS-008/traceability.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1.0",
+  "package_version": "1.0.0",
+  "applies_to": "TLC-FC-15-RELATIONS-008",
+  "scientific_sources": [
+    {
+      "path": "maths/15-relations.md",
+      "role": "authoritative Relations scientific source"
+    }
+  ],
+  "mathematical_contracts": [
+    {
+      "path": "registry/math-contracts/TLC-FC-15-RELATIONS-008/contract.yaml",
+      "role": "validated mathematical contract"
+    }
+  ],
+  "source_irs": [
+    {
+      "path": "registry/ir/TLC-FC-15-RELATIONS-008/ir.yaml",
+      "role": "canonical declarative source IR"
+    }
+  ],
+  "finalized_irs": [
+    {
+      "path": "registry/optimized-ir/relations/TLC-FC-15-RELATIONS-008/ir.yaml",
+      "role": "selected structural implementation IR"
+    }
+  ],
+  "algorithm_specifications": [
+    {
+      "path": "registry/algorithms/relations/TLC-FC-15-RELATIONS-008/algorithm.yaml",
+      "role": "structural algorithm input; total listed order is not imposed beyond observable constraints"
+    }
+  ],
+  "test_plans": [
+    {
+      "path": "registry/test-plans/TLC-FC-15-RELATIONS-008/test-plan.yaml",
+      "role": "upstream structural test plan"
+    }
+  ],
+  "acceptance_oracles": [
+    {
+      "path": "registry/oracles/relations/TLC-FC-15-RELATIONS-008/oracle.yaml",
+      "role": "structural acceptance oracle"
+    }
+  ],
+  "scientific_decisions": [
+    {
+      "path": "registry/domain-finalization/relations/feature-status.yaml",
+      "role": "authoritative domain finalization inventory; preserves TLC-HR-0074"
+    }
+  ]
+}

--- a/reports/handoff/relations/ambiguities.json
+++ b/reports/handoff/relations/ambiguities.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1.0",
+  "domain": "relations",
+  "ambiguities": [
+    {
+      "id": "REL-AMB-001",
+      "classification": "scientific_unresolved",
+      "features": [
+        "TLC-FC-15-RELATIONS-002",
+        "TLC-FC-15-RELATIONS-003",
+        "TLC-FC-15-RELATIONS-004",
+        "TLC-FC-15-RELATIONS-007",
+        "TLC-FC-15-RELATIONS-008"
+      ],
+      "status": "preserved_unresolved",
+      "description": "All scientific relation evaluation semantics are unavailable; only structural records and guards are executable."
+    },
+    {
+      "id": "REL-AMB-002",
+      "classification": "ordering_uncertain",
+      "features": [
+        "TLC-FC-15-RELATIONS-002",
+        "TLC-FC-15-RELATIONS-003",
+        "TLC-FC-15-RELATIONS-004",
+        "TLC-FC-15-RELATIONS-007",
+        "TLC-FC-15-RELATIONS-008"
+      ],
+      "status": "resolved_for_observable_behavior",
+      "description": "Participant and opaque-value order is normative; full algorithm step order is not imposed beyond required validation-before-output constraints."
+    },
+    {
+      "id": "REL-AMB-003",
+      "classification": "runtime_semantics_unspecified",
+      "features": [
+        "TLC-FC-15-RELATIONS-002",
+        "TLC-FC-15-RELATIONS-003",
+        "TLC-FC-15-RELATIONS-004",
+        "TLC-FC-15-RELATIONS-007",
+        "TLC-FC-15-RELATIONS-008"
+      ],
+      "status": "implementation_defined",
+      "description": "Ownership, allocation, layout, thread safety, reentrancy, and serialization remain unconstrained or implementation-defined."
+    },
+    {
+      "id": "REL-AMB-004",
+      "classification": "source_conflict",
+      "features": [
+        "TLC-FC-15-RELATIONS-004"
+      ],
+      "status": "preserved_unresolved",
+      "description": "TLC-DUP-RELATIONS-002 remains unmerged and no scientific identity fusion is performed."
+    },
+    {
+      "id": "REL-AMB-005",
+      "classification": "scientific_unresolved",
+      "features": [
+        "TLC-FC-15-RELATIONS-007"
+      ],
+      "status": "preserved_unresolved",
+      "description": "Endpoint identity cannot be inferred from relation names or ordering."
+    }
+  ]
+}

--- a/reports/handoff/relations/generation-report.md
+++ b/reports/handoff/relations/generation-report.md
@@ -22,4 +22,4 @@ The union of package dependencies is exactly the eight existing handoff shared c
 
 ## Validation
 
-Population and scope reviews are complete. Machine validation is pending the Feature handoff validation workflow and will be updated before merge.
+Population and scope reviews are complete. GitHub Actions `Feature handoff validation` run 95 passed on the complete five-package population; a final validation pass is required after recording this evidence.

--- a/reports/handoff/relations/generation-report.md
+++ b/reports/handoff/relations/generation-report.md
@@ -1,0 +1,25 @@
+# Relations Feature Handoff Package generation report
+
+## Outcome
+
+Compiled five autonomous Feature Handoff Package v1.0 directories in authoritative inventory order: TLC-FC-15-RELATIONS-002, TLC-FC-15-RELATIONS-003, TLC-FC-15-RELATIONS-004, TLC-FC-15-RELATIONS-007, TLC-FC-15-RELATIONS-008.
+
+All packages are finalized for structural implementation and preserve scientific execution as unresolved. No scientific source, upstream registry artifact, schema, shared contract, global catalog, validator, workflow, or implementation code is modified by this domain change.
+
+## Compilation decisions
+
+- Preserved authoritative non-contiguous feature nomenclature: 002, 003, 004, 007, and 008.
+- Preserved PascalCase upstream error names.
+- Required participant and opaque-value ordering is normative.
+- Treated algorithm step lists as compilation inputs; only observable validation-before-output constraints are retained as partial order.
+- Declared all five semantic evaluation paths external-provider-required.
+- Preserved unresolved populations of 5, 5, 31, 12, and 5 respectively.
+- Preserved TLC-DUP-RELATIONS-002, TLC-GCYCLE-DOMAIN-001, TLC-HR-0054, and TLC-HR-0074 without scientific interpretation.
+
+## Shared contract review
+
+The union of package dependencies is exactly the eight existing handoff shared contracts. One Relations structural non-execution pattern is recorded as candidate-only; no shared contract was created or changed.
+
+## Validation
+
+Population and scope reviews are complete. Machine validation is pending the Feature handoff validation workflow and will be updated before merge.

--- a/reports/handoff/relations/shared-contract-candidates.json
+++ b/reports/handoff/relations/shared-contract-candidates.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0",
+  "domain": "relations",
+  "candidates": [
+    {
+      "candidate_id": "RELATIONS-STRUCTURAL-NON-EXECUTION-GUARD",
+      "observed_features": [
+        "TLC-FC-15-RELATIONS-002",
+        "TLC-FC-15-RELATIONS-003",
+        "TLC-FC-15-RELATIONS-004",
+        "TLC-FC-15-RELATIONS-007",
+        "TLC-FC-15-RELATIONS-008"
+      ],
+      "local_structures": [
+        "exact ordered participant validation",
+        "opaque value preservation",
+        "unresolved propagation",
+        "external evaluator rejection"
+      ],
+      "possible_sharing_reason": "The five packages repeat a Relations-specific structural guard pattern.",
+      "semantic_merge_risks": "Features differ in participant populations, opaque payload shapes, unresolved counts, identity-fusion rules, and endpoint restrictions.",
+      "proposed_decision": "Keep local until multiple completed domains demonstrate equivalent semantics.",
+      "status": "candidate_only"
+    }
+  ]
+}

--- a/reports/handoff/relations/validation-report.json
+++ b/reports/handoff/relations/validation-report.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "domain": "relations",
+  "status": "pending_ci",
+  "population": {
+    "expected": 5,
+    "produced": 5,
+    "foreign_packages": 0
+  },
+  "checks": {
+    "json_schema": "pending_ci",
+    "inter_file_consistency": "pending_ci",
+    "shared_dependency_resolution": "pending_ci",
+    "identifier_uniqueness": "pending_ci",
+    "error_consistency": "pending_ci",
+    "authoritative_inventory": "pending_ci",
+    "scientific_non_invention": "reviewed",
+    "implementation_code_absence": "reviewed",
+    "protected_paths": "reviewed"
+  },
+  "validator": "tools/handoff/validate_handoff.py",
+  "source_commit": "f3f4881cf6de85e6b09b4be65dde34f253bd1b04",
+  "notes": [
+    "The authoritative inventory count key is authoritative_feature_count and is supported by merged progressive-validation infrastructure.",
+    "Final pass status will be recorded after GitHub Actions succeeds."
+  ]
+}

--- a/reports/handoff/relations/validation-report.json
+++ b/reports/handoff/relations/validation-report.json
@@ -1,27 +1,34 @@
 {
   "schema_version": "1.0",
   "domain": "relations",
-  "status": "pending_ci",
+  "status": "passed",
   "population": {
     "expected": 5,
     "produced": 5,
     "foreign_packages": 0
   },
   "checks": {
-    "json_schema": "pending_ci",
-    "inter_file_consistency": "pending_ci",
-    "shared_dependency_resolution": "pending_ci",
-    "identifier_uniqueness": "pending_ci",
-    "error_consistency": "pending_ci",
-    "authoritative_inventory": "pending_ci",
-    "scientific_non_invention": "reviewed",
-    "implementation_code_absence": "reviewed",
-    "protected_paths": "reviewed"
+    "json_schema": "passed",
+    "inter_file_consistency": "passed",
+    "shared_dependency_resolution": "passed",
+    "identifier_uniqueness": "passed",
+    "error_consistency": "passed",
+    "authoritative_inventory": "passed",
+    "scientific_non_invention": "passed",
+    "implementation_code_absence": "passed",
+    "protected_paths": "passed"
   },
   "validator": "tools/handoff/validate_handoff.py",
-  "source_commit": "f3f4881cf6de85e6b09b4be65dde34f253bd1b04",
+  "source_commit": "7ed8d26d2e014e65ea06eec9c2337d9f4a7ef905",
   "notes": [
-    "The authoritative inventory count key is authoritative_feature_count and is supported by merged progressive-validation infrastructure.",
-    "Final pass status will be recorded after GitHub Actions succeeds."
-  ]
+    "Authoritative inventory and all five non-contiguous feature IDs validated without renaming.",
+    "The compatibility alias fix was merged separately before this successful domain validation."
+  ],
+  "workflow": {
+    "name": "Feature handoff validation",
+    "run_id": 30281379797,
+    "run_number": 95,
+    "conclusion": "success",
+    "validated_head": "e00c5a5d0d621c26614f56a3e8487fdd5d5a1706"
+  }
 }


### PR DESCRIPTION
## Domain
Relations (index 15)

## Population
Expected: 5
Produced: 5

Authoritative order:
- TLC-FC-15-RELATIONS-002
- TLC-FC-15-RELATIONS-003
- TLC-FC-15-RELATIONS-004
- TLC-FC-15-RELATIONS-007
- TLC-FC-15-RELATIONS-008

## Files
- Five autonomous Feature Handoff Package v1.0 directories (25 files)
- handoff/domains/relations/catalog.json
- Four reports under reports/handoff/relations/

## Preserved ambiguities
All five packages remain structural-only and require an external scientific evaluator. Endpoint identity, direction, runtime arity, relation properties, types, dimensions, and causal meaning are not inferred. TLC-DUP-RELATIONS-002, TLC-GCYCLE-DOMAIN-001, TLC-HR-0054, and TLC-HR-0074 remain unresolved evidence.

## Shared contract candidates
One candidate-only Relations structural non-execution guard pattern is recorded. No shared contract was created or modified.

## Validation
Population, traceability, scope, non-invention, protected-path, and implementation-code reviews are recorded. Merge is gated on a successful `Feature handoff validation` workflow.

No scientific source or upstream artifact was modified. No implementation code was added. Schemas, shared contracts, the global handoff catalog, validator, and workflows are unchanged by this domain PR.

## Summary by Sourcery

Add structural-only handoff packages for five Relations domain features and record their compilation and validation state without changing schemas, shared contracts, or implementation code.

New Features:
- Introduce five finalized Relations Feature Handoff Package v1.0 directories for features TLC-FC-15-RELATIONS-002, -003, -004, -007, and -008 with manifests, contracts, acceptance criteria, and traceability metadata.
- Add a Relations domain handoff catalog entry and generation, ambiguity, shared-contract-candidate, and validation reports documenting the compiled feature packages and preserved unresolved scientific evidence.

Documentation:
- Document the behavior, required implementation, and error contracts for each of the five Relations structural feature packages in dedicated README files.