### PR TITLE
docs: establish production-grade repository experience

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/Tradition-Learning-Community/tllib-specs/security
+    about: Report validator bypasses, integrity failures, or other sensitive security concerns privately.
+  - name: Contribution guide
+    url: https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/CONTRIBUTING.md
+    about: Review roles, authority boundaries, validation, and contribution workflow before proposing a change.

--- a/.github/ISSUE_TEMPLATE/handoff-consumer-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/handoff-consumer-feedback.yml
@@ -1,0 +1,71 @@
+name: Handoff consumer feedback
+description: Report an implementation-facing ambiguity or missing obligation from a standalone bundle.
+title: "handoff: "
+labels: ["handoff-feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form is for downstream implementers consuming `feature/`, `shared/`, and `bundle-lock.json`. Implementation-specific build or platform defects belong downstream unless the handoff is the root cause.
+  - type: input
+    id: feature
+    attributes:
+      label: Feature ID
+      placeholder: TLC-FC-00-MASTER-005
+    validations:
+      required: true
+  - type: input
+    id: fingerprint
+    attributes:
+      label: Bundle fingerprint
+      description: Aggregate bundle hash or exact commit and package version.
+    validations:
+      required: true
+  - type: input
+    id: language
+    attributes:
+      label: Implementation context
+      description: Language and relevant runtime model, only to explain the consumer perspective.
+      placeholder: C++23, Rust stable, Ruby 3.x, another target
+    validations:
+      required: true
+  - type: textarea
+    id: decision
+    attributes:
+      label: Decision that could not be derived
+      description: Identify the input, output, lifetime, ownership, error, ordering, determinism, resource, or conformance question left ambiguous.
+    validations:
+      required: true
+  - type: textarea
+    id: consulted
+    attributes:
+      label: Bundle artifacts consulted
+      description: List the exact feature and shared files reviewed.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Competing conforming interpretations
+      description: Describe at least two plausible interpretations when possible and why the bundle does not distinguish them.
+  - type: dropdown
+    id: result
+    attributes:
+      label: Consequence
+      options:
+        - Implementation is blocked
+        - Multiple observably different implementations appear conforming
+        - Acceptance tests cannot be derived
+        - Low-level guarantee is unclear
+        - Documentation is unclear but contract is sufficient
+    validations:
+      required: true
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope confirmation
+      options:
+        - label: This is a handoff specification concern, not only a downstream build or coding issue.
+          required: true
+        - label: I have not asked the specification to mandate a language-specific design without observable need.
+          required: true

--- a/.github/ISSUE_TEMPLATE/scientific-question.yml
+++ b/.github/ISSUE_TEMPLATE/scientific-question.yml
@@ -1,0 +1,57 @@
+name: Scientific or mathematical question
+description: Clarify scientific meaning, equations, domains, assumptions, proofs, or unresolved semantics.
+title: "science: "
+labels: ["scientific-question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for questions of scientific or mathematical authority. Do not propose implementation defaults for missing science.
+  - type: input
+    id: source
+    attributes:
+      label: Scientific source
+      description: Exact repository path and section, equation, symbol, or statement.
+      placeholder: maths/05-dynamics.md, section ...
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Question or ambiguity
+      description: State precisely what is undefined, inconsistent, disputed, or in need of clarification.
+    validations:
+      required: true
+  - type: textarea
+    id: features
+    attributes:
+      label: Affected feature IDs
+      description: List known feature IDs and domains. Explain uncertainty when the population is not yet known.
+    validations:
+      required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Current impact
+      options:
+        - Blocks scientific execution
+        - Blocks structural finalization
+        - Creates contradictory observable behavior
+        - Non-blocking clarification
+        - Unknown
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or proposed adjudication
+      description: Provide references, derivation, counterexample, or a bounded proposal. Separate evidence from preference.
+  - type: checkboxes
+    id: boundary
+    attributes:
+      label: Scientific boundary
+      options:
+        - label: I have not filled the gap with an implementation convenience or unsupported default.
+          required: true
+        - label: I have distinguished known facts from unresolved interpretation.
+          required: true

--- a/.github/ISSUE_TEMPLATE/specification-defect.yml
+++ b/.github/ISSUE_TEMPLATE/specification-defect.yml
@@ -1,0 +1,71 @@
+name: Specification contradiction or defect
+description: Report incompatible obligations, broken traceability, malformed packages, or validation gaps.
+title: "spec: "
+labels: ["specification-defect"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Report the smallest reproducible contradiction or defect. Preserve unresolved semantics rather than selecting a convenient meaning.
+  - type: input
+    id: feature
+    attributes:
+      label: Feature ID or shared contract
+      placeholder: TLC-FC-00-MASTER-005 or TLC-HC-STRUCTURED-ERROR
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Commit, package version, or bundle hash
+      description: Provide the exact artifact identity used.
+    validations:
+      required: true
+  - type: textarea
+    id: files
+    attributes:
+      label: Conflicting or defective files
+      description: List exact paths, fields, operation IDs, test IDs, or traceability entries.
+    validations:
+      required: true
+  - type: textarea
+    id: defect
+    attributes:
+      label: Defect description
+      description: Explain the incompatible obligations, missing information, malformed structure, or validator false acceptance/rejection.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Minimal reproduction
+      description: Include the smallest input, acceptance conflict, command, or bundle fragment that demonstrates the problem.
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Impact
+      options:
+        - Blocks implementation of one feature
+        - Risks incorrect implementation
+        - Breaks deterministic export or validation
+        - Breaks cross-domain consistency
+        - Documentation or traceability only
+        - Unknown
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected repository behavior
+      description: Describe the expected structural or validation outcome without inventing scientific semantics.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I identified the exact affected artifact rather than reporting only a general concern.
+          required: true
+        - label: I did not resolve the contradiction by choosing an unsupported scientific interpretation.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,84 @@
+## Purpose
+
+Describe the problem and the repository outcome this pull request delivers.
+
+## Change class
+
+- [ ] Editorial only
+- [ ] Structural, non-behavioral
+- [ ] Observable handoff contract change
+- [ ] Algorithmic specification change
+- [ ] Mathematical or scientific change
+- [ ] Validation or tooling change
+- [ ] Cross-domain change
+
+## Scope
+
+Affected domains:
+
+Affected feature IDs:
+
+Affected repository layers:
+
+- [ ] `maths/`
+- [ ] `registry/math-contracts/`
+- [ ] `registry/ir/` or `registry/optimized-ir/`
+- [ ] `registry/algorithms/`
+- [ ] `registry/oracles/`
+- [ ] `handoff/`
+- [ ] `reports/`
+- [ ] `tools/` or workflows
+- [ ] documentation only
+
+## Authority and traceability
+
+Identify the scientific source, contract, decision record, issue, or existing artifact that authorizes the change.
+
+## Scientific boundary
+
+State what remains unresolved. Confirm that no missing equation, type, domain, threshold, relation meaning, proof result, provider behavior, or scientific default was invented.
+
+- [ ] No unresolved scientific question was silently resolved.
+- [ ] Distinct concepts were not merged solely because they share a representation.
+- [ ] Illustrative algorithm steps were not promoted to normative total order without authority.
+
+## Observable impact
+
+Describe changes to valid inputs, outputs, errors, invariants, ordering, determinism, resources, examples, or implementation freedom.
+
+- [ ] No observable handoff obligation changes.
+- [ ] Observable changes are listed above and have compatibility treatment.
+
+## Compatibility and migration
+
+State package-version impact, downstream consumer impact, deprecations, substitutions, and migration steps. Write `Not applicable` only with a reason.
+
+## Validation evidence
+
+Commands or CI runs:
+
+```text
+<validation evidence>
+```
+
+For handoff changes, confirm as applicable:
+
+- [ ] deterministic catalog check passed;
+- [ ] official handoff validator passed;
+- [ ] logical self-tests passed;
+- [ ] all relevant standalone exports passed determinism checks;
+- [ ] no generated archive or temporary artifact was committed.
+
+## Reviewer focus
+
+Call out the highest-risk assumptions, files, or decisions that need close review.
+
+## Completion checklist
+
+- [ ] The change is focused and free of unrelated formatting churn.
+- [ ] Every affected layer is updated or explicitly declared unaffected.
+- [ ] Traceability is complete.
+- [ ] README or example prose introduces no obligation absent from normative contracts.
+- [ ] No runtime implementation code was added.
+- [ ] Documentation reflects the final repository state.
+- [ ] All review threads and required checks are resolved.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,224 @@
+# Contributing to `tllib-specs`
+
+`tllib-specs` is the authoritative specification repository for the TLC model. It is not a runtime implementation repository. Contributions are accepted when they improve scientific clarity, mathematical precision, algorithmic contracts, traceability, validation, or the language-neutral Feature Handoff Packages without inventing unresolved science.
+
+## Choose the right contribution path
+
+| Contributor role | Start here | Typical output | Must not do |
+|---|---|---|---|
+| Scientist or domain expert | `maths/`, scientific review inventory, traceability | clarified source statement, evidence, explicit unresolved question, adjudication proposal | silently rewrite implementation contracts without source impact analysis |
+| Mathematician | `registry/math-contracts/`, source references, invariants | formal definition, domain/codomain, assumptions, proof obligation, counterexample | infer missing equations, types, domains, thresholds, or truth values |
+| Algorithm designer | `registry/algorithms/`, finalized IR, oracles | observable algorithmic obligation, admissible strategy family, partial-order constraint, complexity requirement when justified | turn an illustrative step list into a mandatory total order without authority |
+| Specification engineer | `registry/`, `handoff/`, schemas, validators | traceable contract transformation, consistency repair, deterministic tooling | merge distinct concepts because they share a representation |
+| Runtime implementer | exported bundle from `handoff/` | issue against an ambiguous or contradictory handoff package | add production C++, Rust, Ruby, Python, bindings, solvers, or runtime code here |
+| Reviewer or auditor | changed feature chain and validation reports | contradiction report, traceability review, non-invention review, validation evidence | approve by directory count alone or ignore unresolved semantics |
+
+## Repository layers
+
+```text
+maths/          scientific authority
+registry/       compiler-like intermediate specification pipeline
+handoff/        final language-neutral programmer interface
+reports/        audit evidence and reconciliation records
+tools/          deterministic validation, catalog, and export tooling
+```
+
+A downstream programmer normally starts with a resolved bundle containing `feature/`, `shared/`, and `bundle-lock.json`. The upstream layers remain available for audit and scientific review.
+
+## Contribution classes
+
+### 1. Scientific clarification
+
+Use this path when a source statement, equation, concept, domain, relation, proof, or scientific decision needs clarification.
+
+Required evidence:
+
+- exact scientific source path and section;
+- affected feature IDs;
+- whether the proposal resolves, narrows, or only documents an ambiguity;
+- consequences for contracts, IRs, algorithms, or oracles;
+- explicit statement that no unrelated feature semantics change.
+
+A scientific clarification is not complete until downstream traceability is updated or an explicit follow-up is recorded.
+
+### 2. Mathematical contract change
+
+A mathematical change must identify:
+
+- definitions and symbols affected;
+- assumptions and domains;
+- input and output meaning;
+- invariants and failure conditions;
+- proof obligations or unresolved proof status;
+- backward compatibility or versioning consequences.
+
+Do not use convenient implementation defaults to fill mathematical gaps.
+
+### 3. Algorithmic specification change
+
+Separate three things explicitly:
+
+1. observable behavior;
+2. scientifically or numerically required ordering;
+3. internal implementation strategy.
+
+Use `open`, `partially_constrained`, or `prescribed` strategy semantics according to the actual authority. Performance constraints are normative only when justified by the specification, not merely desirable.
+
+### 4. Handoff package correction
+
+A handoff change must preserve the authority order documented in `handoff/README.md` and keep the package autonomous for downstream implementation.
+
+For every affected feature, check:
+
+- `manifest.json` identity and statuses;
+- `contract.json` observable obligations;
+- `acceptance.json` conformance coverage;
+- `traceability.json` source completeness;
+- optional examples classification;
+- shared-contract dependency closure;
+- deterministic catalog and bundle fingerprints.
+
+The root README, feature README, or example cannot create a normative obligation absent from the structured contracts.
+
+### 5. Tooling or validation change
+
+Validation changes require adversarial tests. A validator must reject malformed or misleading artifacts rather than merely accept the current repository.
+
+At minimum, consider:
+
+- false acceptance;
+- false rejection;
+- duplicate or reordered identities;
+- unresolved dependency paths;
+- status inconsistency;
+- non-deterministic output;
+- implementation-language leakage;
+- protected-source modification;
+- synthetic feature creation.
+
+`tools/handoff/validate_handoff.py` remains the sole official handoff validation CLI.
+
+## Workflow
+
+1. Open or identify a focused issue when the change is scientific, cross-domain, normative, or potentially breaking.
+2. Create a branch from current `main`.
+3. Keep the change within one coherent concern.
+4. Update every affected layer or explicitly document why a layer is unchanged.
+5. Run the relevant validators.
+6. Open a pull request using the repository template.
+7. Address all review threads and validation failures.
+8. Merge only after required checks succeed.
+
+Recommended branch prefixes:
+
+```text
+science/
+math/
+algorithm/
+spec/
+handoff/
+validation/
+docs/
+```
+
+## Required validation
+
+For handoff-related changes:
+
+```bash
+python tools/handoff/generate_catalog.py --check
+python tools/handoff/validate_handoff.py
+python tools/handoff/validate_handoff.py --self-test
+python tools/handoff/export_bundle.py --all --check --verify-determinism
+```
+
+For global specification changes, also run the global finalization validator documented by the repository workflows.
+
+## Pull request quality standard
+
+A production-quality pull request is:
+
+- narrow enough to review;
+- complete across affected layers;
+- explicit about unresolved science;
+- deterministic;
+- traceable to source authority;
+- free of unrelated formatting churn;
+- free of runtime implementation code;
+- accompanied by evidence, not only assertions.
+
+The pull request description must state:
+
+- what changed and why;
+- affected domains and feature IDs;
+- scientific authority used;
+- unresolved items preserved;
+- validation commands or CI runs;
+- compatibility and migration impact;
+- whether any public handoff obligation changed.
+
+## Review standard
+
+Reviewers should evaluate four independent dimensions:
+
+### Scientific integrity
+
+Does the change accurately represent the source? Were unknowns left unknown?
+
+### Structural correctness
+
+Are identities, dependencies, ordering, statuses, and schemas coherent?
+
+### Implementation neutrality
+
+Does the contract define observable behavior without choosing an unjustified language, container, allocation strategy, layout, or error transport?
+
+### Verifiability
+
+Can acceptance tests and validators detect a non-conforming implementation or package?
+
+Approval in one dimension does not substitute for review in another.
+
+## Contradictions
+
+When two authoritative artifacts appear contradictory:
+
+1. stop the affected finalization or implementation path;
+2. record the exact files, fields, and obligations in conflict;
+3. preserve current statuses;
+4. provide a minimal reproducer or conflicting acceptance cases;
+5. request scientific or specification adjudication;
+6. do not choose the most convenient meaning.
+
+## Backward compatibility and versioning
+
+Treat the following as potentially breaking:
+
+- changing observable behavior;
+- changing valid or invalid input sets;
+- changing required output fields;
+- changing stable error codes;
+- strengthening lifetime, ordering, determinism, or resource obligations;
+- changing shared-contract meaning;
+- removing a feature, operation, mode, or normative fixture.
+
+A breaking proposal must state the affected package versions, migration path, and replacement or deprecation policy.
+
+## Security and responsible disclosure
+
+Specification defects may create downstream safety or integrity risks. Follow `SECURITY.md` for sensitive reports. Do not publish exploit details in a public issue before maintainers have assessed the impact.
+
+## What belongs elsewhere
+
+The following belong in downstream implementation repositories:
+
+- runtime source code;
+- bindings;
+- build-system integration;
+- concrete memory ownership conventions;
+- platform-specific optimizations;
+- binary packaging;
+- production benchmarks;
+- release artifacts.
+
+An implementation problem that reveals a specification ambiguity should be reported here with the affected feature ID and bundle fingerprint.

--- a/README.md
+++ b/README.md
@@ -4,42 +4,56 @@
 
 **Language-neutral scientific and engineering specifications for the TLC model.**
 
-[Feature handoff](handoff/) · [Global catalog](handoff/catalog.json) · [Validation](#validation) · [Export](#export-a-standalone-bundle) · [Scientific boundary](#scientific-boundary)
+[Feature handoff](handoff/) · [Global catalog](handoff/catalog.json) · [Contributor guide](CONTRIBUTING.md) · [Repository guide](docs/REPOSITORY-GUIDE.md) · [Validation](#validation) · [Security](SECURITY.md)
 
 </div>
 
-## Finalized scope
+## Production status
 
-`tllib-specs` contains specifications, not a runtime library. Its finalized Feature Handoff Package v1.0 output covers:
+`tllib-specs` is the authoritative specification repository for the TLC model. It contains specifications, validation, traceability, and language-neutral handoff packages—not a runtime library.
 
-| Artifact | Finalized population |
+| Published artifact | Finalized population |
 |---|---:|
 | Domain catalogs | **16** |
-| Feature packages | **166** |
+| Feature Handoff Packages | **166** |
 | Shared structural contracts | **8** |
 | Standalone exports validated by CI | **166** |
 
-The model is independent of C++, Rust, Ruby, Python, or any other implementation language. No production implementation, binding, solver, kernel, package, or release archive belongs in this repository.
+Feature Handoff Package v1.0 is finalized. The published model is independent of C++, Rust, Ruby, Python, or any other implementation language. Production runtime code, bindings, solvers, kernels, binary packages, and release archives belong in downstream implementation repositories.
 
-## Where programmers start
+## Choose your path
 
-[`handoff/`](handoff/) is the final engineering output of this repository. A downstream programmer normally starts from a resolved standalone bundle containing:
+### Scientist or domain expert
 
-```text
-feature/
-shared/
-bundle-lock.json
-```
+Start with the authoritative text under [`maths/`](maths/), then identify the affected feature IDs and scientific review records. Clarify meaning, evidence, unresolved questions, and scientific authority without introducing software defaults.
 
-The feature package states observable behavior, inputs, outputs, invariants, errors, forbidden behavior, acceptance tests, traceability, and implementation freedoms. `shared/` contains the exact versioned structural dependencies needed by that feature. `bundle-lock.json` fixes paths, versions, and SHA-256 fingerprints without a volatile timestamp.
+### Mathematician
 
-Ordinary implementation should not require the programmer to interpret the mathematical sources or intermediate registry pipeline. Those upstream files remain available for audit, contradiction handling, and scientific review.
+Start with [`registry/math-contracts/`](registry/math-contracts/) and the referenced scientific source. Work on definitions, assumptions, domains, invariants, proof obligations, and formal consistency. Missing mathematical semantics remain explicit.
+
+### Algorithm designer
+
+Start with [`registry/algorithms/`](registry/algorithms/), the finalized IR, and the corresponding oracle. Distinguish observable behavior, required partial order, and internal strategy. An upstream step list is not automatically a mandatory total runtime sequence.
+
+### Specification engineer
+
+Work across `registry/`, `handoff/`, schemas, catalogs, reports, and validators. Preserve identity, provenance, unresolved semantics, deterministic outputs, and language neutrality. Shared representation does not establish scientific equivalence.
+
+### Runtime implementer
+
+Start from a resolved standalone bundle exported from [`handoff/`](handoff/). Ordinary implementation should not require interpretation of the mathematical sources or intermediate pipeline. Report handoff ambiguities with the feature ID and bundle fingerprint.
+
+### Reviewer or auditor
+
+Review scientific integrity, structural correctness, implementation neutrality, and verifiability as separate dimensions. Use the committed reports and deterministic fingerprints as evidence.
+
+Detailed role boundaries and workflows are in [`CONTRIBUTING.md`](CONTRIBUTING.md) and the [`Repository operating guide`](docs/REPOSITORY-GUIDE.md).
 
 ## Repository architecture
 
 ```text
 maths/                         authoritative scientific source texts
-registry/                      intermediate specification pipeline
+registry/                      compiler-like intermediate specification pipeline
   math-contracts/              mathematical contracts
   ir/                          source intermediate representations
   test-plans/                  source test plans
@@ -56,26 +70,61 @@ handoff/                       final language-neutral programmer interface
   catalog.json                 deterministic global catalog
 reports/handoff/               domain and global audit evidence
 tools/handoff/                 official validation, catalog, and export tools
+docs/                          contributor operations and decision records
 ```
 
-`registry/` is not the normal downstream API. It is the compiler-like intermediate pipeline that preserves scientific authority and explains how each final package was derived. `handoff/` is the published result.
+The repository functions as a controlled transformation system:
 
-## What a feature package means
+```text
+scientific authority
+    → mathematical contracts
+    → source IR
+    → finalized engineering IR
+    → algorithm specifications
+    → acceptance oracles
+    → Feature Handoff Packages
+    → standalone implementation bundles
+```
 
-Every feature directory contains exactly:
+`registry/` is the auditable intermediate pipeline. `handoff/` is the published programmer-facing result.
+
+## Where downstream programmers start
+
+A resolved standalone bundle contains exactly:
+
+```text
+feature/
+shared/
+bundle-lock.json
+```
+
+The feature package states observable behavior, valid inputs, required outputs, invariants, errors, forbidden behavior, acceptance tests, traceability, and implementation freedoms. `shared/` contains the exact versioned structural dependencies needed by the feature. `bundle-lock.json` fixes versions, paths, and SHA-256 fingerprints without volatile timestamps.
+
+Create or inspect one bundle:
+
+```bash
+python tools/handoff/export_bundle.py TLC-FC-00-MASTER-005 --check
+python tools/handoff/export_bundle.py TLC-FC-00-MASTER-005 ./bundle
+```
+
+Exports do not copy scientific source texts, registry artifacts, intermediate IRs, or generated archives.
+
+## Feature package contract
+
+Every feature directory contains:
 
 - `README.md` — human implementer guide;
 - `manifest.json` — identity, version, statuses, files, and shared dependencies;
 - `contract.json` — normative observable engineering contract;
 - `acceptance.json` — mandatory conformance tests;
 - `traceability.json` — audit links to upstream authority;
-- optional `examples.json` only when a source-backed fixture is honestly justified.
+- optional `examples.json` only when a source-backed fixture is justified.
 
-The authority order within a package is documented in [`handoff/README.md`](handoff/README.md). Examples and README prose cannot create obligations absent from the normative JSON contracts.
+The authority order is documented in [`handoff/README.md`](handoff/README.md). README prose and examples cannot create obligations absent from the normative structured contracts.
 
 ## Language and low-level freedom
 
-The handoff abstracts low-level realization. Unless a package makes a constraint observable, an implementation is free to choose:
+Unless a feature contract makes a property observable, an implementation remains free to choose:
 
 - programming language and naming;
 - storage, allocation, ownership, aliasing, and layout;
@@ -84,11 +133,11 @@ The handoff abstracts low-level realization. Unless a package makes a constraint
 - concurrency, scheduling, and error transport;
 - internal architecture and algorithm decomposition.
 
-An upstream algorithm file does not automatically impose a total runtime sequence. Final contracts publish only the ordering relationships supported by observable authority.
+The handoff can express low-level obligations when required, but it does not select a language-specific mechanism without observable justification.
 
 ## Scientific boundary
 
-Structural finalization does not authorize scientific invention. A downstream implementation must not invent missing:
+Structural finalization does not authorize scientific invention. A contributor or downstream implementation must not invent missing:
 
 - equations, solvers, convergence rules, domains, or types;
 - proof completion or truth values;
@@ -97,21 +146,21 @@ Structural finalization does not authorize scientific invention. A downstream im
 - relation endpoints, direction, arity, composition, or membership;
 - defaults for unresolved parameters or decisions.
 
-Opaque values remain opaque. Unresolved items remain explicit. Provider-required features remain structurally implementable without fabricating provider behavior. The repository's 147 scientific review questions remain scientifically unresolved.
+Opaque values remain opaque. Unresolved items remain explicit. Provider-required features remain structurally implementable without fabricating provider behavior. The repository's **147 scientific review questions remain scientifically unresolved**.
 
 ## Global catalog
 
-[`handoff/catalog.json`](handoff/catalog.json) is generated deterministically from the sixteen domain catalogs, 166 manifests, and eight shared packages. It records:
+[`handoff/catalog.json`](handoff/catalog.json) is a deterministic projection of the sixteen domain catalogs, 166 feature manifests, and eight shared packages. It records:
 
 - model and tool versions;
-- authoritative domain order and counts;
-- all feature IDs, paths, package versions, and multidimensional statuses;
-- `examples.json` presence;
+- authoritative domain order and populations;
+- feature IDs, paths, package versions, and multidimensional statuses;
+- optional example presence;
 - exact shared dependencies;
 - deterministic package and descriptor SHA-256 fingerprints;
 - explicit deprecation and substitution fields.
 
-The catalog contains no timestamp or other volatile normative field. CI regenerates its projection in memory and rejects any mismatch.
+The catalog contains no timestamp or other volatile normative field. CI reconstructs it and rejects any mismatch.
 
 ## Validation
 
@@ -121,51 +170,44 @@ The sole official handoff validation CLI is:
 python tools/handoff/validate_handoff.py
 ```
 
-Logical self-tests are available through:
+Complete handoff validation:
 
 ```bash
+python tools/handoff/generate_catalog.py --check
 python tools/handoff/validate_handoff.py --self-test
-```
-
-The validator checks the exact 16-domain and 166-feature population, authoritative inventory order, package schemas and files, feature ownership, shared dependencies, cross-file identities, traceability, errors, strategies, test uniqueness, global catalog equality, and absence of normative implementation-language code.
-
-Historical inventory metadata aliases are accepted only in strict read mode. Every alias present must agree with the actual ordered population; compatibility never ignores divergence or changes a feature ID.
-
-The permanent GitHub Actions workflow additionally validates all 166 deterministic standalone exports.
-
-## Export a standalone bundle
-
-Resolve and inspect one feature without retaining output:
-
-```bash
-python tools/handoff/export_bundle.py TLC-FC-00-MASTER-005 --check
-```
-
-Create a bundle in a new directory:
-
-```bash
-python tools/handoff/export_bundle.py TLC-FC-00-MASTER-005 ./bundle
-```
-
-Validate every catalog feature and generate each one twice for determinism:
-
-```bash
 python tools/handoff/export_bundle.py --all --check --verify-determinism
 ```
 
-Exports copy only finalized `handoff/features/` and `handoff/shared/` files. They never copy scientific source texts, registry artifacts, or intermediate IRs. Generated archives are not committed.
+The validator checks exact populations and order, schemas, required files, feature ownership, shared dependencies, cross-file identities, traceability, errors, strategies, test uniqueness, global catalog equality, and absence of normative implementation-language code.
+
+The permanent workflow also generates each of the 166 standalone bundles twice and compares their locks and fingerprints for determinism.
+
+## Change workflow
+
+Use the repository issue forms and pull request template rather than unstructured changes.
+
+1. Choose the correct scientific, specification, handoff, validation, or documentation path.
+2. Identify affected domains, feature IDs, and authority.
+3. Preserve unresolved science explicitly.
+4. Update all affected layers or state why they are unaffected.
+5. Run the relevant validation.
+6. Open a focused pull request with compatibility and reviewer guidance.
+7. Merge only after required checks and reviews succeed.
+
+Cross-domain or difficult-to-reverse decisions should use a record based on [`docs/decisions/0000-template.md`](docs/decisions/0000-template.md).
 
 ## Contradictions and unresolved items
 
-When a package appears internally contradictory:
+When two authoritative artifacts appear contradictory:
 
-1. stop the affected implementation path;
+1. stop the affected finalization or implementation path;
 2. identify the exact feature ID, operation, files, and conflicting obligations;
-3. preserve the current scientific and execution statuses;
-4. report the contradiction with a minimal reproducer or acceptance-test conflict;
-5. do not resolve it by choosing a convenient scientific meaning.
+3. preserve current scientific and execution statuses;
+4. report a minimal reproducer or conflicting acceptance case;
+5. request scientific or specification adjudication;
+6. do not choose the most convenient meaning.
 
-An `unresolved` item is a preserved boundary, not a request for an implementation default. It may be carried, serialized, displayed, or routed exactly as the package permits, but it cannot be silently answered.
+An unresolved item is a preserved boundary, not an invitation to create an implementation default.
 
 ## Domains
 
@@ -189,10 +231,18 @@ An `unresolved` item is a preserved boundary, not a request for an implementatio
 | 15 | Relations | 5 |
 |  | **Total** | **166** |
 
+## Governance and support
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — role-based contribution and review standard;
+- [`docs/REPOSITORY-GUIDE.md`](docs/REPOSITORY-GUIDE.md) — operating model, decision ownership, change levels, and definitions of ready and done;
+- [`SUPPORT.md`](SUPPORT.md) — correct pathway for scientific, specification, handoff, and tooling questions;
+- [`SECURITY.md`](SECURITY.md) — sensitive integrity and validator disclosures;
+- [`docs/decisions/`](docs/decisions/) — durable records for cross-domain or difficult-to-reverse choices.
+
 ## Audit evidence
 
-Global handoff evidence is under [`reports/handoff/global/`](reports/handoff/global/), including population validation, cross-domain consistency, shared-contract decisions, unresolved ambiguities, validator consolidation, export validation, representative simulations, protected-artifact changes, and the finalization report.
+Global evidence is under [`reports/handoff/global/`](reports/handoff/global/), including population validation, cross-domain consistency, shared-contract decisions, unresolved ambiguities, validator consolidation, export validation, representative simulations, protected-artifact changes, and the finalization report.
 
-## Contribution boundary
+## Repository boundary
 
-Changes are acceptable only when they preserve scientific identity, traceability, unresolved semantics, exact populations, and language neutrality. Implementation code belongs in a separate downstream repository.
+Changes are acceptable only when they preserve scientific identity, traceability, unresolved semantics, exact populations, deterministic validation, and language neutrality. Runtime implementation belongs in a separate downstream repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security policy
+
+`tllib-specs` contains scientific and engineering specifications, validators, and export tooling. It does not contain production runtime code. Security reports are nevertheless relevant when a defect could cause downstream implementations to accept unsafe, misleading, corrupted, or non-deterministic contracts.
+
+## Supported scope
+
+Reports are in scope when they concern:
+
+- validator bypasses that allow malformed or contradictory packages;
+- path traversal or unsafe file handling in repository tooling;
+- dependency or bundle-lock integrity failures;
+- hash or determinism weaknesses that could conceal changed content;
+- workflow changes that weaken protected-source or implementation-code checks;
+- schema defects that allow identity substitution, dependency confusion, or silent semantic loss;
+- export behavior that includes unintended scientific, registry, secret, or temporary files;
+- supply-chain risks in GitHub Actions or validation dependencies.
+
+Runtime vulnerabilities in downstream implementations should be reported to the relevant implementation repository unless the root cause is a defect in a handoff contract.
+
+## Reporting
+
+Do not open a public issue containing exploit details, sensitive repository information, or a practical validator bypass.
+
+Use GitHub's private vulnerability reporting feature for this repository when available. Include:
+
+- affected commit, file, workflow, schema, or feature ID;
+- impact and realistic attack or failure scenario;
+- reproduction steps or proof of concept;
+- whether generated catalogs or bundles are affected;
+- suggested remediation when known.
+
+If private vulnerability reporting is unavailable, contact the repository maintainers through the organization channels before public disclosure.
+
+## Handling expectations
+
+Maintainers should:
+
+1. acknowledge the report;
+2. determine whether the issue is specification, tooling, workflow, or downstream-runtime related;
+3. preserve evidence and affected fingerprints;
+4. prepare a minimal corrective change with regression coverage;
+5. revalidate catalogs and standalone exports when relevant;
+6. publish an advisory when users need to take action.
+
+No guaranteed response time is promised until the project publishes a formal service-level policy.
+
+## Non-security reports
+
+Use a normal issue for documentation defects, scientific questions, ordinary contradictions, feature requests, and non-sensitive validation failures.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,41 @@
+# Support and questions
+
+Use the pathway that matches the nature of the question. This keeps scientific review, specification maintenance, implementation feedback, and security reports separate.
+
+## Scientific or mathematical question
+
+Open a scientific question issue when the request concerns meaning, equations, domains, assumptions, proof status, relation semantics, thresholds, or unresolved terminology.
+
+Include the exact source path, section, affected feature IDs, and whether the question blocks structural work or only scientific execution.
+
+## Specification contradiction or defect
+
+Open a specification defect issue when two files impose incompatible obligations, a handoff package is incomplete, traceability is broken, or an acceptance test contradicts the contract.
+
+Include:
+
+- feature ID;
+- package version and bundle hash when available;
+- exact files and fields;
+- minimal conflicting example;
+- expected impact on downstream implementers.
+
+Do not resolve the contradiction by proposing an unsupported scientific default.
+
+## Handoff consumer feedback
+
+Downstream implementers should report problems against the exported bundle they used. Provide the feature ID, `bundle-lock.json` fingerprint, implementation language, and the specific decision that could not be derived from the package.
+
+Implementation-specific build failures, performance problems, bindings, packaging, and platform behavior belong in the downstream implementation repository unless the handoff itself is defective.
+
+## Validation or tooling problem
+
+Report the command, commit, platform, Python version, complete diagnostic, and whether the failure is reproducible on an unchanged checkout.
+
+## Sensitive security concern
+
+Follow `SECURITY.md`. Do not disclose a practical bypass or exploit in a public issue.
+
+## General discussion
+
+Keep general design discussion tied to a concrete repository outcome: a source clarification, decision record, contract correction, validator improvement, or documented future proposal. Broad discussion without an actionable specification consequence should remain outside issue tracking until it can be scoped.

--- a/docs/REPOSITORY-GUIDE.md
+++ b/docs/REPOSITORY-GUIDE.md
@@ -1,0 +1,244 @@
+# Repository operating guide
+
+This guide explains how work moves through `tllib-specs`, who owns which decisions, and how to change the repository without weakening scientific integrity or downstream usability.
+
+## Operating model
+
+The repository is a controlled transformation system:
+
+```text
+scientific authority
+    → mathematical contracts
+    → source intermediate representations
+    → finalized engineering IR
+    → algorithm specifications
+    → acceptance oracles
+    → Feature Handoff Packages
+    → standalone bundles for downstream implementation
+```
+
+Each layer has a distinct responsibility. Later layers may clarify structure and testability, but they may not invent scientific meaning absent from earlier authority.
+
+## Who does what
+
+### Scientists and domain experts
+
+Primary responsibility:
+
+- define or clarify domain meaning;
+- identify unsupported assumptions;
+- review unresolved scientific questions;
+- provide evidence, sources, and adjudication proposals;
+- distinguish unknown, undefined, disputed, and external-provider semantics.
+
+They should normally begin in `maths/` and the scientific review records, then identify all affected feature IDs.
+
+A scientifically useful contribution does not need to contain implementation advice. It must, however, state the consequences of the clarification for observable behavior when those consequences are known.
+
+### Mathematicians
+
+Primary responsibility:
+
+- formal definitions;
+- domains and codomains;
+- assumptions;
+- invariants;
+- proof obligations;
+- admissible equivalences;
+- numerical or symbolic constraints.
+
+They should avoid implementation vocabulary unless it is needed to express an observable property. Missing mathematical content remains explicit rather than being replaced with software defaults.
+
+### Algorithm designers
+
+Primary responsibility:
+
+- characterize valid computation or transformation families;
+- distinguish required operations from illustrative decomposition;
+- specify partial ordering only when necessary;
+- define deterministic or stochastic obligations;
+- justify complexity or resource requirements;
+- align algorithms with acceptance oracles.
+
+An algorithm designer must state whether a procedure is open, partially constrained, or prescribed.
+
+### Specification engineers
+
+Primary responsibility:
+
+- maintain identity and traceability across layers;
+- compile authoritative content into coherent contracts;
+- preserve unresolved semantics;
+- prevent accidental equivalence between distinct concepts;
+- maintain schemas, catalogs, validators, and deterministic exports;
+- ensure final handoff packages remain autonomous.
+
+Specification engineers do not adjudicate science by themselves.
+
+### Runtime implementers
+
+Primary responsibility in this repository:
+
+- consume exported bundles;
+- identify ambiguities, contradictions, missing observable obligations, or untestable acceptance criteria;
+- provide minimal implementation-facing reproductions.
+
+Production code, bindings, build files, memory policies, and platform optimizations belong downstream.
+
+### Reviewers and maintainers
+
+Primary responsibility:
+
+- ensure the right expertise reviewed the right dimension;
+- require evidence for normative changes;
+- protect the scientific boundary;
+- prevent repository-wide churn for local changes;
+- ensure CI evidence matches the actual proposed tree;
+- keep decision history discoverable.
+
+## Decision ownership
+
+| Decision | Primary authority | Required consultation |
+|---|---|---|
+| Scientific meaning | scientist or domain expert | mathematician, affected specification owners |
+| Formal mathematical definition | mathematician | domain expert, algorithm designer where executable |
+| Required algorithmic order | algorithm designer with source authority | mathematician, specification engineer |
+| Handoff structure | specification engineer | downstream implementer, validator maintainer |
+| Concrete language API | downstream implementation project | handoff consumer, runtime maintainers |
+| Memory layout and allocation | downstream implementation project | performance and safety reviewers |
+| Resolution of a preserved scientific question | scientific adjudication process | all affected domains |
+
+No single role should silently make a decision outside its authority.
+
+## Change impact levels
+
+### Level 0 — Editorial
+
+Examples: spelling, broken links, clearer non-normative prose.
+
+Requirements:
+
+- no semantic change;
+- no package fingerprint change unless the edited file is part of the fingerprint by design;
+- focused review.
+
+### Level 1 — Structural, non-behavioral
+
+Examples: traceability repair, deterministic tooling improvement, stricter malformed-input rejection without changing valid packages.
+
+Requirements:
+
+- validator evidence;
+- affected package or catalog analysis;
+- no scientific adjudication.
+
+### Level 2 — Observable contract change
+
+Examples: valid input set, required output field, stable error, ordering, determinism, or acceptance criterion changes.
+
+Requirements:
+
+- source authority;
+- feature impact list;
+- compatibility analysis;
+- package version decision;
+- downstream migration note.
+
+### Level 3 — Scientific change
+
+Examples: equation, type, relation meaning, proof status, provider semantics, threshold, or causal interpretation.
+
+Requirements:
+
+- scientific evidence and adjudication;
+- cross-layer propagation plan;
+- affected-domain review;
+- explicit treatment of previously unresolved questions;
+- no merge until authority is clear.
+
+## Definition of ready
+
+A proposed change is ready for implementation when:
+
+- the affected features are known;
+- the authority is cited;
+- unresolved questions are listed;
+- the expected repository layers are identified;
+- compatibility impact is understood;
+- acceptance evidence is defined;
+- the change can be reviewed as one coherent unit.
+
+## Definition of done
+
+A change is done when:
+
+- all affected layers are updated or explicitly declared unaffected;
+- traceability is complete;
+- validators pass;
+- catalogs and exports are deterministic;
+- documentation reflects the final state;
+- no unresolved item has been silently closed;
+- the pull request contains reviewable evidence;
+- temporary files and generated archives are absent.
+
+## Cross-domain changes
+
+Cross-domain work should use a dedicated integration branch and explicit inventory. Do not modify sixteen domains in parallel without first stabilizing shared schemas and contracts.
+
+For cross-domain changes:
+
+1. define the shared change centrally;
+2. identify every affected domain and feature;
+3. update domains in isolated branches or commits;
+4. reconcile shared abstractions only after observing real repetition;
+5. run global population and export validation;
+6. publish one final integration pull request.
+
+Shared representation never proves shared scientific identity.
+
+## Decision records
+
+Create a decision record under `docs/decisions/` for changes that are:
+
+- cross-domain;
+- difficult to reverse;
+- normative for contributors or downstream consumers;
+- likely to be questioned later;
+- based on a rejected alternative that may recur.
+
+Use `docs/decisions/0000-template.md`. Decision records explain why a choice was made; they do not replace normative contracts.
+
+## Repository hygiene
+
+Keep the repository production-grade:
+
+- no decorative generated noise;
+- no committed bundle archives;
+- no duplicated validation authority;
+- no hidden compatibility aliases;
+- no unbounded catch-all documents;
+- no mass formatting unrelated to the change;
+- no misleading status badges;
+- no claims unsupported by committed evidence;
+- no implementation-language examples presented as normative.
+
+## Release posture
+
+Feature Handoff Package v1.0 is a specification release, not a runtime release. Future model versions should publish:
+
+- a versioned catalog;
+- migration notes;
+- compatibility classification;
+- deterministic fingerprints;
+- validation evidence;
+- explicit deprecations and substitutions;
+- unchanged unresolved-science inventory unless scientific adjudication occurred.
+
+## Suggested review routing
+
+- Scientific changes: domain expert + mathematician.
+- Algorithm changes: algorithm designer + mathematician or domain expert.
+- Handoff changes: specification engineer + downstream implementer.
+- Validator changes: tooling reviewer + adversarial test reviewer.
+- Cross-domain changes: at least one reviewer outside the initiating domain.
+- Security-sensitive changes: private review under `SECURITY.md`.

--- a/docs/decisions/0000-template.md
+++ b/docs/decisions/0000-template.md
@@ -1,0 +1,59 @@
+# Decision record: <title>
+
+- Status: proposed
+- Date: YYYY-MM-DD
+- Owners: <roles or maintainers>
+- Affected domains: <domains>
+- Affected features: <feature IDs>
+
+## Context
+
+Describe the concrete problem, current constraints, and why a repository-level decision is required.
+
+## Scientific boundary
+
+State which scientific facts are authoritative, which remain unresolved, and which parts of this decision are engineering-only.
+
+## Decision
+
+State the decision precisely. Separate normative obligations from implementation freedoms.
+
+## Alternatives considered
+
+### Alternative A
+
+Describe the alternative, benefits, risks, and reason for rejection.
+
+### Alternative B
+
+Describe the alternative, benefits, risks, and reason for rejection.
+
+## Consequences
+
+### Positive
+
+- <consequence>
+
+### Negative or costly
+
+- <consequence>
+
+### Neutral or deferred
+
+- <consequence>
+
+## Compatibility and migration
+
+Describe package-version impact, affected consumers, migration steps, deprecation, and rollback considerations.
+
+## Validation evidence
+
+List validators, acceptance cases, simulations, CI runs, or reports that support the decision.
+
+## Traceability
+
+Link to scientific sources, contracts, IRs, algorithm specifications, oracles, issues, and pull requests.
+
+## Follow-up
+
+List bounded follow-up actions. Do not use this section to hide an unresolved prerequisite.


### PR DESCRIPTION
## Purpose

Make the finalized `tllib-specs` repository immediately understandable and professionally operable for scientists, mathematicians, algorithm designers, specification engineers, runtime implementers, reviewers, and security reporters.

## Changes

- rewrites the root README as a production landing page with role-based entry points, repository architecture, handoff consumption, validation, scientific boundaries, governance, and support;
- adds `CONTRIBUTING.md` with contribution classes, authority boundaries, validation, review standards, compatibility rules, and contradiction handling;
- adds `docs/REPOSITORY-GUIDE.md` with the operating model, decision ownership, impact levels, definitions of ready/done, cross-domain workflow, and repository hygiene;
- adds a durable decision-record template under `docs/decisions/`;
- adds `SECURITY.md` and `SUPPORT.md` with clear routing;
- adds structured GitHub issue forms for scientific questions, specification defects, and handoff-consumer feedback;
- adds a production pull request template.

## Scientific boundary

This PR changes documentation and contribution infrastructure only. It does not modify scientific sources, registry artifacts, handoff packages, schemas, catalogs, validators, exports, feature populations, or runtime semantics. It does not resolve any of the 147 scientific review questions and introduces no implementation code.

## Production principles

The repository experience now emphasizes:

- role-specific entry points;
- separation of scientific, mathematical, algorithmic, specification, and implementation authority;
- evidence-based review;
- explicit unresolved semantics;
- deterministic validation and export;
- compatibility and migration analysis;
- durable decision records for cross-domain choices;
- focused issue intake and responsible security disclosure.

## Reviewer focus

Please verify that the documentation accurately reflects the finalized repository and does not accidentally create new normative obligations or imply that runtime implementation belongs here.

## Summary by Sourcery

Establish a production-grade repository experience with clearer role-based documentation, governance, and contribution workflows without changing scientific specifications.

Enhancements:
- Clarify the repository boundary by emphasizing that tllib-specs is an authoritative specification and handoff repository, not a runtime implementation, and by documenting deterministic validation and export expectations.

CI:
- Add structured GitHub pull request template and issue forms to route scientific questions, specification defects, and handoff-consumer feedback through focused workflows.

Documentation:
- Rewrite the root README as a production-oriented landing page with role-specific entry points, repository architecture, and governance and support references.
- Introduce CONTRIBUTING, SECURITY, and SUPPORT guides that define roles, authority boundaries, contribution workflow, and responsible disclosure routes.
- Add a repository operating guide and durable decision-record template to document the operating model, decision ownership, impact levels, and change governance.