### PR TITLE
fix(handoff): support historical inventory population shapes

### DIFF
--- a/reports/handoff/infrastructure/historical-inventory-compatibility.md
+++ b/reports/handoff/infrastructure/historical-inventory-compatibility.md
@@ -1,0 +1,28 @@
+# Historical authoritative-inventory compatibility
+
+## Scope
+
+This infrastructure change extends the existing compatibility layer used by Feature Handoff Package v1.0 validation. It does not modify scientific sources, feature identities, feature statuses, package contracts, domain catalogs, schemas, shared contracts, or runtime behavior.
+
+## Accepted historical shapes
+
+The compatibility validator accepts authoritative `features` populations in either of the repository's established forms:
+
+- a list of objects containing `feature_id`;
+- an insertion-ordered mapping keyed by `feature_id`.
+
+The extracted order remains authoritative and is compared exactly with the domain catalog.
+
+## Count aliases
+
+Every count alias present in an authoritative inventory is checked against the real extracted population. Established root aliases include `feature_count`, `population_count`, `active_feature_count`, `authoritative_feature_count`, `authoritative_population_count`, `expected_count`, `expected_active_count`, `expected_feature_count`, and `expected_active_feature_count`. Established summary aliases are also checked when present.
+
+When an inventory contains no count field, the validator may read the sibling domain-finalization manifest. Any manifest population used as evidence must match the authoritative inventory exactly and in order, and every recognized manifest count must equal that same population.
+
+## Conflict policy
+
+No alias is preferred over another. Missing evidence, non-integer values, conflicting values, wrong population order, or a mismatch with the actual feature population causes validation failure. Historical metadata compatibility never changes or normalizes a `feature_id`.
+
+## Verification
+
+Compatibility self-tests cover list-form features, mapping-form features, agreeing count aliases, and rejection of conflicting count aliases. The existing progressive validator checks and all package, schema, traceability, dependency, strategy, identity, and no-implementation-code controls remain active.

--- a/tools/handoff/validate_handoff_compat.py
+++ b/tools/handoff/validate_handoff_compat.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Run the handoff validator with backward-compatible domain metadata normalization."""
+"""Run the handoff validator with backward-compatible inventory normalization."""
 
 from __future__ import annotations
 
-from pathlib import Path
+import sys
 from typing import Any
 
 import validate_handoff as core
@@ -11,9 +11,35 @@ import validate_handoff as core
 
 _original_feature_identity = core.feature_identity
 
+ROOT_COUNT_KEYS = (
+    "feature_count",
+    "population_count",
+    "active_feature_count",
+    "authoritative_feature_count",
+    "authoritative_population_count",
+    "expected_count",
+    "expected_active_count",
+    "expected_feature_count",
+    "expected_active_feature_count",
+)
+SUMMARY_COUNT_KEYS = (
+    "active_features",
+    "selected_features",
+    "feature_count",
+    "population_count",
+)
+MANIFEST_COUNT_PATHS = (
+    ("feature_count",),
+    ("population_count",),
+    ("expected_feature_count",),
+    ("expected_active_feature_count",),
+    ("baseline", "expected_feature_count"),
+    ("baseline", "expected_active_feature_count"),
+)
+
 
 def feature_identity(feature_id: str) -> tuple[int, str]:
-    """Normalize historical `-de-tl` identifier tokens when an authoritative domain exists."""
+    """Normalize historical ``-de-tl`` identifier tokens only when reversible."""
     domain_index, identifier_domain = _original_feature_identity(feature_id)
     suffix = "-de-tl"
     if identifier_domain.endswith(suffix):
@@ -24,8 +50,76 @@ def feature_identity(feature_id: str) -> tuple[int, str]:
     return domain_index, identifier_domain
 
 
+def authoritative_feature_ids(inventory: dict[str, Any], domain: str) -> list[str]:
+    """Read either historical list-form or insertion-ordered mapping-form features."""
+    features = inventory.get("features")
+    if isinstance(features, list):
+        identifiers = [item.get("feature_id") for item in features if isinstance(item, dict)]
+        if len(identifiers) != len(features) or any(not isinstance(item, str) for item in identifiers):
+            core.fail(f"authoritative inventory contains an invalid feature entry for domain {domain}")
+        return identifiers
+    if isinstance(features, dict):
+        identifiers = list(features)
+        if any(not isinstance(item, str) for item in identifiers) or any(
+            not isinstance(value, dict) for value in features.values()
+        ):
+            core.fail(f"authoritative inventory contains an invalid feature mapping for domain {domain}")
+        return identifiers
+    core.fail(f"authoritative inventory has no feature list or mapping for domain {domain}")
+
+
+def inventory_declared_counts(inventory: dict[str, Any]) -> list[Any]:
+    """Collect every established count alias present in the authoritative inventory."""
+    counts = [inventory[key] for key in ROOT_COUNT_KEYS if key in inventory]
+    summary = inventory.get("summary")
+    if isinstance(summary, dict):
+        counts.extend(summary[key] for key in SUMMARY_COUNT_KEYS if key in summary)
+    return counts
+
+
+def nested_value(document: dict[str, Any], path: tuple[str, ...]) -> tuple[bool, Any]:
+    current: Any = document
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return False, None
+        current = current[key]
+    return True, current
+
+
+def manifest_fallback_counts(domain: str, authoritative_ids: list[str]) -> list[Any]:
+    """Use a sibling finalization manifest only when the inventory has no count field."""
+    manifest_path = core.ROOT / "registry" / "domain-finalization" / domain / "manifest.yaml"
+    if not manifest_path.is_file():
+        return []
+    manifest = core.load_yaml(manifest_path)
+    if not isinstance(manifest, dict):
+        core.fail(f"domain finalization manifest is not an object for domain {domain}")
+
+    population = manifest.get("population")
+    if population is not None:
+        if not isinstance(population, list) or any(not isinstance(item, str) for item in population):
+            core.fail(f"domain finalization manifest has an invalid population for domain {domain}")
+        if population != authoritative_ids:
+            core.fail(f"domain finalization manifest population differs from authoritative inventory for {domain}")
+
+    counts: list[Any] = []
+    for path in MANIFEST_COUNT_PATHS:
+        present, value = nested_value(manifest, path)
+        if present:
+            counts.append(value)
+    return counts
+
+
+def validate_counts(domain: str, values: list[Any], actual_count: int) -> None:
+    """Require every supplied alias to be an integer equal to the real population."""
+    if not values or any(
+        isinstance(value, bool) or not isinstance(value, int) or value != actual_count for value in values
+    ):
+        core.fail(f"authoritative inventory feature count mismatch for domain {domain}")
+
+
 def validate_authoritative_inventory(domain: str, catalog: dict[str, Any]) -> None:
-    """Validate an inventory while accepting established non-scientific count aliases."""
+    """Validate historical metadata without weakening exact population comparison."""
     inventory_value = catalog["metadata"]["authoritative_inventory"]
     expected_value = f"registry/domain-finalization/{domain}/feature-status.yaml"
     if inventory_value != expected_value:
@@ -41,25 +135,11 @@ def validate_authoritative_inventory(domain: str, catalog: dict[str, Any]) -> No
     if not declared_domains or any(value != domain for value in declared_domains):
         core.fail(f"authoritative inventory domain mismatch for {domain}")
 
-    authoritative_features = inventory.get("features")
-    if not isinstance(authoritative_features, list):
-        core.fail(f"authoritative inventory has no feature list for domain {domain}")
-    authoritative_ids = [item.get("feature_id") for item in authoritative_features if isinstance(item, dict)]
-    if len(authoritative_ids) != len(authoritative_features) or any(
-        not isinstance(item, str) for item in authoritative_ids
-    ):
-        core.fail(f"authoritative inventory contains an invalid feature entry for domain {domain}")
-
-    declared_counts = [
-        inventory[key]
-        for key in ("feature_count", "population_count", "active_feature_count", "expected_count", "authoritative_feature_count")
-        if key in inventory
-    ]
-    summary = inventory.get("summary")
-    if isinstance(summary, dict) and "active_features" in summary:
-        declared_counts.append(summary["active_features"])
-    if not declared_counts or any(value != len(authoritative_ids) for value in declared_counts):
-        core.fail(f"authoritative inventory feature count mismatch for domain {domain}")
+    authoritative_ids = authoritative_feature_ids(inventory, domain)
+    declared_counts = inventory_declared_counts(inventory)
+    if not declared_counts:
+        declared_counts = manifest_fallback_counts(domain, authoritative_ids)
+    validate_counts(domain, declared_counts, len(authoritative_ids))
 
     if catalog["ordered_feature_ids"] != authoritative_ids:
         core.fail(f"domain catalog population or order differs from authoritative inventory for {domain}")
@@ -75,12 +155,30 @@ def validate_authoritative_inventory(domain: str, catalog: dict[str, Any]) -> No
                 core.fail(f"authoritative feature artifact is missing: {artifact.relative_to(core.ROOT)}")
 
 
+def run_compatibility_self_tests() -> None:
+    """Exercise historical list, mapping, and conflicting-count shapes."""
+    list_inventory = {"features": [{"feature_id": "A"}, {"feature_id": "B"}]}
+    mapping_inventory = {"features": {"A": {}, "B": {}}}
+    if authoritative_feature_ids(list_inventory, "test-list") != ["A", "B"]:
+        core.fail("compatibility self-test I failed for list-form features")
+    if authoritative_feature_ids(mapping_inventory, "test-mapping") != ["A", "B"]:
+        core.fail("compatibility self-test J failed for mapping-form features")
+    validate_counts("test-counts", [2, 2], 2)
+    core.expect_failure(
+        lambda: validate_counts("test-conflict", [2, 3], 2),
+        "K conflicting historical count aliases",
+    )
+    print("Inventory compatibility logical self-tests I-K passed.")
+
+
 core.feature_identity = feature_identity
 core.validate_authoritative_inventory = validate_authoritative_inventory
 
 
 if __name__ == "__main__":
     try:
+        if sys.argv[1:] == ["--self-test"]:
+            run_compatibility_self_tests()
         raise SystemExit(core.entrypoint())
     except core.ValidationFailure as exc:
         print(f"ERROR: {exc}", file=core.sys.stderr)


### PR DESCRIPTION
## Purpose

Extend the existing Feature Handoff compatibility validator for two authoritative metadata shapes already present in the repository:

- ordered feature mappings, as used by Principle;
- count evidence held by the sibling finalization manifest when `feature-status.yaml` contains no counter, as used by Message.

## Guarantees

- list-form and insertion-ordered mapping-form populations are both read without changing feature identities;
- catalog order must exactly equal the authoritative order;
- every recognized count alias present must be an integer equal to the real population;
- a manifest fallback is used only when the inventory itself has no count field;
- any manifest population used as evidence must match the authoritative population exactly and in order;
- conflicting or missing evidence remains a hard failure.

## Scope

Only `tools/handoff/validate_handoff_compat.py` and an infrastructure rationale report are changed. No scientific source, registry inventory, domain package, schema, shared contract, global catalog, workflow, or implementation code is modified.

## Tests

Compatibility self-tests add coverage for list-form populations, mapping-form populations, agreeing aliases, and rejection of conflicting aliases. All existing progressive validation scenarios remain active.

## Summary by Sourcery

Extend the handoff compatibility validator to support historical authoritative inventory shapes and stricter, alias-aware population count validation, while documenting the infrastructure rationale.

Enhancements:
- Support authoritative inventory features defined as either lists of feature objects or insertion-ordered mappings keyed by feature_id.
- Unify and harden validation of multiple historical count aliases in inventories, with an optional manifest-based fallback when no counts are declared.
- Add internal compatibility self-tests for list and mapping inventory shapes plus conflicting count scenarios, and wire a --self-test entrypoint for the validator script.

Documentation:
- Add an infrastructure report documenting accepted historical inventory shapes, count alias handling, conflict policy, and verification approach.

Tests:
- Introduce logical self-tests for historical inventory population forms, agreeing count aliases, and rejection of conflicting aliases, keeping existing progressive scenarios intact.