### PR TITLE
docs: clarify Tradition Learning ecosystem and restore visual identity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,12 @@
 # Contributing to `tllib-specs`
 
-`tllib-specs` is the authoritative specification repository for the TLC model. It is not a runtime implementation repository. Contributions are accepted when they improve scientific clarity, mathematical precision, algorithmic contracts, traceability, validation, or the language-neutral Feature Handoff Packages without inventing unresolved science.
+`tllib-specs` is the authoritative specification repository preparing `tllib`, the principal software library of the Tradition Learning Community.
+
+Tradition Learning is the theory and research programme. The Tradition Learning Community (TLC) is the community of people advancing it. `tllib` is the downstream AI library intended to complement machine learning, deep learning, reinforcement learning, and related methods. This repository is the upstream scientific and engineering specification workspace; it is not the runtime implementation repository.
+
+The theoretical domain named **Community** is one of the sixteen fundamental domains of Tradition Learning. It is distinct from the Tradition Learning Community organization.
+
+Contributions are accepted when they improve scientific clarity, mathematical precision, algorithmic contracts, traceability, validation, or the language-neutral Feature Handoff Packages without inventing unresolved science.
 
 ## Choose the right contribution path
 
@@ -16,14 +22,14 @@
 ## Repository layers
 
 ```text
-maths/          scientific authority
+maths/          Tradition Learning scientific authority
 registry/       compiler-like intermediate specification pipeline
-handoff/        final language-neutral programmer interface
+handoff/        final language-neutral programmer interface for tllib
 reports/        audit evidence and reconciliation records
 tools/          deterministic validation, catalog, and export tooling
 ```
 
-A downstream programmer normally starts with a resolved bundle containing `feature/`, `shared/`, and `bundle-lock.json`. The upstream layers remain available for audit and scientific review.
+A downstream `tllib` programmer normally starts with a resolved bundle containing `feature/`, `shared/`, and `bundle-lock.json`. The upstream layers remain available for audit and scientific review.
 
 ## Contribution classes
 
@@ -210,7 +216,7 @@ Specification defects may create downstream safety or integrity risks. Follow `S
 
 ## What belongs elsewhere
 
-The following belong in downstream implementation repositories:
+The following belong in downstream `tllib` implementation repositories:
 
 - runtime source code;
 - bindings;

--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
 <div align="center">
 
+<img src="docs/assets/tllib-specs-banner.svg" alt="tllib-specs — language-neutral specifications for the Tradition Learning library" width="100%" />
+
 # tllib-specs
 
-**Language-neutral scientific and engineering specifications for the TLC model.**
+**Scientific, mathematical, algorithmic, and engineering specifications for `tllib`.**
 
 [Feature handoff](handoff/) · [Global catalog](handoff/catalog.json) · [Contributor guide](CONTRIBUTING.md) · [Repository guide](docs/REPOSITORY-GUIDE.md) · [Validation](#validation) · [Security](SECURITY.md)
 
 </div>
 
+## Project identity
+
+**Tradition Learning** is a theory and research programme for learning approaches that do not depend on big-data training regimes.
+
+**Tradition Learning Community (TLC)** is the community of scientists, mathematicians, algorithm designers, engineers, programmers, reviewers, and other contributors who study, formalize, promote, and implement that theory. TLC is an organization of people; it is not the name of the theory and it is not one of the theory's mathematical objects.
+
+**`tllib`** is the principal software product being prepared by the community: a scientific library intended for use in artificial intelligence as a complement to machine learning, deep learning, reinforcement learning, and related methods. Its intended role is comparable to that of a reusable AI library such as TensorFlow or PyTorch, while exposing concepts and capabilities specific to Tradition Learning.
+
+**`tllib-specs`** is the upstream specification repository where scientists, mathematicians, and algorithm designers prepare `tllib` before runtime implementation begins. It transforms the theory into traceable, testable, language-neutral Feature Handoff Packages.
+
+> The **Community** domain under `maths/02-community.md` is one of the sixteen fundamental domains of Tradition Learning, alongside Master, Disciple, Dynamics, Relations, and the other domains. It must not be confused with the Tradition Learning Community organization.
+
 ## Production status
 
-`tllib-specs` is the authoritative specification repository for the TLC model. It contains specifications, validation, traceability, and language-neutral handoff packages—not a runtime library.
+`tllib-specs` contains specifications, validation, traceability, and language-neutral handoff packages—not a runtime library.
 
 | Published artifact | Finalized population |
 |---|---:|
@@ -20,6 +34,29 @@
 | Standalone exports validated by CI | **166** |
 
 Feature Handoff Package v1.0 is finalized. The published model is independent of C++, Rust, Ruby, Python, or any other implementation language. Production runtime code, bindings, solvers, kernels, binary packages, and release archives belong in downstream implementation repositories.
+
+## How the repositories relate
+
+```text
+Tradition Learning theory
+        ↓
+Tradition Learning Community
+  research · formalization · review · implementation
+        ↓
+tllib-specs
+  scientific and engineering specification
+        ↓
+Feature Handoff Packages
+        ↓
+tllib
+  downstream runtime library for AI systems
+```
+
+The repository boundary is intentional:
+
+- this repository defines what `tllib` must mean and how conformity is tested;
+- downstream runtime repositories decide concrete languages, APIs, memory models, build systems, packaging, and optimization strategies;
+- unresolved scientific semantics remain unresolved until reviewed by the proper scientific authority.
 
 ## Choose your path
 
@@ -52,7 +89,7 @@ Detailed role boundaries and workflows are in [`CONTRIBUTING.md`](CONTRIBUTING.m
 ## Repository architecture
 
 ```text
-maths/                         authoritative scientific source texts
+maths/                         authoritative Tradition Learning source texts
 registry/                      compiler-like intermediate specification pipeline
   math-contracts/              mathematical contracts
   ir/                          source intermediate representations
@@ -76,7 +113,7 @@ docs/                          contributor operations and decision records
 The repository functions as a controlled transformation system:
 
 ```text
-scientific authority
+Tradition Learning scientific authority
     → mathematical contracts
     → source IR
     → finalized engineering IR
@@ -84,6 +121,7 @@ scientific authority
     → acceptance oracles
     → Feature Handoff Packages
     → standalone implementation bundles
+    → downstream tllib implementation
 ```
 
 `registry/` is the auditable intermediate pipeline. `handoff/` is the published programmer-facing result.
@@ -211,6 +249,8 @@ An unresolved item is a preserved boundary, not an invitation to create an imple
 
 ## Domains
 
+The sixteen domains below are domains of the **Tradition Learning theory**. The domain named **Community** is a theoretical domain and is distinct from the Tradition Learning Community organization.
+
 | # | Domain | Features |
 |---:|---|---:|
 | 00 | Master | 16 |
@@ -245,4 +285,4 @@ Global evidence is under [`reports/handoff/global/`](reports/handoff/global/), i
 
 ## Repository boundary
 
-Changes are acceptable only when they preserve scientific identity, traceability, unresolved semantics, exact populations, deterministic validation, and language neutrality. Runtime implementation belongs in a separate downstream repository.
+Changes are acceptable only when they preserve scientific identity, traceability, unresolved semantics, exact populations, deterministic validation, and language neutrality. Runtime implementation belongs in a separate downstream repository for `tllib`.

--- a/docs/REPOSITORY-GUIDE.md
+++ b/docs/REPOSITORY-GUIDE.md
@@ -2,19 +2,31 @@
 
 This guide explains how work moves through `tllib-specs`, who owns which decisions, and how to change the repository without weakening scientific integrity or downstream usability.
 
+## Ecosystem terminology
+
+Use these names consistently:
+
+- **Tradition Learning** — the theory and research programme for learning approaches that do not depend on big-data training regimes.
+- **Tradition Learning Community (TLC)** — the community of people who research, formalize, promote, review, and implement Tradition Learning.
+- **Community** — one of the sixteen fundamental domains of the Tradition Learning theory; it is not the TLC organization.
+- **`tllib`** — the principal downstream software library, intended to complement machine learning, deep learning, reinforcement learning, and related AI methods.
+- **`tllib-specs`** — the upstream scientific and engineering specification repository that prepares `tllib` through language-neutral handoff packages.
+
+Do not use “TLC model” as a catch-all for the theory, the community, and the software. Name the exact layer being discussed.
+
 ## Operating model
 
 The repository is a controlled transformation system:
 
 ```text
-scientific authority
+Tradition Learning scientific authority
     → mathematical contracts
     → source intermediate representations
     → finalized engineering IR
     → algorithm specifications
     → acceptance oracles
     → Feature Handoff Packages
-    → standalone bundles for downstream implementation
+    → standalone bundles for downstream tllib implementation
 ```
 
 Each layer has a distinct responsibility. Later layers may clarify structure and testability, but they may not invent scientific meaning absent from earlier authority.
@@ -79,7 +91,7 @@ Specification engineers do not adjudicate science by themselves.
 
 Primary responsibility in this repository:
 
-- consume exported bundles;
+- consume exported bundles intended for `tllib`;
 - identify ambiguities, contradictions, missing observable obligations, or untestable acceptance criteria;
 - provide minimal implementation-facing reproductions.
 
@@ -104,8 +116,8 @@ Primary responsibility:
 | Formal mathematical definition | mathematician | domain expert, algorithm designer where executable |
 | Required algorithmic order | algorithm designer with source authority | mathematician, specification engineer |
 | Handoff structure | specification engineer | downstream implementer, validator maintainer |
-| Concrete language API | downstream implementation project | handoff consumer, runtime maintainers |
-| Memory layout and allocation | downstream implementation project | performance and safety reviewers |
+| Concrete language API | downstream `tllib` implementation project | handoff consumer, runtime maintainers |
+| Memory layout and allocation | downstream `tllib` implementation project | performance and safety reviewers |
 | Resolution of a preserved scientific question | scientific adjudication process | all affected domains |
 
 No single role should silently make a decision outside its authority.
@@ -224,7 +236,7 @@ Keep the repository production-grade:
 
 ## Release posture
 
-Feature Handoff Package v1.0 is a specification release, not a runtime release. Future model versions should publish:
+Feature Handoff Package v1.0 is a specification release for `tllib`, not a runtime release. Future model versions should publish:
 
 - a versioned catalog;
 - migration notes;

--- a/docs/assets/tllib-specs-banner.svg
+++ b/docs/assets/tllib-specs-banner.svg
@@ -1,9 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="360" viewBox="0 0 1200 360" role="img" aria-labelledby="title desc">
-  <title id="title">tllib-specs — scientific specifications before implementation</title>
-  <desc id="desc">A visual overview of the TLC specification pipeline from mathematical sources to contracts, intermediate representations, algorithms, oracles, and implementation tasks.</desc>
+  <title id="title">tllib-specs — specifications for the Tradition Learning library</title>
+  <desc id="desc">A visual overview from Tradition Learning scientific theory through contracts, intermediate representations, algorithms, and acceptance oracles to language-neutral handoff packages for tllib.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="0.55" stop-color="#172554"/>
       <stop offset="1" stop-color="#1d4ed8"/>
     </linearGradient>
     <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
@@ -19,18 +20,19 @@
   <circle cx="1080" cy="65" r="150" fill="#38bdf8" opacity="0.08"/>
   <circle cx="110" cy="330" r="180" fill="#a78bfa" opacity="0.08"/>
 
-  <g transform="translate(72 62)">
+  <g transform="translate(72 52)">
     <text x="0" y="48" fill="#f8fafc" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="52" font-weight="700">tllib-specs</text>
     <rect x="0" y="68" width="520" height="6" rx="3" fill="url(#accent)"/>
-    <text x="0" y="112" fill="#cbd5e1" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="23">Scientific and algorithmic specifications for the TLC library</text>
-    <text x="0" y="146" fill="#94a3b8" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="18">16 domains · 166 active features · structurally finalized engineering contracts</text>
+    <text x="0" y="112" fill="#cbd5e1" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="23">Specifications for the Tradition Learning library</text>
+    <text x="0" y="146" fill="#94a3b8" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="18">16 theory domains · 166 feature packages · 8 shared contracts</text>
+    <text x="0" y="176" fill="#7dd3fc" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="16">Prepared by the Tradition Learning Community · Language-neutral handoff v1.0</text>
   </g>
 
-  <g transform="translate(70 236)" filter="url(#shadow)" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="15" font-weight="600">
+  <g transform="translate(70 246)" filter="url(#shadow)" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="15" font-weight="600">
     <g>
       <rect width="150" height="64" rx="14" fill="#f8fafc"/>
-      <text x="75" y="28" text-anchor="middle" fill="#0f172a">Mathematical</text>
-      <text x="75" y="48" text-anchor="middle" fill="#475569">sources</text>
+      <text x="75" y="28" text-anchor="middle" fill="#0f172a">Tradition Learning</text>
+      <text x="75" y="48" text-anchor="middle" fill="#475569">theory</text>
     </g>
     <path d="M160 32h42" stroke="#7dd3fc" stroke-width="4" stroke-linecap="round"/>
     <path d="M196 25l10 7-10 7" fill="none" stroke="#7dd3fc" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
@@ -61,8 +63,8 @@
 
     <g transform="translate(860)">
       <rect width="200" height="64" rx="14" fill="#e0f2fe"/>
-      <text x="100" y="28" text-anchor="middle" fill="#0c4a6e">Engineering</text>
-      <text x="100" y="48" text-anchor="middle" fill="#0369a1">handoff</text>
+      <text x="100" y="28" text-anchor="middle" fill="#0c4a6e">tllib handoff</text>
+      <text x="100" y="48" text-anchor="middle" fill="#0369a1">166 packages</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Purpose

Correct the project terminology and make the repository landing page accurately describe the Tradition Learning ecosystem.

## Clarified identity

- **Tradition Learning** is the theory and research programme for learning approaches that do not depend on big-data training regimes.
- **Tradition Learning Community (TLC)** is the community of people advancing that theory.
- **Community** is one of the sixteen fundamental theory domains and is distinct from the TLC organization.
- **`tllib`** is the principal downstream AI library, intended to complement ML, DL, RL, and related methods.
- **`tllib-specs`** is the upstream scientific and engineering specification repository preparing `tllib`.

## Changes

- restores the existing SVG banner at the top of the root README;
- updates the banner to reflect the finalized 16-domain, 166-package handoff and the `tllib` destination;
- adds a concise project-identity and repository-relationship section;
- corrects ambiguous “TLC model” terminology in contributor-facing documentation;
- explicitly distinguishes the Community theory domain from the Tradition Learning Community organization;
- clarifies that exported bundles are intended for downstream `tllib` implementation.

## Scope

Documentation and the existing SVG asset only. No scientific source, registry artifact, handoff package, schema, catalog, validator, feature identity, acceptance test, or runtime code is modified. No unresolved scientific question is answered.

## Summary by Sourcery

Clarify the role of `tllib-specs` within the Tradition Learning ecosystem and align documentation and visuals with the finalized project identity.

Enhancements:
- Restore and update the README SVG banner to reflect the finalized Tradition Learning domains and `tllib` destination.
- Standardize terminology from “TLC model” to precise references to Tradition Learning theory, `tllib`, and the Tradition Learning scientific authority in diagrams and architecture descriptions.

Documentation:
- Define and distinguish Tradition Learning, the Tradition Learning Community, the theoretical Community domain, `tllib`, and `tllib-specs` across README, repository guide, and contributing guide.
- Document how Tradition Learning theory, `tllib-specs`, handoff packages, and downstream `tllib` implementations relate in the ecosystem and repository workflows.
- Clarify that exported bundles and handoff artifacts are targeted at downstream `tllib` implementations and not runtime code in this repository.