### PR TITLE
fix(validation): recognize official handoff workflow

### DIFF
--- a/tools/global-finalization/validate_global_finalization.py
+++ b/tools/global-finalization/validate_global_finalization.py
@@ -62,6 +62,10 @@ FORBIDDEN_PREFIXES = (
     "registry/global-reconciliation/",
 )
 FORBIDDEN_SUFFIXES = (".cpp", ".cc", ".cxx", ".hpp", ".hxx", ".so", ".pyd")
+ALLOWED_VALIDATION_WORKFLOWS = {
+    ".github/workflows/global-finalization.yml",
+    ".github/workflows/handoff.yml",
+}
 EXPECTED_MANIFEST_STATUS = "status: integrated_structural_specification_finalized"
 EXPECTED_LIBRARY_STATUS = "status: structurally_finalized_engineering_specification"
 EXPECTED_SCIENTIFIC_DECISION_COUNT = "scientific_decision_count: 147"
@@ -187,8 +191,10 @@ def main() -> None:
         if path.endswith(".status")
         or "__pycache__" in path
         or path.endswith(".log")
-        or path.startswith(".github/workflows/")
-        and "global-finalization" not in path
+        or (
+            path.startswith(".github/workflows/")
+            and path not in ALLOWED_VALIDATION_WORKFLOWS
+        )
     ]
     if temporary:
         fail(f"temporary or unrelated integration artifacts found: {temporary}")


### PR DESCRIPTION
## Failure addressed

Final publication PR #123 passed the complete Feature Handoff validation, including all 166 deterministic exports, but the older `Global finalization validation` integrity job rejected `.github/workflows/handoff.yml` as a temporary or unrelated workflow.

The changed-file audit confirms that `handoff.yml` is the only additional workflow in the publication. It is now the permanent official Feature Handoff Package v1.0 validator and has independently passed its full final run.

## Correction

`tools/global-finalization/validate_global_finalization.py` now allows exactly two permanent validation workflows:

- `.github/workflows/global-finalization.yml`
- `.github/workflows/handoff.yml`

Every other changed workflow remains rejected. The correction also makes the boolean grouping explicit.

## Protections preserved

This does not change or weaken:

- the fixed global-finalization baseline;
- protected scientific source prefixes;
- the exact 16-domain / 166-IR / 166-algorithm / 166-oracle counts;
- the 147 preserved scientific decisions;
- legacy identifier rejection;
- runtime implementation suffix rejection;
- `.status`, log, cache, and unrelated workflow rejection;
- `git diff --check`.

No scientific artifact, handoff package, catalog, report, or implementation code is modified.

After squash merge, PR #123 will rerun both the complete handoff workflow and the global integrity workflow on the updated integration head.

## Summary by Sourcery

Bug Fixes:
- Treat the handoff validation workflow as a valid permanent workflow instead of rejecting it as temporary or unrelated.