### PR TITLE
Temporary snapshot export trigger

### DIFF
--- a/docs/temporary-snapshot-trigger.txt
+++ b/docs/temporary-snapshot-trigger.txt
@@ -1,0 +1,1 @@
+temporary snapshot export trigger


### PR DESCRIPTION
Temporary technical pull request used only to export an exact repository snapshot. It will not target or modify `main`.

## Summary by Sourcery

Documentation:
- Add a temporary snapshot trigger note under docs for one-off repository export.