### PR TITLE
Finalize maths specifications and deterministic catalog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+handoff/** text eol=lf

--- a/maths/17-cascade-transmission/cascade-transmission-system.md
+++ b/maths/17-cascade-transmission/cascade-transmission-system.md
@@ -14,7 +14,9 @@ Il est défini comme le 12-uplet
 
 où $\mathcal G_L$ est le graphe temporel de lignée, $\mathcal G_D$ le graphe doctrinal, $\mathcal F$ la fonction de filiation, $\mathcal P$ le processus de préservation, $\mathcal R$ le système de régulation, $\mathcal C$ le conseil des anciens, $\mathcal A$ l’architecture d’adaptation, $\mathcal S$ le spectre des seuils critiques, $\mathcal M$ les mécanismes de mesure, $\mathcal E$ l’environnement socioculturel, $\mathcal T$ la temporalité multi-échelle et $\mathcal V$ l’espace des valeurs fondatrices.
 
-La transivité est contrôlée : un récepteur ne devient émetteur qu’après validation. Les transformations sont locales au contexte, préservent un noyau essentiel et disposent d’une marge créative.
+> **Convention de notation.** La source réutilise notamment $\mathcal F$ pour la filiation, la fusion et une variable de fidélité, ainsi que $\mathcal R$ pour le système et l’opérateur de régulation. Chaque occurrence conserve ici le sens défini dans sa section.
+
+La transitivité est contrôlée : un récepteur ne devient émetteur qu’après validation. Les transformations sont locales au contexte, préservent un noyau essentiel et disposent d’une marge créative.
 
 ## 2. Axiomes
 

--- a/maths/20-robustness/robustness.md
+++ b/maths/20-robustness/robustness.md
@@ -4,6 +4,8 @@
 
 La robustesse traditionnelle est la capacité du système culturel à préserver son noyau identitaire face aux perturbations tout en restant capable d’adaptation contrôlée. Elle est définie par
 
+> **Convention de notation.** La source emploie $\mathcal R$ pour les différentes composantes de robustesse puis pour une variable dynamique globale ; $\mathcal F$ désigne selon les sections la fidélité $\mathcal F_{\mathrm{fid}}$ ou une composante du système couplé. Ces surcharges sont conservées avec leur sens local.
+
 \[
 \mathcal{R}obustness=\mathcal R_{\text{struct}}\times
 \mathcal R_{\text{proc}}\times\mathcal R_{\text{ctx}}
@@ -38,7 +40,7 @@ La dimension procédurale relève de l’[équité](../21-fairness/fairness.md).
 ## 2. Robustesse intégrée
 
 \[
-\mathcal R_{\text{syst}}=left(\prod_{i=1}^{8}\mathcal R_i^{w_i(t)}\right)
+\mathcal R_{\text{syst}}=\left(\prod_{i=1}^{8}\mathcal R_i^{w_i(t)}\right)
 \exp\!\left(-\sum_{i<j}\operatorname{Cov}(\mathcal R_i,\mathcal R_j)
 -\lambda\|\nabla_{\mathcal{D}im}\mathcal R\|^2\right),
 \]
@@ -158,7 +160,7 @@ sous $\mathcal S_{\text{compl}}(G)\ge\theta_{\text{compl}}$ et $\mathcal F_{\tex
 \]
 
 \[
-\mathcal R_{\text{struct}}=min_{v\in V}
+\mathcal R_{\text{struct}}=\min_{v\in V}
 \frac{\deg(v)}{\deg_{\text{avg}}}\lambda_2(L_G)
 \mathcal S_{\text{conn}}(G)\mathcal A\text{lig}(G,\mathcal T).
 \]
@@ -189,7 +191,7 @@ avec $\|\beta(c)\|\le\beta_{\max}$ et $\mathcal F_{\text{fid}}(\hat y_{\mathcal 
 \]
 
 \[
-\mathcal R_{\text{ctx}}^{\mathcal T}=min_{c\in\mathcal C}
+\mathcal R_{\text{ctx}}^{\mathcal T}=\min_{c\in\mathcal C}
 \frac{\mathcal P(c)}{\mathcal P_{\max}}
 \frac{\mathcal F_{\text{fid}}(c)}{\mathcal F_{\text{fid}}^{\max}}
 \frac{\mathcal A\text{lig}(c,\mathcal T)}{\mathcal A\text{lig}_{\max}}.

--- a/maths/28-finality-and-evolutionary-teleology/finality-and-evolutionary-teleology.md
+++ b/maths/28-finality-and-evolutionary-teleology/finality-and-evolutionary-teleology.md
@@ -78,7 +78,7 @@ H=p\cdot\mathbf F(\mathbf X,u)-L(\mathbf X,u,\mathcal G)
 La trajectoire optimale satisfait aussi
 
 \[
-\frac{\partial V}{\partial t}+min_u
+\frac{\partial V}{\partial t}+\min_u
 \left[L(\mathbf X,u,t,\mathcal G)
 +\nabla_{\mathbf X}V\cdot\mathbf F(\mathbf X,u)\right]=0.
 \]

--- a/maths/33-low-data-architecture/architectural-principles-for-low-data-environments.md
+++ b/maths/33-low-data-architecture/architectural-principles-for-low-data-environments.md
@@ -214,8 +214,14 @@ Le rituel filtre par convolution
 \mathcal T_{\text{rit}}(\mathbf X)=\int K(t-s)\mathbf X(s)\,ds.
 \]
 
-La correction collective donne $\boldsymbol\varepsilon_{\text{final}}=
-\boldsymbol\varepsilon-\mathbf C(\boldsymbol\varepsilon)$ ; la reconstruction générative exige
+La correction collective donne
+
+\[
+\boldsymbol\varepsilon_{\text{final}}
+=\boldsymbol\varepsilon-\mathbf C(\boldsymbol\varepsilon).
+\]
+
+La reconstruction générative exige
 
 \[
 \|\mathcal R_{\text{rec}}(\tilde x)-x\|

--- a/maths/34-transmission-lifecycle/impregnation-phase.md
+++ b/maths/34-transmission-lifecycle/impregnation-phase.md
@@ -93,7 +93,7 @@ La mémoire explicite possède sa propre équation,
 \frac{d\mathcal M_{\mathrm{expl}}}{dt}
 =\mu(t)\mathcal E_{\mathrm{first}}(\mathcal N_{\min},\mathcal D)
 -\lambda_{\mathrm{expl}}\mathcal M_{\mathrm{expl}}
-+\text{recall term},
++\underbrace{\text{terme de rappel}}_{\text{non défini dans la source}},
 \]
 
 puis les deux mémoires sont couplées par

--- a/maths/integration/synthesis-and-supreme-integration.md
+++ b/maths/integration/synthesis-and-supreme-integration.md
@@ -1,3 +1,222 @@
-# Synthesis and Supreme Integration
+# Synthèse et intégration suprême
 
-> Statut : contenu scientifique à transcrire depuis `partie3/Synthesis_and_Supreme_Integration`. Aucune proposition scientifique nouvelle n’est introduite dans cette ossature.
+## 1. Périmètre
+
+La source réunit les modèles de Tradition Learning à deux niveaux : une hiérarchie de métamodèles, puis un système d’interactions entre dimensions complémentaires. Elle ne redéfinit pas les entités, relations et dynamiques déjà spécifiées ; elle décrit leur articulation et renvoie notamment à la [temporalité](../22-temporality/temporality.md), la [mémoire](../23-memory/memory.md), le [contexte](../24-context/context.md), l’[identité](../26-identity/identity.md) et la [finalité](../28-finality-and-evolutionary-teleology/finality-and-evolutionary-teleology.md).
+
+> **Convention de notation.** Dans cette source, $\mathcal M_i$ désigne un niveau de modèle, $\mathcal M(\mathbf X)$ la mémoire attachée à un état et $\mathcal M\text{éta}$ l’opérateur de métamodélisation. Ces emplois distincts sont conservés.
+
+## 2. Hiérarchie des modèles
+
+Les niveaux d’abstraction forment la tour
+
+\[
+\mathcal M_0\subset\mathcal M_1\subset\mathcal M_2
+\subset\cdots\subset
+\mathcal M_\infty
+=\varinjlim_{i\to\infty}\mathcal M_i.
+\]
+
+$\mathcal M_0$ porte sur la pratique immédiate, $\mathcal M_1$ sur les compétences et $\mathcal M_2$ sur les vertus. La source présente $\mathcal M_\infty$ comme une limite inductive idéale.
+
+Le passage entre deux niveaux est assuré par
+
+\[
+F_{i\to i+1}:\mathcal M_i\to\mathcal M_{i+1},
+\qquad
+F_{i\to i+1}(\mathbf X)
+=\mathbf X+\varepsilon_i(\mathbf X)
+\Delta_i(\mathbf X,\nabla\mathbf X).
+\]
+
+$\Delta_i$ donne une direction de montée dans la hiérarchie et $\varepsilon_i$ en règle l’amplitude. L’adaptation de ces opérateurs dépend du contexte, de l’histoire et du sujet.
+
+La propriété d’« exhaustivité asymptotique » est formulée par
+
+\[
+\lim_{i\to\infty}
+\left\lVert F_{0\to i}(\mathbf X)-\mathbf X_\infty\right\rVert
+=0
+\quad\text{dans}\quad
+\mathcal M_\infty\otimes\mathcal Dim.
+\]
+
+## 3. Auto-référence et cohérence du métamodèle
+
+L’opérateur enrichi est
+
+\[
+\mathcal M\text{éta}:\mathcal M_i\to\mathcal M_{i+1},
+\qquad
+\mathcal M\text{éta}(\mathbf X)
+=\bigl(
+\mathbf X,\nabla\mathbf X,\nabla^2\mathbf X,
+\mathcal M(\mathbf X),\mathcal I(\mathbf X)
+\bigr).
+\]
+
+Il adjoint à l’état ses dérivées, sa mémoire et son identité. La contrainte de cohérence forte est
+
+\[
+\Phi_{\text{méta}}(\mathbf X)
+=\left\lVert\mathcal M\text{éta}(\mathbf X)-\mathbf X\right\rVert^2
++\lambda
+\left\lVert
+\nabla\mathcal M\text{éta}(\mathbf X)-\nabla\mathbf X
+\right\rVert^2
+\leq\varepsilon_{\text{méta}}.
+\]
+
+Le premier terme mesure la fidélité de la représentation au modèle ; le second compare leurs dynamiques locales.
+
+## 4. Espace multidimensionnel intégré
+
+La source construit le produit fibré
+
+\[
+\begin{aligned}
+\mathcal Dim_{\text{total}}
+={}&\mathcal Temps\times_{\mathcal{TLS}}\mathcal M\text{émoire}
+\times_{\mathcal{TLS}}\mathcal Contexte
+\times_{\mathcal{TLS}}\mathcal I\text{dentité}\\
+&\times_{\mathcal{TLS}}\mathcal F\text{inalité}
+\times_{\mathcal{TLS}}\mathcal M\text{éta}.
+\end{aligned}
+\]
+
+Chaque facteur est présenté comme une fibration sur le système de tradition $\mathcal{TLS}$. La compatibilité de deux dimensions $D_i$ et $D_j$ exige
+
+\[
+\Phi_{ij}(D_i,D_j)
+=\left\lVert\mathcal C_{D_i}-\mathcal C_{D_j}\right\rVert^2
++\left\lVert
+\nabla_{D_i}\mathcal C_{D_j}
+-\nabla_{D_j}\mathcal C_{D_i}
+\right\rVert^2
+\leq\theta_{ij}(t).
+\]
+
+## 5. Dynamique et interactions
+
+La dynamique intégratrice est
+
+\[
+\frac{d\mathbf X}{dt}
+=\mathbf F_{\text{total}}\!\left(
+\mathbf X,
+\mathcal M(\mathbf X),
+\mathcal C_{\text{contexte}},
+\mathcal I_{\text{identité}},
+\mathcal G_{\text{finalité}},
+\mathcal M\text{éta}(\mathbf X),
+t,
+\nabla_{\mathcal Dim}\mathbf X
+\right).
+\]
+
+L’interaction de deux dimensions est mesurée par
+
+\[
+\begin{aligned}
+\mathcal I_{D_iD_j}(\mathbf X)
+={}&\alpha_{ij}\nabla_{D_i}\mathbf F\cdot\nabla_{D_j}\mathbf F
++\beta_{ij}\nabla^2_{D_iD_j}\mathbf F\\
+&+\gamma_{ij}
+\frac{\partial\mathbf F}{\partial(\nabla D_i)}
+\cdot
+\frac{\partial\mathbf F}{\partial(\nabla D_j)}.
+\end{aligned}
+\]
+
+La source interprète ces termes comme corrélation des gradients, courbure croisée et interaction de dépendances aux gradients.
+
+## 6. Émergence et stabilité
+
+Les propriétés transdimensionnelles sont définies par
+
+\[
+\mathcal E_{\text{cross}}
+=\left\{
+\mathcal P\in\mathcal{TLS}
+\;\middle|\;
+\mathcal P=\Psi(D_1,\ldots,D_6),\;
+\frac{\partial\Psi}{\partial D_i}\neq0,\;
+\nabla_{\mathcal Dim}\mathcal P\neq0
+\right\}.
+\]
+
+Une configuration intégrée est dite stable dans la source si les quatre conditions suivantes sont réunies :
+
+\[
+\operatorname{Re}(\sigma(J_{\text{total}}))< -\delta<0,
+\qquad
+\Phi_{ij}(D_i,D_j)\leq\theta_{ij}(t),
+\]
+
+\[
+\left\lVert\nabla_D\mathbf F_{\text{total}}\right\rVert\leq M_D,
+\qquad
+\mathcal P_{\text{prés}}>\theta_{\text{prés}}.
+\]
+
+La source énonce, sous des conditions nommées de régularité, compatibilité et préservation, l’existence de configurations stables et leur caractère d’attracteurs locaux.
+
+## 7. Métriques intégratrices
+
+L’harmonie dimensionnelle globale est
+
+\[
+\mathcal H_{\text{dim}}(t)
+=\prod_{i=1}^{6}
+\left(
+1-\frac{\lVert\nabla_{D_i}\mathbf F\rVert}
+{\lVert\mathbf F\rVert+\varepsilon}
+\right)
+\exp\!\left(
+-\sum_{i<j}\Phi_{ij}(D_i,D_j)
+-\lVert\nabla_{\mathcal Dim}\mathbf F\rVert^2
+\right).
+\]
+
+La flexibilité multiscalaire et la résilience transdimensionnelle sont respectivement
+
+\[
+\mathcal F_{\text{flex}}(t)
+=\frac{1}{6}\sum_{i=1}^{6}
+\left\lVert\frac{\partial\mathbf X^*}{\partial D_i}\right\rVert^{-1}
+\mathcal H_{\text{dim}}(t)
+\exp\!\left(-\frac{\lVert d\mathbf X^*/dt\rVert^2}{2\sigma^2}\right),
+\]
+
+\[
+\mathcal R_{\text{cross}}(t)
+=\min_{D_i}
+\left(\frac{1}{\sigma(\mathbf X_{D_i})+\varepsilon}\right)
+\mathcal H_{\text{dim}}(t)
+\exp\!\left(
+-\lVert\nabla_{\mathcal Dim}\mathbf F\rVert
+-\lVert d\mathcal Dim/dt\rVert
+\right).
+\]
+
+## 8. Résultats formulés par la source
+
+La source donne le statut de théorème aux affirmations suivantes :
+
+- hiérarchie stricte des émergences $\mathcal E_{\text{dim}}\subsetneq\mathcal E_{\text{cross}}\subsetneq\mathcal E_{\text{méta}}\subsetneq\mathcal E_{\text{total}}$ ;
+- irréductibilité de $\mathcal E_{\text{cross}}$ à la somme directe des propriétés dimensionnelles ;
+- existence globale de solutions dans $\mathcal{TLS}\otimes\mathcal Dim$ sous régularité, compatibilité et préservation ;
+- convergence harmonique $\Phi_{ij}\to0$ et $\mathcal H_{\text{dim}}\to1$.
+
+Ces énoncés sont transcrits avec leur statut source ; le chapitre ne fournit pas leurs démonstrations.
+
+## 9. Limites et points scientifiques non résolus
+
+- Les inclusions $\mathcal M_i\subset\mathcal M_{i+1}$, les catégories sous-jacentes et le système inductif définissant $\varinjlim\mathcal M_i$ ne sont pas construits.
+- $F_{i\to i+1}$ est qualifié de foncteur, mais ses catégories, morphismes, identités et lois de composition ne sont pas spécifiés.
+- $\mathcal M\text{éta}(\mathbf X)$ et $\mathbf X$ n’ont pas le même type apparent dans $\Phi_{\text{méta}}$ ; leur soustraction n’est pas justifiée.
+- Les fibrations et les applications vers la base $\mathcal{TLS}$ nécessaires au produit fibré ne sont pas données.
+- La dynamique intégratrice affirme une cohérence et une unicité des solutions sans hypothèses analytiques détaillées.
+- Les espaces $\mathcal E_{\text{dim}}$, $\mathcal E_{\text{cross}}$, $\mathcal E_{\text{méta}}$ et $\mathcal E_{\text{total}}$ ne sont pas construits comme espaces vectoriels, alors que des dimensions et sommes directes leur sont appliquées.
+- Le facteur $1-\lVert\nabla_{D_i}\mathbf F\rVert/(\lVert\mathbf F\rVert+\varepsilon)$ peut être négatif ; la source n’établit donc pas que $\mathcal H_{\text{dim}}$ appartient à $[0,1]$.
+- Les théorèmes d’existence, de stabilité, d’émergence et de convergence sont énoncés sans démonstration ni formulation complète des hypothèses.

--- a/maths/integration/tl-as-a-general-theory.md
+++ b/maths/integration/tl-as-a-general-theory.md
@@ -1,3 +1,114 @@
-# TL as a General Theory
+# Tradition Learning comme théorie générale
 
-> Statut : contenu scientifique à transcrire depuis `partie3/TL_as_a_General_Theory`. Aucune proposition scientifique nouvelle n’est introduite dans cette ossature.
+## 1. Statut et périmètre
+
+La source présente Tradition Learning comme un cadre général de transmission et de transformation susceptible d’éclairer l’intelligence artificielle, l’éducation, les organisations, le développement personnel et la durée des civilisations. Cette portée est une proposition théorique et programmatique : le chapitre ne donne ni théorème d’universalité ni validation empirique générale.
+
+Le texte compare TL à l’apprentissage fondé sur l’information et à l’éducation institutionnelle, formule des applications possibles, puis consacre une partie explicite aux objections, aux difficultés de validation et aux risques d’interprétation.
+
+## 2. Objets généraux proposés
+
+Le cadre est organisé autour d’objets déjà spécifiés dans les domaines scientifiques :
+
+- des personnes et rôles de transmission, reliés durablement plutôt que réduits à des producteurs et consommateurs de données ;
+- une [communauté](../02-community/community.md) porteuse de mémoire, d’évaluation et de régulation ;
+- un état de transformation intégrant compétences, capacités, principes, vertus, valeurs et identité ;
+- un [noyau invariant](../04-invariants/invariants.md) soumis à des variations contextuelles contrôlées ;
+- un [cycle de transmission](../34-transmission-lifecycle/operational-pipeline.md) allant de l’initiation à la capacité de transmettre ;
+- des artefacts, rites et récits qui distribuent la mémoire ;
+- une évaluation multidimensionnelle et communautaire ;
+- des mécanismes de fidélité, adaptation, correction et propagation générationnelle.
+
+Ces objets sont proposés comme communs aux domaines d’application discutés. La source ne démontre pas qu’ils sont nécessaires ou suffisants pour toute forme d’apprentissage.
+
+## 3. Comparaison avec l’apprentissage fondé sur l’information
+
+La comparaison formulée par la source porte sur cinq dimensions :
+
+| Dimension | Apprentissage fondé sur l’information | Tradition Learning selon la source |
+|---|---|---|
+| Fondement | Régularités extraites de données | Savoirs portés par des personnes, communautés et traditions vivantes |
+| Nature de l’apprentissage | Ajustement statistique d’un modèle | Transformation par immersion, relation et pratique |
+| Évaluation | Métriques quantitatives sur des données de test | Évaluation technique, éthique, contextuelle, identitaire et communautaire |
+| Données | Dépendance à leur quantité et représentativité | Exploitation de peu d’exemples par répétition, redondance et principes |
+| Éthique | Contraintes ou corrections souvent ajoutées | Valeurs et principes placés au cœur du dispositif théorique |
+
+Le texte affirme un avantage de TL dans les situations à faibles données et une robustesse liée à l’incarnation, à la communauté et à la mémoire distribuée. Il ne fournit toutefois aucune comparaison expérimentale ou borne mathématique établissant une supériorité générale.
+
+## 4. Complémentarités et non-équivalence
+
+La source n’oppose pas absolument TL aux approches computationnelles. Elle envisage :
+
+- des architectures à faibles données inspirées de la redondance, de la pratique et de l’apprentissage par principes ;
+- l’assistance au suivi des trajectoires, à la recommandation et à la simulation ;
+- des systèmes hybrides associant maître humain et outils d’intelligence artificielle ;
+- des systèmes multi-agents où les rôles de maître, disciple et pair structurent les interactions.
+
+Ces propositions sont des perspectives. Elles ne constituent ni une équivalence entre agents logiciels et personnes, ni une architecture algorithmique complète, ni une preuve que les mécanismes TL se transfèrent sans perte vers l’IA.
+
+## 5. Comparaison avec l’éducation institutionnelle
+
+Le texte oppose des tendances structurelles : finalité de transformation globale plutôt que seule acquisition standardisée, relation durable maître-disciple plutôt que relation pédagogique distante, progression par seuils plutôt que calendrier uniforme, et validation communautaire plutôt qu’examen exclusivement externe.
+
+Il propose comme complémentarités le mentorat de long terme, l’apprentissage expérientiel, l’implication de la communauté, l’incarnation des valeurs et la reconnaissance de compétences non académiques. Les dispositifs hybrides cités sont des écoles intégrant l’apprentissage auprès de praticiens, des parcours universitaires de mentorat et des formations professionnelles avec validation par les pairs.
+
+Ces descriptions sont comparatives et normatives ; elles ne démontrent pas que toute institution possède les caractéristiques critiquées ni que tout dispositif TL produit de meilleurs résultats.
+
+## 6. Domaines d’application mentionnés
+
+La source envisage quatre familles d’application :
+
+- **intelligence artificielle** : faibles données, systèmes multi-agents et alignement éthique ;
+- **éducation** : conception de parcours, formation des enseignants et évaluation communautaire ;
+- **organisations** : culture, transmission des savoirs tacites, leadership et succession ;
+- **développement personnel et transmission familiale** : autoformation, identité et passage entre générations.
+
+Elle mobilise aussi TL comme grille d’interprétation de la continuité culturelle : transmission d’un noyau, adaptation périphérique, rôle des maîtres et institutions, fidélité et régénération après les crises. L’expression « ADN culturel » est une analogie employée pour le noyau invariant ; elle n’établit aucune identité avec un mécanisme biologique.
+
+## 7. Portée des affirmations
+
+### 7.1 Affirmations explicites
+
+La source affirme que TL vise la transformation multidimensionnelle, fonctionne théoriquement avec peu de données, articule transmission et adaptation et intègre l’éthique dès ses objets fondamentaux. Elle présente les communautés, la mémoire, les artefacts et la validation comme des mécanismes de continuité.
+
+### 7.2 Analogies et illustrations
+
+Le noyau comme « ADN culturel », les traditions comme moteurs de civilisation et les cas historiques cités sont des analogies ou illustrations. Ils ne sont pas formalisés comme équivalences ni évalués comme démonstrations comparatives.
+
+### 7.3 Ambitions et perspectives
+
+La reconstruction des communautés, la formation de maîtres, l’IA alignée inspirée de TL, les réformes éducatives et la renaissance culturelle sont formulées comme projets ou pistes. Leur faisabilité et leur efficacité restent à établir.
+
+### 7.4 Résultats démontrés
+
+Ce fichier source ne contient aucun environnement `theorem`, `proposition` ou démonstration mathématique. Il réemploie des résultats annoncés dans les chapitres antérieurs, mais n’en établit pas de nouveau concernant la généralité de TL.
+
+## 8. Limites reconnues par la source
+
+La source énumère quatre limites propres à TL :
+
+- lenteur des transformations ;
+- dépendance envers des maîtres, des communautés et des relations de confiance ;
+- risque de dogmatisme ;
+- difficulté à mesurer les dimensions qualitatives.
+
+Elle formule également trois objections théoriques : essentialisme du noyau invariant, conservatisme possible et idéalisation des traditions passées. Les réponses proposées invoquent un noyau lentement évolutif, l’innovation fidèle et le statut illustratif des exemples ; elles ne suppriment pas empiriquement les objections.
+
+Les difficultés de validation concernent la mesure de concepts subtils, le grand nombre de paramètres et la durée générationnelle des phénomènes. Les réponses envisagées — études empiriques progressives, cohortes synthétiques, récits de vie, archives et comparaisons — restent des stratégies de recherche.
+
+## 9. Risques et garde-fous formulés
+
+Les risques nommés sont la dérive dogmatique, l’instrumentalisation politique et la réduction de TL à une méthode ou à un ensemble d’équations. Les garde-fous avancés sont la pluralité des maîtres, la diversité des interprétations, le dialogue, le consensus, l’équité et la justice.
+
+Le texte affirme que TL est incompatible avec la domination et l’oppression en raison de son éthique fondamentale. Cette incompatibilité est une exigence normative de la source ; aucun mécanisme formel n’y démontre qu’un système se réclamant de TL ne peut pas être détourné.
+
+## 10. Limites de généralité et points scientifiques non résolus
+
+- La qualification de « théorie générale » n’est accompagnée ni d’un domaine mathématique universel, ni d’un critère de réfutabilité commun à toutes les applications.
+- Les comparaisons avec ML, DL, RL et l’éducation institutionnelle sont qualitatives et ne reposent pas dans ce chapitre sur un protocole expérimental commun.
+- Les affirmations de fiabilité, robustesse et transparence ne sont pas assorties d’estimations comparatives ou de conditions nécessaires et suffisantes.
+- Le passage des mécanismes humains et communautaires à des systèmes artificiels reste analogique ; les correspondances entre rôles humains et agents ne sont pas construites.
+- Le noyau invariant est présenté à la fois comme condition de continuité et comme construction communautaire révisable ; le critère de révision légitime reste ouvert.
+- Les exemples historiques et civilisationnels illustrent la théorie mais ne prouvent ni sa portée causale ni son applicabilité universelle.
+- Les garde-fous éthiques sont des prescriptions ; leur efficacité face à une instrumentalisation réelle n’est pas démontrée.
+- Les perspectives d’implémentation et de réforme sont des ambitions de recherche, non des résultats établis.

--- a/maths/integration/towards-implementation.md
+++ b/maths/integration/towards-implementation.md
@@ -1,3 +1,214 @@
-# Towards Implementation
+# Vers l’implémentation
 
-> Statut : contenu scientifique à transcrire depuis `partie3/Towards_Implementation`. Aucune proposition scientifique nouvelle n’est introduite dans cette ossature.
+## 1. Périmètre
+
+La source organise le passage de la théorie vers l’observation et la simulation autour de quatre tâches : mesurer la transformation, définir des indicateurs observables, calibrer des paramètres structurels et intégrer les dynamiques dans des simulations. Ce document reste une spécification scientifique : il ne définit ni API, ni classe, ni base de données, ni environnement d’exécution.
+
+Les dynamiques de référence restent celles des domaines existants, notamment l’[évaluation](../18-evaluation/evaluation.md), la [robustesse](../20-robustness/robustness.md), l’[architecture à faibles données](../33-low-data-architecture/architectural-principles-for-low-data-environments.md) et le [cycle de transmission](../34-transmission-lifecycle/operational-pipeline.md).
+
+## 2. État observable et dimensions de transformation
+
+La source retient cinq dimensions : maîtrise technique, intégrité éthique, intelligence contextuelle, cohérence comportementale et capacité de transmission.
+
+La maîtrise technique est une application
+
+\[
+M_T:\mathcal D\times\mathbb R^+\longrightarrow\mathbb R^+,
+\qquad
+M_T(d,t)=\Phi_T\bigl(\mathbf C_a(d,t)\bigr),
+\]
+
+où $\mathbf C_a(d,t)$ est le vecteur des compétences et $\Phi_T$ une fonction d’agrégation. Ses sous-dimensions sont la précision, la fluidité, la vitesse, l’efficacité et la robustesse.
+
+L’intégrité éthique est
+
+\[
+I_E:\mathcal D\times\mathbb R^+\longrightarrow[0,1],
+\qquad
+I_E(d,t)
+=\Psi_E\bigl(\mathbf{Val}(d,t),\mathbf A(d,t)\bigr),
+\]
+
+où $\mathbf{Val}$ contient les valeurs intériorisées et $\mathbf A$ la trace des actions observées. La cohérence parole-action est notamment
+
+\[
+C_{pa}(d,t)
+=1-
+\frac{
+\left\lVert\pi_{\mathcal Val}(\mathbf A(t))-\mathbf{Val}(t)\right\rVert}
+{\left\lVert\mathbf{Val}(t)\right\rVert
++\left\lVert\pi_{\mathcal Val}(\mathbf A(t))\right\rVert}.
+\]
+
+L’intelligence contextuelle est
+
+\[
+I_C:\mathcal D\times\mathbb R^+\longrightarrow\mathbb R^+,
+\qquad
+I_C(d,t)
+=\Xi_C\bigl(\mathbf C_a(d,t),\mathcal E_{\mathrm{exp}}(d,t)\bigr),
+\]
+
+et comprend perception, adaptation, transfert, innovation et anticipation. L’adaptation est donnée par
+
+\[
+A_d(d,t)
+=\mathbb E_{c\sim\mu_{\mathcal C}}
+\left[
+\exp\!\left(
+-\left\lVert\mathbf C_a(d,t,c)-\mathbf C_a^*(c)\right\rVert
+\right)
+\right].
+\]
+
+La cohérence comportementale est
+
+\[
+C_C:\mathcal D\times\mathbb R^+\longrightarrow[0,1],
+\qquad
+C_C(d,t)=\Gamma_C\bigl(\mathbf R(d,t),\mathbf X(d,t)\bigr),
+\]
+
+où $\mathbf R$ est l’état identitaire et $\mathbf X$ l’état global.
+
+La capacité de transmission est
+
+\[
+C_T:\mathcal D\times\mathbb R^+\longrightarrow\mathbb R^+,
+\qquad
+C_T(d,t)
+=\Theta_T\bigl(
+\mathbf C_a(d,t),
+\mathcal P_{\mathrm{ped}}(d,t),
+\mathcal R_{\mathrm{soc}}(d,t)
+\bigr).
+\]
+
+Elle réunit les compétences pédagogiques, relationnelles, diagnostiques et régulatrices ainsi que l’innovation contrôlée.
+
+## 3. Agrégation et axiomes de mesure
+
+L’indice global de transformation est
+
+\[
+\mathcal{TG}(d,t)
+=\alpha_TM_T(d,t)
++\alpha_EI_E(d,t)
++\alpha_CI_C(d,t)
++\alpha_{Coh}C_C(d,t)
++\alpha_{Tr}C_T(d,t),
+\qquad
+\sum\alpha=1.
+\]
+
+La source pose trois axiomes :
+
+1. pour chaque dimension, une procédure humaine ou automatisée fournit une valeur numérique à un instant donné ;
+2. les sous-dimensions sont normalisées sur $[0,1]$ ou $\mathbb R^+$ avec des échelles comparables ;
+3. les indicateurs augmentent avec la progression, sauf cas pathologiques.
+
+Ces mesures alimentent les boucles de régulation ; elles ne remplacent pas l’évaluation qualitative et communautaire.
+
+## 4. Flux scientifique d’observation
+
+La trajectoire observée est la suite des états du disciple dans l’espace des dimensions mesurables. Les indicateurs explicitement nommés sont
+
+\[
+v(t)=\left\lVert\frac{d\mathbf X}{dt}\right\rVert,
+\qquad
+\theta(t)=\operatorname{angle}\!\left(
+\frac{d\mathbf X}{dt},\mathbf X_{\mathrm{target}}-\mathbf X
+\right),
+\qquad
+\kappa(t)=\left\lVert\frac{d^2\mathbf X}{dt^2}\right\rVert.
+\]
+
+Ils sont complétés par la distance aux seuils et la variance sur une fenêtre temporelle. La chaîne scientifique décrite par le texte va donc de l’observation des états à la construction des indicateurs, puis à la détection de trajectoires anormales et à l’ajustement des paramètres.
+
+## 5. Contraintes de faibles données
+
+Les critères retenus sont la vitesse d’apprentissage, la généralisation, la robustesse, l’interprétabilité et l’alignement éthique. La source nomme comme techniques possibles l’apprentissage par transfert, semi-supervisé, auto-supervisé et fondé sur des principes. Elle n’impose aucun algorithme ni modèle concret.
+
+Les cohortes synthétiques sont définies comme des ensembles de disciples virtuels dont les traits, typologies et paramètres individuels sont échantillonnés, puis dont l’évolution est soumise aux équations TL. Elles servent à tester des hypothèses, explorer l’effet des paramètres et préparer des scénarios. Leurs résultats doivent rester distincts d’une validation sur des observations réelles.
+
+## 6. Paramètres à calibrer
+
+La source identifie huit paramètres structurels :
+
+- intensité de la mission ;
+- densité communautaire ;
+- pression environnementale ;
+- taux d’adaptation ;
+- niveau de résistance ;
+- taux de reproduction $R$ ;
+- sensibilité aux seuils ;
+- temps de maturation.
+
+Le taux de reproduction est défini par
+
+\[
+R
+=\frac{\text{nombre de nouveaux transmetteurs}}
+{\text{nombre de transmetteurs}},
+\]
+
+avec les régimes $R>1$, $R=1$ et $R<1$ respectivement associés dans la source à l’expansion, la stabilité et au déclin.
+
+Le calibrage doit tenir compte du contexte, de la tradition et de la phase d’apprentissage. Le chapitre ne fournit pas une procédure d’identification unique pour ces paramètres.
+
+## 7. Modélisation intégrée et simulation
+
+Le système de simulation réunit cinq blocs : évolution individuelle, dynamique de cohorte, interactions communautaires, régulation et adaptation, dimensions complémentaires. La source reprend l’équation intégrée spécifiée dans [Synthèse et intégration suprême](synthesis-and-supreme-integration.md), puis précise qu’elle est trop générale pour une résolution analytique et doit être approchée numériquement.
+
+Un sous-système réduit du disciple comprend notamment
+
+\[
+\begin{aligned}
+\frac{dC}{dt}
+&=\kappa_1O(t)(C_{\max}-C)
+\sigma(\mathcal V_{\mathrm{rec}}-\theta_1)
+\mathbb{1}_{\{\mathcal{V}al_{\mathrm{open}}>\psi_1\}},\\
+\frac{dV}{dt}
+&=\alpha\mathcal P_{\mathrm{pratique}}(V_{\max}-V)
++\beta CV+\gamma\mathcal{V}al\nabla\mathcal E,\\
+\frac{dVal}{dt}
+&=\lambda(Val_{\mathrm{master}}-Val)
++\mu V\nabla Val+\eta(t),\\
+\frac{dI}{dt}
+&=A(I)+B(M-I)+C\bigl(I\times(M-I)\bigr)
++D(\nabla V_{\mathrm{ident}}).
+\end{aligned}
+\]
+
+Des influences des pairs, du maître et de la communauté sont ajoutées à ce système, puis des boucles ajustent seuils et poids. Les simulations visent les trajectoires de réussite, stagnation, déviance et crise ainsi que les scénarios de perte du maître, schisme, pression externe ou dispersion.
+
+## 8. Validation et stabilité
+
+Un point fixe satisfait $d\mathbf X/dt=0$. La source retient le critère local suivant : toutes les valeurs propres du Jacobien ont une partie réelle négative pour la stabilité ; la présence d’une partie réelle positive caractérise l’instabilité ; des valeurs propres purement imaginaires peuvent être associées à des cycles limites.
+
+Les sorties de simulation sont comparées à des trajectoires historiques ou observées. Les indicateurs de crise sont le taux de survie, le temps de récupération, la perte de fidélité et l’innovation post-crise.
+
+## 9. Conséquences pour les spécifications
+
+Une future implémentation doit représenter sans les confondre :
+
+- l’état scientifique et ses dimensions ;
+- les observations et leur provenance ;
+- les indicateurs dérivés et leurs normalisations ;
+- les paramètres calibrés et leur contexte de validité ;
+- les trajectoires simulées et les observations empiriques ;
+- les décisions de régulation et la validation communautaire.
+
+La source ne définit cependant ni séparation logicielle normative entre ces éléments, ni format de données, ni protocole runtime.
+
+## 10. Limites et points scientifiques non résolus
+
+- Plusieurs agrégations sont introduites par des fonctions $\Phi_T$, $\Psi_E$, $\Xi_C$, $\Gamma_C$ et $\Theta_T$ non construites.
+- Certaines métriques contiennent des divisions dont les dénominateurs peuvent être nuls, sans convention de repli.
+- La vitesse technique $R=T_{\mathrm{ref}}/T_{\mathrm{exec}}$ est fixée à $1$ « autrement » dans la source ; sa définition par cas et sa normalisation ne sont pas entièrement formalisées.
+- L’agrégation de l’intégrité éthique contient littéralement des « additional terms » pour $R_t$ et $R_p$ ; ces termes ne sont pas complétés ici.
+- L’axiome d’observabilité affirme l’existence de procédures de mesure, mais le chapitre reconnaît ensuite la difficulté de mesurer les vertus, valeurs et identités.
+- Les techniques de faibles données sont énumérées sans protocole de sélection, hypothèses statistiques ni preuve d’adéquation aux objets TL.
+- Les cohortes synthétiques dépendent du modèle qu’elles sont censées évaluer ; la source ne donne pas de procédure indépendante de validation empirique.
+- L’équation intégrée et plusieurs sous-systèmes utilisent des termes génériques, des points de suspension ou du texte comme « noise » ; ils ne constituent pas un système numérique fermé.
+- Les conditions dites nécessaires à la stabilité sont proposées comme résultats de simulation possibles et non démontrées comme nécessités mathématiques générales.

--- a/reports/scientific-extraction/capacities/scientific-extraction-report.md
+++ b/reports/scientific-extraction/capacities/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\11-capacities.md`
+- Source du dépôt : `maths/11-capacities/capacities.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/11-capacities/capacities.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/community/scientific-extraction-report.md
+++ b/reports/scientific-extraction/community/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\02-community.md`
+- Source du dépôt : `maths/02-community/community.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/02-community/community.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/competencies/scientific-extraction-report.md
+++ b/reports/scientific-extraction/competencies/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\12-competencies.md`
+- Source du dépôt : `maths/12-competencies/competencies.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/12-competencies/competencies.md`
 - Branche : `main`
 - Commit source : `aef09e74f85b5f0c930d5940f1753536af61686f`

--- a/reports/scientific-extraction/disciple/scientific-extraction-report.md
+++ b/reports/scientific-extraction/disciple/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\01-disciple.md`
+- Source du dépôt : `maths/01-disciple/disciple.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/01-disciple/disciple.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/dynamics/scientific-extraction-report.md
+++ b/reports/scientific-extraction/dynamics/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\05-dynamics.md`
+- Source du dépôt : `maths/05-dynamics/dynamics.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/05-dynamics/dynamics.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/huit-dimensions-de-tl/scientific-extraction-report.md
+++ b/reports/scientific-extraction/huit-dimensions-de-tl/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\03-huit-dimensions-de-tl.md`
+- Source du dépôt : `maths/03-huit-dimensions-de-tl/huit-dimensions-de-tl.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/03-huit-dimensions-de-tl/huit-dimensions-de-tl.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/invariants/scientific-extraction-report.md
+++ b/reports/scientific-extraction/invariants/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\04-invariants.md`
+- Source du dépôt : `maths/04-invariants/invariants.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/04-invariants/invariants.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/lived-experience/scientific-extraction-report.md
+++ b/reports/scientific-extraction/lived-experience/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\14-lived-experience.md`
+- Source du dépôt : `maths/14-lived-experience/lived-experience.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/14-lived-experience/lived-experience.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/master/scientific-extraction-report.md
+++ b/reports/scientific-extraction/master/scientific-extraction-report.md
@@ -19,7 +19,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 ## Source et environnement
 
 - Source traitée : `maths/00-master/master.md`
-- Source locale : `C:\TLC\repo\tllib-specs\maths\00-master.md`
+- Source du dépôt : `maths/00-master/master.md`
 - URL reçue : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/00-master/master.md`
 - Branche : `main`
 - Commit source : `fe8b990d7560869889b153cc8422b5d6918678e6`

--- a/reports/scientific-extraction/message/scientific-extraction-report.md
+++ b/reports/scientific-extraction/message/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\07-message.md`
+- Source du dépôt : `maths/07-message/message.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/07-message/message.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/practice/scientific-extraction-report.md
+++ b/reports/scientific-extraction/practice/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\13-practice.md`
+- Source du dépôt : `maths/13-practice/practice.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/13-practice/practice.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/principle/scientific-extraction-report.md
+++ b/reports/scientific-extraction/principle/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\08-principle.md`
+- Source du dépôt : `maths/08-principle/principle.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/08-principle/principle.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/relations/scientific-extraction-report.md
+++ b/reports/scientific-extraction/relations/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\15-relations.md`
+- Source du dépôt : `maths/15-relations/relations.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/15-relations/relations.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/theorems/scientific-extraction-report.md
+++ b/reports/scientific-extraction/theorems/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\06-theorems.md`
+- Source du dépôt : `maths/06-theorems/theorems.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/06-theorems/theorems.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/values/scientific-extraction-report.md
+++ b/reports/scientific-extraction/values/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\09-values.md`
+- Source du dépôt : `maths/09-values/values.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/09-values/values.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`

--- a/reports/scientific-extraction/virtues/scientific-extraction-report.md
+++ b/reports/scientific-extraction/virtues/scientific-extraction-report.md
@@ -18,7 +18,7 @@ generator_role: TLC_SCIENTIFIC_OBJECT_EXTRACTOR
 
 ## Source et périmètre
 
-- Source locale : `C:\TLC\repo\tllib-specs\maths\10-virtues.md`
+- Source du dépôt : `maths/10-virtues/virtues.md`
 - URL GitHub : `https://github.com/Tradition-Learning-Community/tllib-specs/blob/main/maths/10-virtues/virtues.md`
 - Branche : `main`
 - Commit source : `68a4d4c728bab655631543b3e1788d4f0da31e8e`


### PR DESCRIPTION
## Summary

- Corrects transcription, typography, and LaTeX rendering defects in the new maths domains.
- Addresses the still-valid review findings from PR #139, including overloaded-notation reading notes.
- Replaces the three integration placeholders with scientific specifications extracted exclusively from the authoritative local `.tex` sources.
- Removes every targeted placeholder under `maths/`.
- Makes deterministic handoff hashing stable across Windows and Linux by enforcing LF for `handoff/**`.
- Replaces 16 pre-existing machine-local report paths with repository-logical source paths so the required global path scan is clean.
- Adds no scientific invention, implementation, handoff package mutation, PDF, or Internet-derived theory.

## Corrected issues

- `transivité` → `transitivité` in cascade transmission.
- `left(` → `\left(` in system robustness.
- Missing operator backslashes restored after checking the corresponding TeX:
  - `min_{v\in V}` → `\min_{v\in V}` in robustness;
  - `min_u` → `\min_u` in evolutionary teleology.
- A cross-line inline formula in the low-data architecture is now a display formula.
- The source-literal, undefined `recall term` is no longer left as a raw formula fragment; the equation marks it as an undefined source term and the scientific limitation is preserved.
- Neutral local notation conventions document source-level overloads of `\mathcal F` and `\mathcal R` without renaming theory symbols.
- Repository-wide targeted searches find no unescaped `left/right`, raw mathematical extrema operators, or malformed `mathcal/mathbb/mathbf/mathrm/text/operatorname` commands.
- A delimiter/environment audit of all Markdown under `maths/` finds no unmatched display delimiters, inline dollar delimiters, `left/right` pairs, or `aligned/cases/matrix/pmatrix/bmatrix` environments.

## Integration source coverage

| Document | Source(s) .tex | Sections covered | Limits preserved |
|---|---|---|---|
| `synthesis-and-supreme-integration.md` | `partie3/Synthesis_and_Supreme_Integration.tex`; ordering context from `TraditionLearning.tex`; notation context from `preambule.tex` | Hierarchical metamodelling; adaptive functors; metamodel consistency; fibre product; coupled cross-dimensional dynamics; emergence, stability, metrics, and source-labelled integration theorems | Undefined categories, functors, fibrations, type compatibilities, proof hypotheses, and metric bounds are explicitly retained as unresolved |
| `towards-implementation.md` | `partie3/Towards_Implementation.tex`; ordering context from `TraditionLearning.tex`; notation context from `preambule.tex` | Five measurable transformation dimensions; global index and measurability axioms; observation trajectories; low-data evaluation; synthetic cohorts; eight calibration parameters; integrated simulation and validation constraints | No API, framework, database, concrete class, or invented algorithm; generic functions, zero-denominator cases, incomplete terms, observability tensions, and non-closed equations remain open |
| `tl-as-a-general-theory.md` | `partie3/TL_as_a_General_Theory.tex`; ordering context from `TraditionLearning.tex`; notation context from `preambule.tex` | Comparison with information-based learning and institutional education; application fields; civilisational claims; objections, empirical challenges, risks, and implementation perspectives | Generality is presented as a programmatic claim, not a universality theorem; analogies are not converted into equivalences; no new demonstrated result is attributed to the chapter |

None of these three sources contains an `\input` or `\include`.

## Catalog reconciliation

The initial Windows `generate_catalog.py --check` reported the catalog as stale and an official `--write` changed all derived hashes. Investigation showed that the generator hashes working-tree bytes and Git was converting LF to CRLF on Windows. The same commit in an LF worktree passed `--check`, proving that committing Windows hashes would invalidate the catalog on Linux.

The minimal derived correction is `.gitattributes` with `handoff/** text eol=lf`. After normalizing the local checkout and rerunning the official generator:

- `handoff/catalog.json` regenerated byte-for-byte identically to the version already tracked;
- no handoff package, domain catalog, schema, or manually edited SHA changed;
- a second `--write` retained SHA-256 `FDB134CEA1D165CC194E67659551999AB15D7B7BB731A46D93827470CAC5D513` and produced zero Git diff;
- a fresh Windows worktree checked out handoff inputs as LF and passed `--check`.

Thus the obsolete signal was reconciled without committing platform-dependent hashes. No generated file required a content update.

## Validation

All commands below completed successfully:

- `git diff --check origin/main...HEAD`
- global placeholder scan under `maths/`: 0 matches
- all four forbidden local-path scans: 0 matches
- forbidden-file scan: 0 additions
- local Markdown links in all 8 changed maths documents: valid
- global LaTeX delimiter/environment audit under `maths/`: passed
- targeted malformed-command scans: 0 matches
- `python tools/handoff/generate_catalog.py --check`: current, 16 domains / 166 features
- `python tools/handoff/validate_handoff.py --self-test`: logical self-tests A–K passed
- `python tools/handoff/export_bundle.py --all --check --verify-determinism`: 166 standalone bundles validated byte-for-byte
- second `generate_catalog.py --write`: zero-byte change and zero Git diff
- second catalog check: passed
- second deterministic export: 166 bundles passed again
- fresh Windows worktree catalog check: passed

## Scope exceptions

Two minimal exceptions are necessary to make the explicitly required global validations true:

1. `.gitattributes` enforces LF only below `handoff/**`, resolving the catalog's cross-platform false-staleness.
2. Sixteen existing scientific-extraction reports replace a machine-local `C:\TLC\repo\...` source string with the corresponding current repository path. No report analysis or scientific content was otherwise changed.

## Scientific boundary

- No equation, threshold, theorem, conclusion, operator, or architecture absent from the authoritative TeX was added.
- No source ambiguity was resolved arbitrarily; unresolved definitions and incomplete hypotheses are documented neutrally.
- No implementation, Python/C++ code, API, framework selection, database schema, or runtime design was added.
- No PDF was used.
- No Internet source was used for the theory.
- The integration files are specification extractions, not full-book conversions.

## Summary by Sourcery

Transcribe the three maths integration chapters from their TeX sources into fully specified French markdown, correcting mathematical notation and documenting unresolved scientific gaps, while cleaning up remaining maths placeholders and notation defects and aligning scientific-extraction reports with repository-relative paths.

Bug Fixes:
- Fix LaTeX command issues in robustness, teleology, low-data architecture, transmission lifecycle, and cascade transmission documents, including extrema operators, delimiters, and undefined recall term notation.

Enhancements:
- Document overloaded mathematical notation conventions in robustness and cascade transmission specs to preserve source usage without renaming symbols.
- Reformat an inline cross-line formula in low-data architecture into a display equation for clarity.

Build:
- Add a .gitattributes rule enforcing LF line endings under handoff/** to stabilize cross-platform deterministic catalog generation.

Documentation:
- Replace placeholder skeletons for integration specifications with detailed, non-inventive extractions from the authoritative TeX sources for synthesis and supreme integration, towards implementation, and TL as a general theory.
- Clarify scientific scope and unresolved points in the new integration documents, explicitly marking undefined constructions, missing proofs, and open measurement issues.
- Update scientific extraction reports to reference repository-logical maths source paths instead of machine-local Windows paths.