### PR TITLE
Present maths domains as stable scientific documentation

### DIFF
--- a/maths/00-master/README.md
+++ b/maths/00-master/README.md
@@ -1,11 +1,7 @@
 # Domaine 00 — Maître
 
-Ce dossier présente le domaine **Maître** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Maître** formalise l’entité qui incarne, organise et transmet une Tradition. Il rassemble sa définition conceptuelle et mathématique, ses conditions de reconnaissance, sa structure interne, ses axiomes, ses invariants et ses dynamiques.
 
-## Fichiers
+## Document scientifique
 
-- [`master.md`](master.md) — texte scientifique existant consacré à la définition mathématique et scientifique du Maître.
-
-## Compatibilité
-
-Le chemin historique [`../00-master.md`](../00-master.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`master.md`](master.md) — définition scientifique et mathématique du Maître.

--- a/maths/01-disciple/README.md
+++ b/maths/01-disciple/README.md
@@ -1,11 +1,7 @@
 # Domaine 01 — Disciple
 
-Ce dossier présente le domaine **Disciple** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Disciple** formalise l’entité engagée dans une trajectoire de transformation au contact d’un Maître, d’une Communauté et des objets de la Tradition. Il décrit sa structure, ses états, ses capacités de réception et son évolution.
 
-## Fichiers
+## Document scientifique
 
-- [`disciple.md`](disciple.md) — texte scientifique existant consacré à la définition mathématique et scientifique du Disciple.
-
-## Compatibilité
-
-Le chemin historique [`../01-disciple.md`](../01-disciple.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`disciple.md`](disciple.md) — définition scientifique et mathématique du Disciple.

--- a/maths/02-community/README.md
+++ b/maths/02-community/README.md
@@ -1,11 +1,7 @@
 # Domaine 02 — Communauté
 
-Ce dossier présente le domaine **Communauté** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Communauté** formalise l’entité collective au sein de laquelle la Tradition est portée, transmise, validée et transformée. Il décrit sa composition, sa structure relationnelle, sa mémoire, son identité et ses dynamiques.
 
-## Fichiers
+## Document scientifique
 
-- [`community.md`](community.md) — texte scientifique existant consacré à la définition mathématique et scientifique de la Communauté.
-
-## Compatibilité
-
-Le chemin historique [`../02-community.md`](../02-community.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`community.md`](community.md) — définition scientifique et mathématique de la Communauté.

--- a/maths/03-huit-dimensions-de-tl/README.md
+++ b/maths/03-huit-dimensions-de-tl/README.md
@@ -1,11 +1,7 @@
 # Domaine 03 — Huit dimensions de TL
 
-Ce dossier présente le domaine **Huit dimensions de TL** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Huit dimensions de TL** présente l’architecture composée du Message, des Principes, des Valeurs, des Vertus, des Capacités, des Compétences, de la Pratique et de l’Expérience vécue. Il expose leur complémentarité dans la transmission et la résolution collective de problèmes.
 
-## Fichiers
+## Document scientifique
 
-- [`huit-dimensions-de-tl.md`](huit-dimensions-de-tl.md) — texte scientifique existant consacré à le cadre scientifique des huit dimensions de Tradition Learning.
-
-## Compatibilité
-
-Le chemin historique [`../03-huit-dimensions-de-tl.md`](../03-huit-dimensions-de-tl.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`huit-dimensions-de-tl.md`](huit-dimensions-de-tl.md) — présentation intégrée des huit dimensions de la Tradition.

--- a/maths/04-invariants/README.md
+++ b/maths/04-invariants/README.md
@@ -1,11 +1,7 @@
 # Domaine 04 — Invariants
 
-Ce dossier présente le domaine **Invariants** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Invariants** identifie les propriétés structurelles, relationnelles et fonctionnelles qui doivent être préservées pour maintenir l’identité et la cohérence d’un système de Tradition Learning.
 
-## Fichiers
+## Document scientifique
 
-- [`invariants.md`](invariants.md) — texte scientifique existant consacré à les invariants fondamentaux de Tradition Learning.
-
-## Compatibilité
-
-Le chemin historique [`../04-invariants.md`](../04-invariants.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`invariants.md`](invariants.md) — définitions et propriétés des invariants de Tradition Learning.

--- a/maths/05-dynamics/README.md
+++ b/maths/05-dynamics/README.md
@@ -1,11 +1,7 @@
 # Domaine 05 — Dynamiques
 
-Ce dossier présente le domaine **Dynamiques** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Dynamiques** formalise l’évolution temporelle des entités et de leurs interactions. Il rassemble les systèmes d’équations décrivant les transformations du Maître, du Disciple et de la Communauté.
 
-## Fichiers
+## Document scientifique
 
-- [`dynamics.md`](dynamics.md) — texte scientifique existant consacré à les équations et mécanismes dynamiques de Tradition Learning.
-
-## Compatibilité
-
-Le chemin historique [`../05-dynamics.md`](../05-dynamics.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`dynamics.md`](dynamics.md) — équations et modèles dynamiques de Tradition Learning.

--- a/maths/06-theorems/README.md
+++ b/maths/06-theorems/README.md
@@ -1,11 +1,7 @@
 # Domaine 06 — Théorèmes
 
-Ce dossier présente le domaine **Théorèmes** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Théorèmes** rassemble les résultats mathématiques qui établissent des propriétés de cohérence, de stabilité, de convergence, d’émergence et de robustesse dans Tradition Learning.
 
-## Fichiers
+## Document scientifique
 
-- [`theorems.md`](theorems.md) — texte scientifique existant consacré à les théorèmes fondamentaux de Tradition Learning.
-
-## Compatibilité
-
-Le chemin historique [`../06-theorems.md`](../06-theorems.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`theorems.md`](theorems.md) — énoncés, hypothèses et démonstrations des théorèmes fondamentaux.

--- a/maths/07-message/README.md
+++ b/maths/07-message/README.md
@@ -1,11 +1,7 @@
 # Domaine 07 — Message
 
-Ce dossier présente le domaine **Message** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Message** formalise le noyau symbolique, narratif et conceptuel transmis par une Tradition. Il étudie sa structure, son interprétation, sa portée et son rôle dans la coordination des acteurs.
 
-## Fichiers
+## Document scientifique
 
-- [`message.md`](message.md) — texte scientifique existant consacré à la dimension Message de la Tradition.
-
-## Compatibilité
-
-Le chemin historique [`../07-message.md`](../07-message.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`message.md`](message.md) — définition scientifique du Message.

--- a/maths/08-principle/README.md
+++ b/maths/08-principle/README.md
@@ -1,11 +1,7 @@
 # Domaine 08 — Principe
 
-Ce dossier présente le domaine **Principe** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Principe** formalise les structures rationnelles, logiques, morales ou techniques qui organisent le raisonnement et l’action dans une Tradition.
 
-## Fichiers
+## Document scientifique
 
-- [`principle.md`](principle.md) — texte scientifique existant consacré à la dimension Principe de la Tradition.
-
-## Compatibilité
-
-Le chemin historique [`../08-principle.md`](../08-principle.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`principle.md`](principle.md) — définition scientifique des Principes.

--- a/maths/09-values/README.md
+++ b/maths/09-values/README.md
@@ -1,11 +1,7 @@
 # Domaine 09 — Valeurs
 
-Ce dossier présente le domaine **Valeurs** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Valeurs** formalise les orientations axiologiques qui déterminent ce qui est jugé désirable, prioritaire ou digne d’être poursuivi au sein d’une Tradition.
 
-## Fichiers
+## Document scientifique
 
-- [`values.md`](values.md) — texte scientifique existant consacré à la dimension Valeurs de la Tradition.
-
-## Compatibilité
-
-Le chemin historique [`../09-values.md`](../09-values.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`values.md`](values.md) — définition scientifique des Valeurs.

--- a/maths/10-virtues/README.md
+++ b/maths/10-virtues/README.md
@@ -1,11 +1,7 @@
 # Domaine 10 — Vertus
 
-Ce dossier présente le domaine **Vertus** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Vertus** formalise les dispositions éthiques et comportementales cultivées chez les acteurs afin de soutenir une action juste, stable et excellente.
 
-## Fichiers
+## Document scientifique
 
-- [`virtues.md`](virtues.md) — texte scientifique existant consacré à la dimension Vertus de la Tradition.
-
-## Compatibilité
-
-Le chemin historique [`../10-virtues.md`](../10-virtues.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`virtues.md`](virtues.md) — définition scientifique des Vertus.

--- a/maths/11-capacities/README.md
+++ b/maths/11-capacities/README.md
@@ -1,11 +1,7 @@
 # Domaine 11 — Capacités
 
-Ce dossier présente le domaine **Capacités** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Capacités** formalise les potentialités latentes — intellectuelles, intuitives, pratiques, émotionnelles ou relationnelles — susceptibles d’être révélées et développées par la Tradition.
 
-## Fichiers
+## Document scientifique
 
-- [`capacities.md`](capacities.md) — texte scientifique existant consacré à la dimension Capacités de la Tradition.
-
-## Compatibilité
-
-Le chemin historique [`../11-capacities.md`](../11-capacities.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`capacities.md`](capacities.md) — définition scientifique des Capacités.

--- a/maths/12-competencies/README.md
+++ b/maths/12-competencies/README.md
@@ -1,11 +1,7 @@
 # Domaine 12 — Compétences
 
-Ce dossier présente le domaine **Compétences** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Compétences** formalise les aptitudes opérationnelles qui transforment les capacités en actions observables et efficaces dans un contexte donné.
 
-## Fichiers
+## Document scientifique
 
-- [`competencies.md`](competencies.md) — texte scientifique existant consacré à la dimension Compétences de la Tradition.
-
-## Compatibilité
-
-Le chemin historique [`../12-competencies.md`](../12-competencies.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`competencies.md`](competencies.md) — définition scientifique des Compétences.

--- a/maths/13-practice/README.md
+++ b/maths/13-practice/README.md
@@ -1,11 +1,7 @@
 # Domaine 13 — Pratique
 
-Ce dossier présente le domaine **Pratique** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Pratique** formalise les exercices, méthodes, protocoles et applications par lesquels les connaissances et compétences sont consolidées dans l’action.
 
-## Fichiers
+## Document scientifique
 
-- [`practice.md`](practice.md) — texte scientifique existant consacré à la dimension Pratique de la Tradition.
-
-## Compatibilité
-
-Le chemin historique [`../13-practice.md`](../13-practice.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`practice.md`](practice.md) — définition scientifique de la Pratique.

--- a/maths/14-lived-experience/README.md
+++ b/maths/14-lived-experience/README.md
@@ -1,11 +1,7 @@
 # Domaine 14 — Expérience vécue
 
-Ce dossier présente le domaine **Expérience vécue** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Expérience vécue** formalise la dimension incarnée, tacite et existentielle de la transmission. Il traite de l’apprentissage produit par l’immersion, l’observation, la participation et la vie partagée.
 
-## Fichiers
+## Document scientifique
 
-- [`lived-experience.md`](lived-experience.md) — texte scientifique existant consacré à la dimension Expérience vécue de la Tradition.
-
-## Compatibilité
-
-Le chemin historique [`../14-lived-experience.md`](../14-lived-experience.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`lived-experience.md`](lived-experience.md) — définition scientifique de l’Expérience vécue.

--- a/maths/15-relations/README.md
+++ b/maths/15-relations/README.md
@@ -1,11 +1,7 @@
 # Domaine 15 — Relations
 
-Ce dossier présente le domaine **Relations** et organise sa source scientifique autoritative. Le fichier de contenu conserve sans réécriture le texte précédemment publié à la racine de `maths/`.
+Le domaine **Relations** formalise les liens et interactions entre les entités fondamentales et les objets de la Tradition. Il précise les rôles, directions, effets et conditions des relations étudiées par la théorie.
 
-## Fichiers
+## Document scientifique
 
-- [`relations.md`](relations.md) — texte scientifique existant consacré à les relations et interactions formalisées dans Tradition Learning.
-
-## Compatibilité
-
-Le chemin historique [`../15-relations.md`](../15-relations.md) est conservé comme lien symbolique vers ce fichier afin de ne pas rompre la traçabilité des registres, rapports et Feature Handoff Packages déjà finalisés.
+- [`relations.md`](relations.md) — définition scientifique des Relations.

--- a/maths/16-cohort/README.md
+++ b/maths/16-cohort/README.md
@@ -1,15 +1,11 @@
 # Domaine 16 — Cohorte
 
-Ce dossier réserve et décrit le domaine **Cohorte** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Cohorte** rassemble les développements scientifiques de Tradition Learning consacrés à la cohorte.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/cohort`
 
-## Fichiers
+## Documents scientifiques
 
-- [`cohort.md`](cohort.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`cohort.md`](cohort.md) — texte scientifique consacré à la Cohorte.

--- a/maths/17-cascade-transmission/README.md
+++ b/maths/17-cascade-transmission/README.md
@@ -1,15 +1,11 @@
 # Domaine 17 — Transmission en cascade
 
-Ce dossier réserve et décrit le domaine **Transmission en cascade** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Transmission en cascade** rassemble les développements scientifiques de Tradition Learning consacrés au système de transmission en cascade.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/cascade_transmission_system`
 
-## Fichiers
+## Documents scientifiques
 
-- [`cascade-transmission-system.md`](cascade-transmission-system.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`cascade-transmission-system.md`](cascade-transmission-system.md) — texte scientifique consacré au système de transmission en cascade.

--- a/maths/18-evaluation/README.md
+++ b/maths/18-evaluation/README.md
@@ -1,15 +1,11 @@
 # Domaine 18 — Évaluation
 
-Ce dossier réserve et décrit le domaine **Évaluation** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Évaluation** rassemble les développements scientifiques de Tradition Learning consacrés à l’évaluation.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/evaluation_regulation`
 
-## Fichiers
+## Documents scientifiques
 
-- [`evaluation.md`](evaluation.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`evaluation.md`](evaluation.md) — texte scientifique consacré à l’Évaluation.

--- a/maths/19-regulation/README.md
+++ b/maths/19-regulation/README.md
@@ -1,15 +1,11 @@
 # Domaine 19 — Régulation
 
-Ce dossier réserve et décrit le domaine **Régulation** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Régulation** rassemble les développements scientifiques de Tradition Learning consacrés à la régulation.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/evaluation_regulation`
 
-## Fichiers
+## Documents scientifiques
 
-- [`regulation.md`](regulation.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`regulation.md`](regulation.md) — texte scientifique consacré à la Régulation.

--- a/maths/20-robustness/README.md
+++ b/maths/20-robustness/README.md
@@ -1,15 +1,11 @@
 # Domaine 20 — Robustesse
 
-Ce dossier réserve et décrit le domaine **Robustesse** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Robustesse** rassemble les développements scientifiques de Tradition Learning consacrés à la robustesse.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Robustness_Fairness`
 
-## Fichiers
+## Documents scientifiques
 
-- [`robustness.md`](robustness.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`robustness.md`](robustness.md) — texte scientifique consacré à la Robustesse.

--- a/maths/21-fairness/README.md
+++ b/maths/21-fairness/README.md
@@ -1,15 +1,11 @@
 # Domaine 21 — Équité
 
-Ce dossier réserve et décrit le domaine **Équité** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Équité** rassemble les développements scientifiques de Tradition Learning consacrés à la fairness et à l’équité.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Robustness_Fairness`
 
-## Fichiers
+## Documents scientifiques
 
-- [`fairness.md`](fairness.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`fairness.md`](fairness.md) — texte scientifique consacré à l’Équité.

--- a/maths/22-temporality/README.md
+++ b/maths/22-temporality/README.md
@@ -1,15 +1,11 @@
 # Domaine 22 — Temporalité
 
-Ce dossier réserve et décrit le domaine **Temporalité** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Temporalité** rassemble les développements scientifiques de Tradition Learning consacrés à la temporalité.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Temporality_Memory`
 
-## Fichiers
+## Documents scientifiques
 
-- [`temporality.md`](temporality.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`temporality.md`](temporality.md) — texte scientifique consacré à la Temporalité.

--- a/maths/23-memory/README.md
+++ b/maths/23-memory/README.md
@@ -1,15 +1,11 @@
 # Domaine 23 — Mémoire
 
-Ce dossier réserve et décrit le domaine **Mémoire** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Mémoire** rassemble les développements scientifiques de Tradition Learning consacrés à la mémoire.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Temporality_Memory`
 
-## Fichiers
+## Documents scientifiques
 
-- [`memory.md`](memory.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`memory.md`](memory.md) — texte scientifique consacré à la Mémoire.

--- a/maths/24-context/README.md
+++ b/maths/24-context/README.md
@@ -1,15 +1,11 @@
 # Domaine 24 — Contexte
 
-Ce dossier réserve et décrit le domaine **Contexte** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Contexte** rassemble les développements scientifiques de Tradition Learning consacrés au contexte.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Context_Culture`
 
-## Fichiers
+## Documents scientifiques
 
-- [`context.md`](context.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`context.md`](context.md) — texte scientifique consacré au Contexte.

--- a/maths/25-culture/README.md
+++ b/maths/25-culture/README.md
@@ -1,15 +1,11 @@
 # Domaine 25 — Culture
 
-Ce dossier réserve et décrit le domaine **Culture** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Culture** rassemble les développements scientifiques de Tradition Learning consacrés à la culture.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Context_Culture`
 
-## Fichiers
+## Documents scientifiques
 
-- [`culture.md`](culture.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`culture.md`](culture.md) — texte scientifique consacré à la Culture.

--- a/maths/26-identity/README.md
+++ b/maths/26-identity/README.md
@@ -1,15 +1,11 @@
 # Domaine 26 — Identité
 
-Ce dossier réserve et décrit le domaine **Identité** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Identité** rassemble les développements scientifiques de Tradition Learning consacrés à l’identité.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/identity_reflexivity`
 
-## Fichiers
+## Documents scientifiques
 
-- [`identity.md`](identity.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`identity.md`](identity.md) — texte scientifique consacré à l’Identité.

--- a/maths/27-reflexivity/README.md
+++ b/maths/27-reflexivity/README.md
@@ -1,15 +1,11 @@
 # Domaine 27 — Réflexivité
 
-Ce dossier réserve et décrit le domaine **Réflexivité** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Réflexivité** rassemble les développements scientifiques de Tradition Learning consacrés à la réflexivité.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/identity_reflexivity`
 
-## Fichiers
+## Documents scientifiques
 
-- [`reflexivity.md`](reflexivity.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`reflexivity.md`](reflexivity.md) — texte scientifique consacré à la Réflexivité.

--- a/maths/28-finality-and-evolutionary-teleology/README.md
+++ b/maths/28-finality-and-evolutionary-teleology/README.md
@@ -1,15 +1,11 @@
 # Domaine 28 — Finalité et téléologie évolutive
 
-Ce dossier réserve et décrit le domaine **Finalité et téléologie évolutive** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Finalité et téléologie évolutive** rassemble les développements scientifiques de Tradition Learning consacrés à la finalité et à la téléologie évolutive.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Finality_and_Evolutionary_Teleology`
 
-## Fichiers
+## Documents scientifiques
 
-- [`finality-and-evolutionary-teleology.md`](finality-and-evolutionary-teleology.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`finality-and-evolutionary-teleology.md`](finality-and-evolutionary-teleology.md) — texte scientifique consacré à la finalité et à la téléologie évolutive.

--- a/maths/29-generational-propagation/README.md
+++ b/maths/29-generational-propagation/README.md
@@ -1,15 +1,11 @@
 # Domaine 29 — Propagation générationnelle
 
-Ce dossier réserve et décrit le domaine **Propagation générationnelle** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Propagation générationnelle** rassemble les développements scientifiques de Tradition Learning consacrés à la propagation entre générations.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Generational_Propagation_and_Expansion`
 
-## Fichiers
+## Documents scientifiques
 
-- [`generational-propagation.md`](generational-propagation.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`generational-propagation.md`](generational-propagation.md) — texte scientifique consacré à la propagation générationnelle.

--- a/maths/30-expansion/README.md
+++ b/maths/30-expansion/README.md
@@ -1,16 +1,12 @@
 # Domaine 30 — Expansion
 
-Ce dossier réserve et décrit le domaine **Expansion** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Expansion** rassemble les développements scientifiques de Tradition Learning consacrés à l’expansion.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Generational_Propagation_and_Expansion`
 - `partie3/Expansion_and_Institutionalisation`
 
-## Fichiers
+## Documents scientifiques
 
-- [`expansion.md`](expansion.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`expansion.md`](expansion.md) — texte scientifique consacré à l’Expansion.

--- a/maths/31-institutionalization/README.md
+++ b/maths/31-institutionalization/README.md
@@ -1,15 +1,11 @@
 # Domaine 31 — Institutionnalisation
 
-Ce dossier réserve et décrit le domaine **Institutionnalisation** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Institutionnalisation** rassemble les développements scientifiques de Tradition Learning consacrés à l’institutionnalisation.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Expansion_and_Institutionalisation`
 
-## Fichiers
+## Documents scientifiques
 
-- [`institutionalization.md`](institutionalization.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`institutionalization.md`](institutionalization.md) — texte scientifique consacré à l’Institutionnalisation.

--- a/maths/32-drift-and-correction/README.md
+++ b/maths/32-drift-and-correction/README.md
@@ -1,15 +1,11 @@
 # Domaine 32 — Dérive et correction
 
-Ce dossier réserve et décrit le domaine **Dérive et correction** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Dérive et correction** rassemble les développements scientifiques de Tradition Learning consacrés à la stabilité, à la dérive et à la correction.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Stability_Drift_and_Correction`
 
-## Fichiers
+## Documents scientifiques
 
-- [`stability-drift-and-correction.md`](stability-drift-and-correction.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`stability-drift-and-correction.md`](stability-drift-and-correction.md) — texte scientifique consacré à la stabilité, à la dérive et à la correction.

--- a/maths/33-low-data-architecture/README.md
+++ b/maths/33-low-data-architecture/README.md
@@ -1,15 +1,11 @@
 # Domaine 33 — Architecture pour environnements à faibles données
 
-Ce dossier réserve et décrit le domaine **Architecture pour environnements à faibles données** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Architecture pour environnements à faibles données** rassemble les principes architecturaux de Tradition Learning consacrés aux environnements à faibles données.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Architectural_Principles_for_LowData_Environments`
 
-## Fichiers
+## Documents scientifiques
 
-- [`architectural-principles-for-low-data-environments.md`](architectural-principles-for-low-data-environments.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`architectural-principles-for-low-data-environments.md`](architectural-principles-for-low-data-environments.md) — texte scientifique consacré aux principes architecturaux pour les environnements à faibles données.

--- a/maths/34-transmission-lifecycle/README.md
+++ b/maths/34-transmission-lifecycle/README.md
@@ -1,8 +1,8 @@
 # Domaine 34 — Cycle de transmission
 
-Ce dossier réserve et décrit le domaine **Cycle de transmission** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Cycle de transmission** organise le pipeline opérationnel de transmission et les phases explicitement définies par la théorie : initiation, imprégnation, guidage, incorporation, intégration, validation et autonomisation.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Operational_Pipeline_The_Unfolding_of_Transmission`
 - `partie3/Initiation_Phase_Establishing_the_Relationship`
@@ -13,17 +13,13 @@ Ce dossier réserve et décrit le domaine **Cycle de transmission** dans l’arc
 - `partie3/Validation_Phase_Community_Regulation`
 - `partie3/Empowerment_Phase_Emancipation_of_the_Disciple`
 
-## Fichiers
+## Documents scientifiques
 
-- [`operational-pipeline.md`](operational-pipeline.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-- [`initiation-phase.md`](initiation-phase.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-- [`impregnation-phase.md`](impregnation-phase.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-- [`guidance-phase.md`](guidance-phase.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-- [`incorporation-phase.md`](incorporation-phase.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-- [`integration-phase.md`](integration-phase.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-- [`validation-phase.md`](validation-phase.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-- [`empowerment-phase.md`](empowerment-phase.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`operational-pipeline.md`](operational-pipeline.md) — vue d’ensemble du pipeline opérationnel de transmission.
+- [`initiation-phase.md`](initiation-phase.md) — phase d’initiation et établissement de la relation.
+- [`impregnation-phase.md`](impregnation-phase.md) — phase d’imprégnation, d’exposition et de résonance.
+- [`guidance-phase.md`](guidance-phase.md) — phase de guidage et de transmission active.
+- [`incorporation-phase.md`](incorporation-phase.md) — phase d’incorporation par la pratique et la réflexion.
+- [`integration-phase.md`](integration-phase.md) — phase d’intégration, de cohérence et d’identité.
+- [`validation-phase.md`](validation-phase.md) — phase de validation et de régulation communautaire.
+- [`empowerment-phase.md`](empowerment-phase.md) — phase d’autonomisation du Disciple.

--- a/maths/35-fidelity-to-invariant-core/README.md
+++ b/maths/35-fidelity-to-invariant-core/README.md
@@ -1,15 +1,11 @@
 # Domaine 35 — Fidélité au noyau invariant
 
-Ce dossier réserve et décrit le domaine **Fidélité au noyau invariant** dans l’architecture scientifique de Tradition Learning. Cette première étape crée uniquement l’organisation documentaire : elle ne complète, ne corrige et n’invente aucun contenu de la théorie.
+Le domaine **Fidélité au noyau invariant** rassemble les développements scientifiques de Tradition Learning consacrés à la fidélité au noyau invariant.
 
-## Sources à transcrire
+## Références scientifiques
 
 - `partie3/Fidelity_to_the_Invariant_Core`
 
-## Fichiers
+## Documents scientifiques
 
-- [`fidelity-to-the-invariant-core.md`](fidelity-to-the-invariant-core.md) — emplacement réservé à la transcription scientifique du chapitre source correspondant.
-
-## État
-
-L’ossature documentaire est créée. Le contenu scientifique devra être transcrit depuis les sources identifiées, sans duplication textuelle avec les autres domaines et sans déduction non autorisée.
+- [`fidelity-to-the-invariant-core.md`](fidelity-to-the-invariant-core.md) — texte scientifique consacré à la fidélité au noyau invariant.

--- a/maths/README.md
+++ b/maths/README.md
@@ -1,61 +1,57 @@
 # Sources scientifiques de Tradition Learning
 
-Le dossier `maths/` contient l’autorité scientifique amont de `tllib-specs`.
+Le dossier `maths/` rassemble les textes qui constituent l’autorité scientifique amont de `tllib-specs`.
 
-## Convention documentaire
+## Organisation
 
-Chaque domaine pertinent dispose de son propre dossier. Chaque dossier contient obligatoirement :
+Chaque domaine dispose d’un dossier autonome contenant :
 
-- un `README.md` bref, limité à la présentation du domaine, aux sources et à l’organisation des fichiers ;
-- un ou plusieurs fichiers `.md` distincts portant le contenu scientifique du domaine.
+- un `README.md` qui présente brièvement son périmètre, ses références et l’organisation de ses documents ;
+- un ou plusieurs fichiers `.md` portant le contenu scientifique du domaine.
 
-Le `README.md` d’un domaine n’est jamais utilisé comme substitut au texte scientifique. Les domaines existants conservent leur contenu sans réécriture. Les nouveaux domaines ne contiennent pour l’instant qu’une ossature explicitement marquée comme non transcrite.
+Les README servent de points d’entrée. Les définitions, équations, axiomes, théorèmes et développements scientifiques sont conservés dans les documents dédiés.
 
 ## Domaines
 
-| Index | Domaine | État documentaire |
-|---:|---|---|
-| 00 | [Maître](00-master/) | Existant, contenu conservé |
-| 01 | [Disciple](01-disciple/) | Existant, contenu conservé |
-| 02 | [Communauté](02-community/) | Existant, contenu conservé |
-| 03 | [Huit dimensions de TL](03-huit-dimensions-de-tl/) | Existant, contenu conservé |
-| 04 | [Invariants](04-invariants/) | Existant, contenu conservé |
-| 05 | [Dynamiques](05-dynamics/) | Existant, contenu conservé |
-| 06 | [Théorèmes](06-theorems/) | Existant, contenu conservé |
-| 07 | [Message](07-message/) | Existant, contenu conservé |
-| 08 | [Principe](08-principle/) | Existant, contenu conservé |
-| 09 | [Valeurs](09-values/) | Existant, contenu conservé |
-| 10 | [Vertus](10-virtues/) | Existant, contenu conservé |
-| 11 | [Capacités](11-capacities/) | Existant, contenu conservé |
-| 12 | [Compétences](12-competencies/) | Existant, contenu conservé |
-| 13 | [Pratique](13-practice/) | Existant, contenu conservé |
-| 14 | [Expérience vécue](14-lived-experience/) | Existant, contenu conservé |
-| 15 | [Relations](15-relations/) | Existant, contenu conservé |
-| 16 | [Cohorte](16-cohort/) | Ossature créée, transcription à faire |
-| 17 | [Transmission en cascade](17-cascade-transmission/) | Ossature créée, transcription à faire |
-| 18 | [Évaluation](18-evaluation/) | Ossature créée, transcription à faire |
-| 19 | [Régulation](19-regulation/) | Ossature créée, transcription à faire |
-| 20 | [Robustesse](20-robustness/) | Ossature créée, transcription à faire |
-| 21 | [Équité](21-fairness/) | Ossature créée, transcription à faire |
-| 22 | [Temporalité](22-temporality/) | Ossature créée, transcription à faire |
-| 23 | [Mémoire](23-memory/) | Ossature créée, transcription à faire |
-| 24 | [Contexte](24-context/) | Ossature créée, transcription à faire |
-| 25 | [Culture](25-culture/) | Ossature créée, transcription à faire |
-| 26 | [Identité](26-identity/) | Ossature créée, transcription à faire |
-| 27 | [Réflexivité](27-reflexivity/) | Ossature créée, transcription à faire |
-| 28 | [Finalité et téléologie évolutive](28-finality-and-evolutionary-teleology/) | Ossature créée, transcription à faire |
-| 29 | [Propagation générationnelle](29-generational-propagation/) | Ossature créée, transcription à faire |
-| 30 | [Expansion](30-expansion/) | Ossature créée, transcription à faire |
-| 31 | [Institutionnalisation](31-institutionalization/) | Ossature créée, transcription à faire |
-| 32 | [Dérive et correction](32-drift-and-correction/) | Ossature créée, transcription à faire |
-| 33 | [Architecture pour environnements à faibles données](33-low-data-architecture/) | Ossature créée, transcription à faire |
-| 34 | [Cycle de transmission](34-transmission-lifecycle/) | Ossature créée, transcription à faire |
-| 35 | [Fidélité au noyau invariant](35-fidelity-to-invariant-core/) | Ossature créée, transcription à faire |
+| Index | Domaine |
+|---:|---|
+| 00 | [Maître](00-master/) |
+| 01 | [Disciple](01-disciple/) |
+| 02 | [Communauté](02-community/) |
+| 03 | [Huit dimensions de TL](03-huit-dimensions-de-tl/) |
+| 04 | [Invariants](04-invariants/) |
+| 05 | [Dynamiques](05-dynamics/) |
+| 06 | [Théorèmes](06-theorems/) |
+| 07 | [Message](07-message/) |
+| 08 | [Principe](08-principle/) |
+| 09 | [Valeurs](09-values/) |
+| 10 | [Vertus](10-virtues/) |
+| 11 | [Capacités](11-capacities/) |
+| 12 | [Compétences](12-competencies/) |
+| 13 | [Pratique](13-practice/) |
+| 14 | [Expérience vécue](14-lived-experience/) |
+| 15 | [Relations](15-relations/) |
+| 16 | [Cohorte](16-cohort/) |
+| 17 | [Transmission en cascade](17-cascade-transmission/) |
+| 18 | [Évaluation](18-evaluation/) |
+| 19 | [Régulation](19-regulation/) |
+| 20 | [Robustesse](20-robustness/) |
+| 21 | [Équité](21-fairness/) |
+| 22 | [Temporalité](22-temporality/) |
+| 23 | [Mémoire](23-memory/) |
+| 24 | [Contexte](24-context/) |
+| 25 | [Culture](25-culture/) |
+| 26 | [Identité](26-identity/) |
+| 27 | [Réflexivité](27-reflexivity/) |
+| 28 | [Finalité et téléologie évolutive](28-finality-and-evolutionary-teleology/) |
+| 29 | [Propagation générationnelle](29-generational-propagation/) |
+| 30 | [Expansion](30-expansion/) |
+| 31 | [Institutionnalisation](31-institutionalization/) |
+| 32 | [Dérive et correction](32-drift-and-correction/) |
+| 33 | [Architecture pour environnements à faibles données](33-low-data-architecture/) |
+| 34 | [Cycle de transmission](34-transmission-lifecycle/) |
+| 35 | [Fidélité au noyau invariant](35-fidelity-to-invariant-core/) |
 
 ## Textes intégrateurs
 
-Les documents de synthèse générale se trouvent dans [`integration/`](integration/). Ils ne sont pas comptés comme domaines autonomes dans cette première organisation.
-
-## Compatibilité des chemins historiques
-
-Les seize anciens fichiers `maths/00-*.md` à `maths/15-*.md` sont maintenus comme liens symboliques vers les nouveaux emplacements. Cette compatibilité évite de rompre immédiatement les références de traçabilité existantes. Leur retrait éventuel devra faire l’objet d’une migration distincte de tous les chemins consommateurs.
+Les textes qui articulent l’ensemble des domaines se trouvent dans [`integration/`](integration/). Ils présentent la synthèse générale de Tradition Learning, son orientation vers l’implémentation et sa formulation comme théorie générale.

--- a/maths/integration/README.md
+++ b/maths/integration/README.md
@@ -1,11 +1,9 @@
 # Intégration générale de Tradition Learning
 
-Ce dossier contient les textes qui synthétisent, articulent ou projettent l’ensemble des domaines. Ils ne sont pas numérotés comme domaines autonomes à ce stade, car leur fonction annoncée est intégratrice.
+Ce dossier rassemble les textes qui articulent les domaines de Tradition Learning dans une vue d’ensemble cohérente. Leur fonction est intégratrice : ils présentent la synthèse de la théorie, son passage vers l’implémentation et sa portée générale.
 
-## Fichiers
+## Documents scientifiques
 
-- [`synthesis-and-supreme-integration.md`](synthesis-and-supreme-integration.md)
-- [`towards-implementation.md`](towards-implementation.md)
-- [`tl-as-a-general-theory.md`](tl-as-a-general-theory.md)
-
-Cette ossature ne contient encore aucune transcription scientifique.
+- [`synthesis-and-supreme-integration.md`](synthesis-and-supreme-integration.md) — synthèse et intégration générale des domaines.
+- [`towards-implementation.md`](towards-implementation.md) — articulation entre la théorie et sa mise en œuvre.
+- [`tl-as-a-general-theory.md`](tl-as-a-general-theory.md) — formulation de Tradition Learning comme théorie générale.


### PR DESCRIPTION
## Summary

- rewrite the `maths/` landing page and all domain README files as stable reader-facing documentation;
- remove migration history, compatibility notes, scaffold language, and work-in-progress phrasing from domain entry pages;
- present each existing domain through its scientific scope and document;
- present each added domain conservatively through its named theory source, without adding scientific claims beyond the source titles;
- keep all scientific content files and compatibility links unchanged.

## Validation

- confirmed the branch contains one commit;
- confirmed the diff is limited to 38 README files under `maths/`;
- confirmed no scientific source document, registry artifact, handoff package, validator, or compatibility link is modified.

## Summary by Sourcery

Reframe the maths domain landing and README files as stable, reader-facing scientific documentation while keeping underlying scientific content unchanged.

Documentation:
- Rewrite the maths/ README to describe the directory structure, domain entry role, and integrative texts as stable scientific documentation.
- Update all domain README files to present each domain by its scientific scope, references, and documents instead of migration or scaffold status.
- Clarify integration/ README to explain its role in synthesizing domains, linking theory, implementation, and general formulation of Tradition Learning.