### PR TITLE
fix(handoff): align compatibility feature count aliases

### DIFF
--- a/reports/handoff/infrastructure/compat-authoritative-feature-count-alias.md
+++ b/reports/handoff/infrastructure/compat-authoritative-feature-count-alias.md
@@ -1,0 +1,3 @@
+# Compatibility feature-count alias alignment
+
+The compatibility validator now accepts `authoritative_feature_count`, matching the core validator and the established Relations authoritative inventory. Existing aliases and all count-equality checks remain unchanged. No inventory, scientific artifact, schema, shared contract, package, or domain semantics is modified.

--- a/tools/handoff/validate_handoff_compat.py
+++ b/tools/handoff/validate_handoff_compat.py
@@ -52,7 +52,7 @@ def validate_authoritative_inventory(domain: str, catalog: dict[str, Any]) -> No
 
     declared_counts = [
         inventory[key]
-        for key in ("feature_count", "population_count", "active_feature_count", "expected_count")
+        for key in ("feature_count", "population_count", "active_feature_count", "expected_count", "authoritative_feature_count")
         if key in inventory
     ]
     summary = inventory.get("summary")


### PR DESCRIPTION
Align the CI compatibility validator with the core progressive validator by accepting the established `authoritative_feature_count` inventory key. Existing aliases and equality validation are preserved. No scientific inventory, schema, shared contract, package, workflow, or domain semantics is modified.

## Summary by Sourcery

Align the handoff compatibility validator with the core validator by recognizing the authoritative feature count alias without changing existing equality semantics or domain behavior.

New Features:
- Support the authoritative_feature_count key as an additional alias for feature-count validation in the handoff compatibility checker.

Documentation:
- Add a short infrastructure report documenting acceptance of the authoritative_feature_count alias and confirming unchanged semantics.