### PR TITLE
Prepare the production pipeline for domains 16–35

### DIFF
--- a/registry/domain-progress/extension-16-35.yaml
+++ b/registry/domain-progress/extension-16-35.yaml
@@ -1,0 +1,536 @@
+schema_version: 1
+program:
+  id: domains-16-35-extension
+  strategy: vertical-domain-completion
+  publication_policy: complete-domain-only
+  pilot_domain: 16
+  production_branch_pattern: pipeline/domain-<index>-<slug>
+  production_pr_policy: one-domain-per-pr
+
+baseline:
+  completed_domain_range: 00-15
+  published_domain_count: 16
+  published_feature_count: 166
+  stable_catalog: handoff/catalog.json
+  required_ancestor: 2b32e5a49e57389d03b1f4958bf3ca5cae2dbf1b
+
+source_authorities:
+  domain_index: maths/README.md
+  integration_documents:
+    - maths/integration/synthesis-and-supreme-integration.md
+    - maths/integration/towards-implementation.md
+    - maths/integration/tl-as-a-general-theory.md
+  completed_domain_artifacts:
+    range: 00-15
+    domain_progress: registry/domain-progress/
+    domain_finalization: registry/domain-finalization/
+    optimized_ir: registry/optimized-ir/
+    algorithms: registry/algorithms/
+    oracles: registry/oracles/
+    handoff_domains: handoff/domains/
+    handoff_features: handoff/features/
+
+states:
+  scientific_source: complete
+  functional_decomposition: not_started
+  registries: not_started
+  ir: not_started
+  contracts: not_started
+  algorithms: not_started
+  oracles: not_started
+  handoff_packages: not_started
+
+publication_rules:
+  incomplete_domain_in_global_catalog: forbidden
+  empty_or_placeholder_package: forbidden
+  domain_catalog_entry_requires:
+    - all_retained_features_finalized
+    - complete_traceability
+    - contracts_complete
+    - oracles_complete
+    - validation_passed
+    - deterministic_export
+  linked_domains_may_be_analyzed_together: true
+  linked_domains_are_merged_separately: true
+  shared_contract_requires_demonstrated_need: true
+  algorithm_requires_source_backed_procedure: true
+  declarative_feature_may_omit_algorithm: true
+  scientific_ambiguities_must_be_preserved: true
+  scientifically_blocked_feature_is_not_implementation_ready: true
+
+waves:
+  - id: pilot
+    order: 0
+    title: Pilote
+    domains: [16]
+    analysis_groups: []
+  - id: wave-1
+    order: 1
+    title: Fondations temporelles et contextuelles
+    domains: [22, 23, 24, 25, 26, 27]
+    analysis_groups:
+      - [22, 23]
+      - [24, 25]
+      - [26, 27]
+  - id: wave-2
+    order: 2
+    title: Mesure, contrôle et fidélité
+    domains: [18, 19, 20, 21, 32, 35]
+    analysis_groups:
+      - [18, 19]
+      - [20, 21]
+      - [32, 35]
+  - id: wave-3
+    order: 3
+    title: Finalité et propagation à grande échelle
+    domains: [28, 29, 30, 31]
+    analysis_groups:
+      - [29, 30, 31]
+  - id: wave-4
+    order: 4
+    title: Orchestration de la transmission
+    domains: [17, 34]
+    analysis_groups: []
+  - id: wave-5
+    order: 5
+    title: Architecture spécialisée
+    domains: [33]
+    analysis_groups: []
+
+dependency_graph:
+  policy:
+    confirmed_requires_explicit_source_evidence: true
+    historical_shared_tex_is_not_sufficient: true
+    thematic_proximity_is_not_sufficient: true
+    analysis_dependency_is_not_runtime_dependency: true
+    scientific_dependency_is_not_shared_contract_dependency: true
+    provisional_edges_do_not_order_domain_publication: true
+  analysis:
+    - id: analysis-22-23
+      members: [22, 23]
+      status: operational
+    - id: analysis-24-25
+      members: [24, 25]
+      status: operational
+    - id: analysis-26-27
+      members: [26, 27]
+      status: operational
+    - id: analysis-18-19
+      members: [18, 19]
+      status: operational
+    - id: analysis-20-21
+      members: [20, 21]
+      status: operational
+    - id: analysis-32-35
+      members: [32, 35]
+      status: operational
+    - id: analysis-29-30-31
+      members: [29, 30, 31]
+      status: operational
+  scientific:
+    - id: scientific-19-18
+      from_domain: 19
+      to_domain: 18
+      status: confirmed
+      evidence: maths/19-regulation/regulation.md
+      rationale: Regulation explicitly uses evaluation results to correct trajectories and adapt the system.
+    - id: scientific-20-21
+      from_domain: 20
+      to_domain: 21
+      status: confirmed
+      evidence: maths/20-robustness/robustness.md
+      rationale: Robustness explicitly assigns its procedural dimension to Fairness.
+    - id: scientific-22-23
+      from_domain: 22
+      to_domain: 23
+      status: confirmed
+      evidence: maths/22-temporality/temporality.md
+      rationale: Temporality explicitly uses the memory kernel and mnemonic operator defined by Memory.
+    - id: scientific-25-24
+      from_domain: 25
+      to_domain: 24
+      status: confirmed
+      evidence: maths/25-culture/culture.md
+      rationale: Culture explicitly reuses the contextual space and contextual adaptation operator rather than defining an autonomous replacement.
+    - id: scientific-27-26
+      from_domain: 27
+      to_domain: 26
+      status: confirmed
+      evidence: maths/27-reflexivity/reflexivity.md
+      rationale: Reflexivity is defined as a process over the identity state and reuses the identity dissonance cost.
+    - id: scientific-30-29
+      from_domain: 30
+      to_domain: 29
+      status: confirmed
+      evidence: maths/30-expansion/expansion.md
+      rationale: Expansion explicitly places expansion nodes in the generational graph defined by Generational Propagation.
+    - id: scientific-32-04
+      from_domain: 32
+      to_domain: 4
+      status: confirmed
+      evidence: maths/32-drift-and-correction/stability-drift-and-correction.md
+      rationale: Drift diagnostics explicitly defer the fundamental invariant definition to domain 04.
+    - id: scientific-35-04
+      from_domain: 35
+      to_domain: 4
+      status: confirmed
+      evidence: maths/35-fidelity-to-invariant-core/fidelity-to-the-invariant-core.md
+      rationale: Fidelity explicitly states that it does not redefine the invariants specified by domain 04.
+  runtime: []
+  shared_contract: []
+
+domains:
+  - index: 16
+    slug: cohort
+    title: Cohorte
+    scientific_directory: maths/16-cohort/
+    scientific_readme: maths/16-cohort/README.md
+    scientific_sources:
+      - maths/16-cohort/cohort.md
+    wave: pilot
+    analysis_companions: []
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: []
+      unknown: true
+    pipeline: &unstarted_pipeline
+      scientific_source: complete
+      functional_decomposition: not_started
+      registries: not_started
+      ir: not_started
+      contracts: not_started
+      algorithms: not_started
+      oracles: not_started
+      handoff_packages: not_started
+
+  - index: 17
+    slug: cascade-transmission
+    title: Transmission en cascade
+    scientific_directory: maths/17-cascade-transmission/
+    scientific_readme: maths/17-cascade-transmission/README.md
+    scientific_sources:
+      - maths/17-cascade-transmission/cascade-transmission-system.md
+    wave: wave-4
+    analysis_companions: []
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 18
+    slug: evaluation
+    title: Évaluation
+    scientific_directory: maths/18-evaluation/
+    scientific_readme: maths/18-evaluation/README.md
+    scientific_sources:
+      - maths/18-evaluation/evaluation.md
+    wave: wave-2
+    analysis_companions: [19]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 19
+    slug: regulation
+    title: Régulation
+    scientific_directory: maths/19-regulation/
+    scientific_readme: maths/19-regulation/README.md
+    scientific_sources:
+      - maths/19-regulation/regulation.md
+    wave: wave-2
+    analysis_companions: [18]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: [18]
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 20
+    slug: robustness
+    title: Robustesse
+    scientific_directory: maths/20-robustness/
+    scientific_readme: maths/20-robustness/README.md
+    scientific_sources:
+      - maths/20-robustness/robustness.md
+    wave: wave-2
+    analysis_companions: [21]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: [21]
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 21
+    slug: fairness
+    title: Équité
+    scientific_directory: maths/21-fairness/
+    scientific_readme: maths/21-fairness/README.md
+    scientific_sources:
+      - maths/21-fairness/fairness.md
+    wave: wave-2
+    analysis_companions: [20]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 22
+    slug: temporality
+    title: Temporalité
+    scientific_directory: maths/22-temporality/
+    scientific_readme: maths/22-temporality/README.md
+    scientific_sources:
+      - maths/22-temporality/temporality.md
+    wave: wave-1
+    analysis_companions: [23]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: [23]
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 23
+    slug: memory
+    title: Mémoire
+    scientific_directory: maths/23-memory/
+    scientific_readme: maths/23-memory/README.md
+    scientific_sources:
+      - maths/23-memory/memory.md
+    wave: wave-1
+    analysis_companions: [22]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 24
+    slug: context
+    title: Contexte
+    scientific_directory: maths/24-context/
+    scientific_readme: maths/24-context/README.md
+    scientific_sources:
+      - maths/24-context/context.md
+    wave: wave-1
+    analysis_companions: [25]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: [25]
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 25
+    slug: culture
+    title: Culture
+    scientific_directory: maths/25-culture/
+    scientific_readme: maths/25-culture/README.md
+    scientific_sources:
+      - maths/25-culture/culture.md
+    wave: wave-1
+    analysis_companions: [24]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: [24]
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 26
+    slug: identity
+    title: Identité
+    scientific_directory: maths/26-identity/
+    scientific_readme: maths/26-identity/README.md
+    scientific_sources:
+      - maths/26-identity/identity.md
+    wave: wave-1
+    analysis_companions: [27]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: [27]
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 27
+    slug: reflexivity
+    title: Réflexivité
+    scientific_directory: maths/27-reflexivity/
+    scientific_readme: maths/27-reflexivity/README.md
+    scientific_sources:
+      - maths/27-reflexivity/reflexivity.md
+    wave: wave-1
+    analysis_companions: [26]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: [26]
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 28
+    slug: finality-and-evolutionary-teleology
+    title: Finalité et téléologie évolutive
+    scientific_directory: maths/28-finality-and-evolutionary-teleology/
+    scientific_readme: maths/28-finality-and-evolutionary-teleology/README.md
+    scientific_sources:
+      - maths/28-finality-and-evolutionary-teleology/finality-and-evolutionary-teleology.md
+    wave: wave-3
+    analysis_companions: []
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 29
+    slug: generational-propagation
+    title: Propagation générationnelle
+    scientific_directory: maths/29-generational-propagation/
+    scientific_readme: maths/29-generational-propagation/README.md
+    scientific_sources:
+      - maths/29-generational-propagation/generational-propagation.md
+    wave: wave-3
+    analysis_companions: [30, 31]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 30
+    slug: expansion
+    title: Expansion
+    scientific_directory: maths/30-expansion/
+    scientific_readme: maths/30-expansion/README.md
+    scientific_sources:
+      - maths/30-expansion/expansion.md
+    wave: wave-3
+    analysis_companions: [29, 31]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: [29]
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 31
+    slug: institutionalization
+    title: Institutionnalisation
+    scientific_directory: maths/31-institutionalization/
+    scientific_readme: maths/31-institutionalization/README.md
+    scientific_sources:
+      - maths/31-institutionalization/institutionalization.md
+    wave: wave-3
+    analysis_companions: [29, 30]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 32
+    slug: drift-and-correction
+    title: Dérive et correction
+    scientific_directory: maths/32-drift-and-correction/
+    scientific_readme: maths/32-drift-and-correction/README.md
+    scientific_sources:
+      - maths/32-drift-and-correction/stability-drift-and-correction.md
+    wave: wave-2
+    analysis_companions: [35]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: [4]
+      provisional: [35]
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 33
+    slug: low-data-architecture
+    title: Architecture pour environnements à faibles données
+    scientific_directory: maths/33-low-data-architecture/
+    scientific_readme: maths/33-low-data-architecture/README.md
+    scientific_sources:
+      - maths/33-low-data-architecture/architectural-principles-for-low-data-environments.md
+    wave: wave-5
+    analysis_companions: []
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 34
+    slug: transmission-lifecycle
+    title: Cycle de transmission
+    scientific_directory: maths/34-transmission-lifecycle/
+    scientific_readme: maths/34-transmission-lifecycle/README.md
+    scientific_sources:
+      - maths/34-transmission-lifecycle/operational-pipeline.md
+      - maths/34-transmission-lifecycle/initiation-phase.md
+      - maths/34-transmission-lifecycle/impregnation-phase.md
+      - maths/34-transmission-lifecycle/guidance-phase.md
+      - maths/34-transmission-lifecycle/incorporation-phase.md
+      - maths/34-transmission-lifecycle/integration-phase.md
+      - maths/34-transmission-lifecycle/validation-phase.md
+      - maths/34-transmission-lifecycle/empowerment-phase.md
+    wave: wave-4
+    analysis_companions: []
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: []
+      provisional: []
+      unknown: true
+    pipeline: *unstarted_pipeline
+
+  - index: 35
+    slug: fidelity-to-invariant-core
+    title: Fidélité au noyau invariant
+    scientific_directory: maths/35-fidelity-to-invariant-core/
+    scientific_readme: maths/35-fidelity-to-invariant-core/README.md
+    scientific_sources:
+      - maths/35-fidelity-to-invariant-core/fidelity-to-the-invariant-core.md
+    wave: wave-2
+    analysis_companions: [32]
+    feature_count: null
+    handoff_publication: false
+    dependencies:
+      confirmed: [4]
+      provisional: [32]
+      unknown: true
+    pipeline: *unstarted_pipeline

--- a/reports/domain-extension/production-plan-16-35.md
+++ b/reports/domain-extension/production-plan-16-35.md
@@ -10,7 +10,7 @@ Les domaines `16–35` disposent actuellement de leurs sources scientifiques sou
 
 Le registre machine-readable de cette extension est `registry/domain-progress/extension-16-35.yaml`.
 
-## Sources autoritatives
+## Sources de référence
 
 La préparation et les futures finalisations verticales utilisent uniquement les sources du dépôt :
 
@@ -29,7 +29,7 @@ La production `16–35` conserve les conventions observées dans les domaines ex
 
 - slugs de domaine stables et chemins de sources relatifs au dépôt ;
 - identifiants de fonctionnalités attribués uniquement après la décomposition fonctionnelle ;
-- population fonctionnelle autoritative figée avant la finalisation aval ;
+- population fonctionnelle de référence figée avant la finalisation aval ;
 - finalisation par domaine sous `registry/domain-finalization/<slug>/` ;
 - IR finalisées sous `registry/optimized-ir/<slug>/<FEATURE_ID>/` ;
 - algorithmes sous `registry/algorithms/<slug>/<FEATURE_ID>/` uniquement lorsque la théorie permet une procédure exploitable ;

--- a/reports/domain-extension/production-plan-16-35.md
+++ b/reports/domain-extension/production-plan-16-35.md
@@ -1,0 +1,257 @@
+# Plan de production des domaines 16–35
+
+## Contexte
+
+Les domaines `00–15` disposent déjà de la chaîne complète de spécification et de handoff : inventaires scientifiques, décomposition fonctionnelle, registres, IR finalisées, contrats, algorithmes lorsque la théorie autorise une procédure, oracles, catalogues de domaine et Feature Handoff Packages validés.
+
+Les domaines `16–35` disposent actuellement de leurs sources scientifiques sous `maths/`, avec un README par domaine et les documents scientifiques qui y sont déclarés. Les couches aval ne sont pas encore produites et ne doivent pas être précréées par cette phase 0.
+
+`handoff/catalog.json` reste la référence stable publiée pour les seize premiers domaines et leurs 166 Feature Handoff Packages. La phase 0 ne régénère pas ce catalogue et ne modifie aucun package existant.
+
+Le registre machine-readable de cette extension est `registry/domain-progress/extension-16-35.yaml`.
+
+## Sources autoritatives
+
+La préparation et les futures finalisations verticales utilisent uniquement les sources du dépôt :
+
+- `maths/README.md` ;
+- le README et les documents scientifiques de chaque domaine `16–35` ;
+- `maths/integration/synthesis-and-supreme-integration.md` ;
+- `maths/integration/towards-implementation.md` ;
+- `maths/integration/tl-as-a-general-theory.md` ;
+- les artefacts finalisés des domaines `00–15` comme conventions de production et de validation.
+
+Les références historiques communes à plusieurs domaines peuvent motiver une analyse conjointe, mais ne constituent pas à elles seules une dépendance scientifique, runtime ou de contrat partagé.
+
+## Conventions réutilisées
+
+La production `16–35` conserve les conventions observées dans les domaines existants, notamment `00-master`, `01-disciple`, `02-community`, `08-principle` et `15-relations` :
+
+- slugs de domaine stables et chemins de sources relatifs au dépôt ;
+- identifiants de fonctionnalités attribués uniquement après la décomposition fonctionnelle ;
+- population fonctionnelle autoritative figée avant la finalisation aval ;
+- finalisation par domaine sous `registry/domain-finalization/<slug>/` ;
+- IR finalisées sous `registry/optimized-ir/<slug>/<FEATURE_ID>/` ;
+- algorithmes sous `registry/algorithms/<slug>/<FEATURE_ID>/` uniquement lorsque la théorie permet une procédure exploitable ;
+- oracles sous `registry/oracles/<slug>/<FEATURE_ID>/` avec critères d’acceptation explicites ;
+- conservation des ambiguïtés, valeurs opaques et réserves scientifiques au lieu de les résoudre silencieusement ;
+- catalogue complet de domaine sous `handoff/domains/<slug>/catalog.json` avant publication de sa population ;
+- Feature Handoff Packages autonomes, traçables, déterministes et validables sans lecture de toute la théorie ;
+- validation handoff par `tools/handoff/validate_handoff.py` et export déterministe par `tools/handoff/export_bundle.py` lorsque le domaine atteint la porte de publication.
+
+## Stratégie retenue
+
+```text
+Infrastructure commune minimale
+        ↓
+Domaine 16 Cohorte complet
+        ↓
+Domaines suivants par vagues
+        ↓
+Un domaine terminé jusqu’aux handoffs avant le suivant
+        ↓
+Finalisation globale 00–35
+```
+
+La stratégie est une **finalisation verticale complète domaine par domaine, organisée en vagues de dépendances**. Les vagues servent à ordonner l’analyse et la production ; elles ne constituent pas une nouvelle affirmation scientifique.
+
+Une branche et une PR de production sont utilisées par domaine. Des domaines liés peuvent être analysés ensemble pour clarifier leurs dépendances, mais leur finalisation et leur fusion restent séparées.
+
+## Définition de « domaine terminé »
+
+Un domaine est terminé seulement lorsque toutes les couches suivantes sont présentes et validées :
+
+```text
+Théorie scientifique
+Découpage fonctionnel
+Registres
+IR
+Contrats
+Algorithmes lorsque possibles
+Oracles
+Handoff Packages
+Catalogue du domaine
+Exports déterministes
+```
+
+La présence d’une source scientifique seule, d’un inventaire partiel ou d’un package vide ne constitue jamais une finalisation.
+
+## Portes de validation
+
+### Porte scientifique
+
+La porte scientifique exige :
+
+- une source complète et traçable ;
+- un inventaire des symboles et objets utiles à la décomposition ;
+- la conservation explicite des ambiguïtés, contradictions et éléments non résolus ;
+- aucune définition, dépendance, dimension, équation ou procédure inventée pour combler un manque de la théorie.
+
+### Porte fonctionnelle
+
+La porte fonctionnelle exige :
+
+- des fonctionnalités autonomes, compréhensibles et testables ;
+- des identifiants stables attribués après le découpage scientifique ;
+- des dépendances explicites et classées ;
+- un nombre de fonctionnalités figé et justifié par l’inventaire retenu ;
+- aucune fonctionnalité artificielle créée uniquement pour remplir une couche technique.
+
+Avant cette porte, `feature_count` reste non déterminé.
+
+### Porte IR et contrats
+
+Pour chaque fonctionnalité retenue, la porte IR et contrats exige au minimum :
+
+- entrées ;
+- sorties ;
+- types ;
+- préconditions ;
+- postconditions ;
+- invariants ;
+- erreurs ;
+- cas limites ;
+- traçabilité vers la source scientifique et les décisions de découpage.
+
+Les informations non spécifiées restent non spécifiées. Une valeur opaque ou une réservation scientifique ne reçoit pas de valeur par défaut inventée.
+
+### Porte algorithmes et oracles
+
+Un algorithme est produit uniquement lorsque la théorie définit une procédure exploitable ou autorise explicitement une procédure structurelle. Une fonctionnalité déclarative peut disposer d’un contrat et d’un oracle sans imposer un algorithme scientifique inexistant.
+
+Toute fonctionnalité implémentable doit disposer d’un oracle. Le type d’oracle doit être explicite : exact, structurel, propriété, métamorphique, différentiel, de conservation, ou autre catégorie effectivement justifiée par la fonctionnalité.
+
+Un oracle ne transforme pas une ambiguïté scientifique en résultat supposé.
+
+### Porte handoff
+
+Chaque package handoff doit être autonome et contenir suffisamment d’information pour qu’un contributeur puisse implémenter la fonctionnalité sans lire toute la théorie. La porte exige :
+
+- traçabilité complète ;
+- contrat exploitable ;
+- critères d’acceptation ;
+- erreurs et cas limites ;
+- dépendances résolues ou explicitement bloquantes ;
+- conservation des réserves scientifiques ;
+- aucun placeholder ou package vide.
+
+Une fonctionnalité bloquée scientifiquement ne doit pas être présentée comme prête à l’implémentation.
+
+### Porte de publication
+
+Un domaine entre dans la publication globale uniquement lorsque :
+
+- toutes les fonctionnalités retenues sont finalisées ;
+- la traçabilité est complète ;
+- les contrats sont complets ;
+- les oracles sont présents et cohérents ;
+- les validations handoff réussissent ;
+- le catalogue du domaine est complet et valide ;
+- les exports sont déterministes.
+
+Un domaine incomplet ne doit pas entrer dans `handoff/catalog.json`. Aucun package vide ou placeholder ne doit être publié. Le catalogue global ne doit pas être régénéré lorsqu’aucun nouveau domaine finalisé n’est publié.
+
+## Politique des dépendances
+
+Les dépendances sont classées séparément :
+
+- **analyse** : rapprochement opérationnel pour étudier ensemble des domaines liés ;
+- **scientifique** : une définition, une procédure ou un objet d’un domaine dépend explicitement d’un autre texte scientifique ;
+- **runtime** : une fonctionnalité exécutable requiert réellement un composant d’un autre domaine ;
+- **contrat partagé** : plusieurs fonctionnalités ont démontré un besoin commun d’interface ou de type partagé.
+
+Une dépendance est `confirmed` seulement lorsqu’une source ou un registre existant fournit une référence explicite. Une proximité thématique ou une origine `.tex` commune ne suffit pas. Une dépendance plausible mais non établie reste `provisional`, et une dépendance non connue reste inconnue.
+
+Le graphe de la phase 0 est volontairement provisoire. Il contient uniquement les liens confirmés inspectés et les groupes d’analyse imposés par la stratégie. Il sera affiné pendant la finalisation verticale de chaque domaine sans modifier rétroactivement les 166 packages existants.
+
+## Ordre des vagues
+
+### Pilote
+
+- `16 — Cohorte`
+
+### Vague 1 — Fondations temporelles et contextuelles
+
+- `22 — Temporalité`
+- `23 — Mémoire`
+- `24 — Contexte`
+- `25 — Culture`
+- `26 — Identité`
+- `27 — Réflexivité`
+
+Groupes d’analyse : `22 + 23`, `24 + 25`, `26 + 27`.
+
+### Vague 2 — Mesure, contrôle et fidélité
+
+- `18 — Évaluation`
+- `19 — Régulation`
+- `20 — Robustesse`
+- `21 — Équité`
+- `32 — Dérive et correction`
+- `35 — Fidélité au noyau invariant`
+
+Groupes d’analyse : `18 + 19`, `20 + 21`, `32 + 35`.
+
+Les domaines 32 et 35 renvoient explicitement à `04-invariants` dans leurs textes scientifiques. Ce lien est enregistré comme dépendance scientifique confirmée, sans créer de dépendance runtime ou de contrat partagé par anticipation.
+
+### Vague 3 — Finalité et propagation à grande échelle
+
+- `28 — Finalité et téléologie évolutive`
+- `29 — Propagation générationnelle`
+- `30 — Expansion`
+- `31 — Institutionnalisation`
+
+Le groupe `29 + 30 + 31` partage une analyse de dépendances. Chaque domaine reste finalisé et fusionné séparément. Le texte d’Expansion renvoie explicitement au graphe défini par Propagation générationnelle ; ce lien scientifique est enregistré sans déduire d’autres dépendances du seul historique de sources communes.
+
+### Vague 4 — Orchestration de la transmission
+
+- `17 — Transmission en cascade`
+- `34 — Cycle de transmission`
+
+### Vague 5 — Architecture spécialisée
+
+- `33 — Architecture pour environnements à faibles données`
+
+Chaque index `16–35` appartient à une seule vague.
+
+## Politique de publication progressive
+
+1. Un domaine incomplet ne doit pas entrer dans `handoff/catalog.json`.
+2. Aucun package vide ou placeholder ne doit être publié.
+3. Un domaine entre dans le catalogue uniquement lorsque toutes ses fonctionnalités retenues sont finalisées, traçables, contractées, munies d’oracles, validées et exportables de manière déterministe.
+4. Les domaines liés peuvent être analysés ensemble, mais sont fusionnés séparément.
+5. Une branche et une PR de production sont utilisées par domaine.
+6. Les contrats partagés ne sont ajoutés que lorsqu’un besoin réel est démontré.
+7. Un algorithme n’est produit que lorsque la théorie définit une procédure exploitable.
+8. Une fonctionnalité déclarative peut avoir un contrat et un oracle sans imposer un algorithme.
+9. Les ambiguïtés scientifiques sont conservées et documentées.
+10. Une fonctionnalité bloquée scientifiquement n’est pas transformée en tâche d’implémentation prétendument prête.
+
+## Validation de la phase 0
+
+`tools/domain-progress/validate_extension_16_35.py` valide uniquement le registre de pilotage et les garde-fous de cette phase. Il ne finalise aucun domaine et ne génère aucun artefact aval.
+
+Le validateur contrôle :
+
+- les 20 domaines et la couverture exacte `16–35` ;
+- l’unicité des indices et des slugs ;
+- l’existence des sources scientifiques déclarées ;
+- l’appartenance unique à une vague ;
+- la cohérence des groupes d’analyse ;
+- l’absence de nombre de fonctionnalités fixé ;
+- la publication handoff désactivée ;
+- les couches aval à `not_started` ;
+- l’absence d’identifiant de fonctionnalité futur instancié dans le manifeste ;
+- l’absence de domaine futur ou d’identifiant futur dans le catalogue handoff global.
+
+Aucun workflow GitHub Actions temporaire n’est ajouté. Les checks GitHub existants restent l’autorité CI disponible sur la PR.
+
+## Prochaine action
+
+La prochaine PR de production est :
+
+**Domaine 16 — Cohorte : chaîne complète jusqu’aux Handoff Packages**
+
+En anglais pour le handoff de production :
+
+`Domain 16 — Cohort, complete vertical pipeline to validated Handoff Packages.`

--- a/tools/domain-progress/validate_extension_16_35.py
+++ b/tools/domain-progress/validate_extension_16_35.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Validate the phase-0 production registry for domains 16 through 35."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = ROOT / "registry/domain-progress/extension-16-35.yaml"
+CATALOG_PATH = ROOT / "handoff/catalog.json"
+EXPECTED_INDICES = set(range(16, 36))
+EXPECTED_WAVES = {
+    "pilot": {16},
+    "wave-1": {22, 23, 24, 25, 26, 27},
+    "wave-2": {18, 19, 20, 21, 32, 35},
+    "wave-3": {28, 29, 30, 31},
+    "wave-4": {17, 34},
+    "wave-5": {33},
+}
+EXPECTED_ANALYSIS_GROUPS = {
+    frozenset({22, 23}),
+    frozenset({24, 25}),
+    frozenset({26, 27}),
+    frozenset({18, 19}),
+    frozenset({20, 21}),
+    frozenset({32, 35}),
+    frozenset({29, 30, 31}),
+}
+DOWNSTREAM_STATES = (
+    "functional_decomposition",
+    "registries",
+    "ir",
+    "contracts",
+    "algorithms",
+    "oracles",
+    "handoff_packages",
+)
+FUTURE_FEATURE_ID = re.compile(
+    r"\bTLC-FC-(?:1[6-9]|2[0-9]|3[0-5])-[A-Z0-9-]+-[0-9]{3}\b"
+)
+errors: list[str] = []
+
+
+def fail(message: str) -> None:
+    errors.append(message)
+
+
+def load_yaml(path: Path):
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        fail(f"YAML parse failed: {path.relative_to(ROOT)}: {exc}")
+        return None
+
+
+def load_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        fail(f"JSON parse failed: {path.relative_to(ROOT)}: {exc}")
+        return None
+
+
+def scan_catalog_for_future_publication(value, path: str = "catalog") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}"
+            if key == "domain_index" and child in EXPECTED_INDICES:
+                fail(f"Future domain {child} is already published at {child_path}")
+            scan_catalog_for_future_publication(child, child_path)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            scan_catalog_for_future_publication(child, f"{path}[{index}]")
+    elif isinstance(value, str) and FUTURE_FEATURE_ID.search(value):
+        fail(f"Future feature identifier already appears in handoff catalog at {path}: {value}")
+
+
+manifest = load_yaml(MANIFEST_PATH)
+if not isinstance(manifest, dict):
+    fail("Extension manifest must be a YAML mapping")
+    manifest = {}
+
+if manifest.get("schema_version") != 1:
+    fail("schema_version must be 1")
+
+program = manifest.get("program", {})
+if program.get("id") != "domains-16-35-extension":
+    fail("Unexpected program id")
+if program.get("strategy") != "vertical-domain-completion":
+    fail("Program strategy must be vertical-domain-completion")
+if program.get("publication_policy") != "complete-domain-only":
+    fail("Program publication policy must be complete-domain-only")
+if program.get("pilot_domain") != 16:
+    fail("Pilot domain must be 16")
+
+baseline = manifest.get("baseline", {})
+if baseline.get("completed_domain_range") != "00-15":
+    fail("Baseline completed domain range must be 00-15")
+if baseline.get("published_domain_count") != 16:
+    fail("Baseline published domain count must remain 16")
+if baseline.get("published_feature_count") != 166:
+    fail("Baseline published feature count must remain 166")
+if baseline.get("stable_catalog") != "handoff/catalog.json":
+    fail("Stable catalog must remain handoff/catalog.json")
+
+domains = manifest.get("domains")
+if not isinstance(domains, list):
+    fail("domains must be a list")
+    domains = []
+if len(domains) != 20:
+    fail(f"Expected 20 domains, found {len(domains)}")
+
+indices = [domain.get("index") for domain in domains if isinstance(domain, dict)]
+slugs = [domain.get("slug") for domain in domains if isinstance(domain, dict)]
+if len(indices) != len(set(indices)):
+    fail("Domain indices must be unique")
+if len(slugs) != len(set(slugs)):
+    fail("Domain slugs must be unique")
+if set(indices) != EXPECTED_INDICES:
+    fail(f"Domain coverage must be exactly 16-35, got {sorted(set(indices))}")
+
+waves = manifest.get("waves")
+if not isinstance(waves, list):
+    fail("waves must be a list")
+    waves = []
+wave_domains: dict[str, set[int]] = {}
+seen_wave_members: list[int] = []
+manifest_analysis_groups: set[frozenset[int]] = set()
+for wave in waves:
+    if not isinstance(wave, dict):
+        fail("Each wave must be a mapping")
+        continue
+    wave_id = wave.get("id")
+    members = wave.get("domains", [])
+    if wave_id in wave_domains:
+        fail(f"Duplicate wave id: {wave_id}")
+        continue
+    if not isinstance(members, list):
+        fail(f"Wave {wave_id} domains must be a list")
+        continue
+    member_set = set(members)
+    if len(member_set) != len(members):
+        fail(f"Wave {wave_id} contains a duplicate domain")
+    wave_domains[wave_id] = member_set
+    seen_wave_members.extend(members)
+    for group in wave.get("analysis_groups", []):
+        if not isinstance(group, list) or len(group) < 2:
+            fail(f"Wave {wave_id} contains an invalid analysis group: {group}")
+            continue
+        manifest_analysis_groups.add(frozenset(group))
+
+if wave_domains != EXPECTED_WAVES:
+    fail(f"Wave membership differs from the canonical plan: {wave_domains}")
+if set(seen_wave_members) != EXPECTED_INDICES or len(seen_wave_members) != 20:
+    fail("Every domain index 16-35 must belong to exactly one wave")
+if manifest_analysis_groups != EXPECTED_ANALYSIS_GROUPS:
+    fail("Analysis groups differ from the canonical pair/group plan")
+
+expected_companions: dict[int, set[int]] = {index: set() for index in EXPECTED_INDICES}
+for group in EXPECTED_ANALYSIS_GROUPS:
+    for member in group:
+        expected_companions[member].update(group - {member})
+
+for domain in domains:
+    if not isinstance(domain, dict):
+        fail("Each domain entry must be a mapping")
+        continue
+    index = domain.get("index")
+    slug = domain.get("slug")
+    label = f"domain {index} ({slug})"
+
+    if index not in EXPECTED_INDICES:
+        continue
+    declared_wave = domain.get("wave")
+    if declared_wave not in EXPECTED_WAVES or index not in EXPECTED_WAVES[declared_wave]:
+        fail(f"{label}: inconsistent wave {declared_wave}")
+
+    companions = domain.get("analysis_companions", [])
+    if set(companions) != expected_companions[index]:
+        fail(
+            f"{label}: analysis companions must be "
+            f"{sorted(expected_companions[index])}, got {sorted(companions)}"
+        )
+
+    readme = domain.get("scientific_readme")
+    if not isinstance(readme, str) or not (ROOT / readme).is_file():
+        fail(f"{label}: missing scientific README {readme}")
+
+    sources = domain.get("scientific_sources")
+    if not isinstance(sources, list) or not sources:
+        fail(f"{label}: scientific_sources must be a non-empty list")
+    else:
+        for source in sources:
+            if not isinstance(source, str) or not (ROOT / source).is_file():
+                fail(f"{label}: missing scientific source {source}")
+
+    if domain.get("feature_count") is not None:
+        fail(f"{label}: feature_count must remain null before decomposition")
+    if domain.get("handoff_publication") is not False:
+        fail(f"{label}: handoff_publication must remain false")
+
+    pipeline = domain.get("pipeline", {})
+    if pipeline.get("scientific_source") != "complete":
+        fail(f"{label}: scientific_source must be complete")
+    for state in DOWNSTREAM_STATES:
+        if pipeline.get(state) != "not_started":
+            fail(f"{label}: downstream state {state} must remain not_started")
+
+    dependencies = domain.get("dependencies", {})
+    confirmed = dependencies.get("confirmed", [])
+    provisional = dependencies.get("provisional", [])
+    for dependency in [*confirmed, *provisional]:
+        if not isinstance(dependency, int) or dependency < 0 or dependency > 35:
+            fail(f"{label}: invalid dependency index {dependency}")
+        if dependency == index:
+            fail(f"{label}: self-dependency is not allowed")
+    if set(confirmed) & set(provisional):
+        fail(f"{label}: a dependency cannot be both confirmed and provisional")
+
+manifest_text = MANIFEST_PATH.read_text(encoding="utf-8") if MANIFEST_PATH.is_file() else ""
+future_ids = sorted(set(FUTURE_FEATURE_ID.findall(manifest_text)))
+if future_ids:
+    fail(f"Future feature identifiers must not be instantiated in phase 0: {future_ids}")
+
+catalog = load_json(CATALOG_PATH)
+if catalog is not None:
+    scan_catalog_for_future_publication(catalog)
+
+if errors:
+    print("Domains 16-35 extension validation: FAIL")
+    for error in errors:
+        print(f"- {error}")
+    sys.exit(1)
+
+print("Domains 16-35 extension validation: PASS (20 domains, exact coverage 16-35)")

--- a/tools/domain-progress/validate_extension_16_35.py
+++ b/tools/domain-progress/validate_extension_16_35.py
@@ -44,198 +44,302 @@ DOWNSTREAM_STATES = (
 FUTURE_FEATURE_ID = re.compile(
     r"\bTLC-FC-(?:1[6-9]|2[0-9]|3[0-5])-[A-Z0-9-]+-[0-9]{3}\b"
 )
-errors: list[str] = []
 
 
-def fail(message: str) -> None:
-    errors.append(message)
-
-
-def load_yaml(path: Path):
+def load_yaml(path: Path, errors: list[str]):
     try:
         return yaml.safe_load(path.read_text(encoding="utf-8"))
     except Exception as exc:
-        fail(f"YAML parse failed: {path.relative_to(ROOT)}: {exc}")
+        errors.append(f"YAML parse failed: {path.relative_to(ROOT)}: {exc}")
         return None
 
 
-def load_json(path: Path):
+def load_json(path: Path, errors: list[str]):
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except Exception as exc:
-        fail(f"JSON parse failed: {path.relative_to(ROOT)}: {exc}")
+        errors.append(f"JSON parse failed: {path.relative_to(ROOT)}: {exc}")
         return None
 
 
-def scan_catalog_for_future_publication(value, path: str = "catalog") -> None:
-    if isinstance(value, dict):
-        for key, child in value.items():
-            child_path = f"{path}.{key}"
-            if key == "domain_index" and child in EXPECTED_INDICES:
-                fail(f"Future domain {child} is already published at {child_path}")
-            scan_catalog_for_future_publication(child, child_path)
-    elif isinstance(value, list):
-        for index, child in enumerate(value):
-            scan_catalog_for_future_publication(child, f"{path}[{index}]")
-    elif isinstance(value, str) and FUTURE_FEATURE_ID.search(value):
-        fail(f"Future feature identifier already appears in handoff catalog at {path}: {value}")
+def validate_global_catalog(catalog, errors: list[str]) -> None:
+    """Reject publication of any domain or feature from the reserved 16-35 range."""
+    if not isinstance(catalog, dict):
+        errors.append("handoff/catalog.json must contain a JSON object")
+        return
 
-
-manifest = load_yaml(MANIFEST_PATH)
-if not isinstance(manifest, dict):
-    fail("Extension manifest must be a YAML mapping")
-    manifest = {}
-
-if manifest.get("schema_version") != 1:
-    fail("schema_version must be 1")
-
-program = manifest.get("program", {})
-if program.get("id") != "domains-16-35-extension":
-    fail("Unexpected program id")
-if program.get("strategy") != "vertical-domain-completion":
-    fail("Program strategy must be vertical-domain-completion")
-if program.get("publication_policy") != "complete-domain-only":
-    fail("Program publication policy must be complete-domain-only")
-if program.get("pilot_domain") != 16:
-    fail("Pilot domain must be 16")
-
-baseline = manifest.get("baseline", {})
-if baseline.get("completed_domain_range") != "00-15":
-    fail("Baseline completed domain range must be 00-15")
-if baseline.get("published_domain_count") != 16:
-    fail("Baseline published domain count must remain 16")
-if baseline.get("published_feature_count") != 166:
-    fail("Baseline published feature count must remain 166")
-if baseline.get("stable_catalog") != "handoff/catalog.json":
-    fail("Stable catalog must remain handoff/catalog.json")
-
-domains = manifest.get("domains")
-if not isinstance(domains, list):
-    fail("domains must be a list")
-    domains = []
-if len(domains) != 20:
-    fail(f"Expected 20 domains, found {len(domains)}")
-
-indices = [domain.get("index") for domain in domains if isinstance(domain, dict)]
-slugs = [domain.get("slug") for domain in domains if isinstance(domain, dict)]
-if len(indices) != len(set(indices)):
-    fail("Domain indices must be unique")
-if len(slugs) != len(set(slugs)):
-    fail("Domain slugs must be unique")
-if set(indices) != EXPECTED_INDICES:
-    fail(f"Domain coverage must be exactly 16-35, got {sorted(set(indices))}")
-
-waves = manifest.get("waves")
-if not isinstance(waves, list):
-    fail("waves must be a list")
-    waves = []
-wave_domains: dict[str, set[int]] = {}
-seen_wave_members: list[int] = []
-manifest_analysis_groups: set[frozenset[int]] = set()
-for wave in waves:
-    if not isinstance(wave, dict):
-        fail("Each wave must be a mapping")
-        continue
-    wave_id = wave.get("id")
-    members = wave.get("domains", [])
-    if wave_id in wave_domains:
-        fail(f"Duplicate wave id: {wave_id}")
-        continue
-    if not isinstance(members, list):
-        fail(f"Wave {wave_id} domains must be a list")
-        continue
-    member_set = set(members)
-    if len(member_set) != len(members):
-        fail(f"Wave {wave_id} contains a duplicate domain")
-    wave_domains[wave_id] = member_set
-    seen_wave_members.extend(members)
-    for group in wave.get("analysis_groups", []):
-        if not isinstance(group, list) or len(group) < 2:
-            fail(f"Wave {wave_id} contains an invalid analysis group: {group}")
-            continue
-        manifest_analysis_groups.add(frozenset(group))
-
-if wave_domains != EXPECTED_WAVES:
-    fail(f"Wave membership differs from the canonical plan: {wave_domains}")
-if set(seen_wave_members) != EXPECTED_INDICES or len(seen_wave_members) != 20:
-    fail("Every domain index 16-35 must belong to exactly one wave")
-if manifest_analysis_groups != EXPECTED_ANALYSIS_GROUPS:
-    fail("Analysis groups differ from the canonical pair/group plan")
-
-expected_companions: dict[int, set[int]] = {index: set() for index in EXPECTED_INDICES}
-for group in EXPECTED_ANALYSIS_GROUPS:
-    for member in group:
-        expected_companions[member].update(group - {member})
-
-for domain in domains:
-    if not isinstance(domain, dict):
-        fail("Each domain entry must be a mapping")
-        continue
-    index = domain.get("index")
-    slug = domain.get("slug")
-    label = f"domain {index} ({slug})"
-
-    if index not in EXPECTED_INDICES:
-        continue
-    declared_wave = domain.get("wave")
-    if declared_wave not in EXPECTED_WAVES or index not in EXPECTED_WAVES[declared_wave]:
-        fail(f"{label}: inconsistent wave {declared_wave}")
-
-    companions = domain.get("analysis_companions", [])
-    if set(companions) != expected_companions[index]:
-        fail(
-            f"{label}: analysis companions must be "
-            f"{sorted(expected_companions[index])}, got {sorted(companions)}"
-        )
-
-    readme = domain.get("scientific_readme")
-    if not isinstance(readme, str) or not (ROOT / readme).is_file():
-        fail(f"{label}: missing scientific README {readme}")
-
-    sources = domain.get("scientific_sources")
-    if not isinstance(sources, list) or not sources:
-        fail(f"{label}: scientific_sources must be a non-empty list")
+    domains = catalog.get("domains")
+    if not isinstance(domains, list):
+        errors.append("handoff/catalog.json domains must be a list")
     else:
-        for source in sources:
-            if not isinstance(source, str) or not (ROOT / source).is_file():
-                fail(f"{label}: missing scientific source {source}")
+        for position, domain in enumerate(domains):
+            path = f"catalog.domains[{position}]"
+            if not isinstance(domain, dict):
+                errors.append(f"{path} must be an object")
+                continue
+            domain_index = domain.get("domain_index")
+            if isinstance(domain_index, bool) or not isinstance(domain_index, int):
+                errors.append(f"{path}.domain_index must be an integer")
+                continue
+            if domain_index in EXPECTED_INDICES:
+                errors.append(
+                    f"Future domain {domain_index} is already published at {path}.domain_index"
+                )
 
-    if domain.get("feature_count") is not None:
-        fail(f"{label}: feature_count must remain null before decomposition")
-    if domain.get("handoff_publication") is not False:
-        fail(f"{label}: handoff_publication must remain false")
+    features = catalog.get("features")
+    if not isinstance(features, list):
+        errors.append("handoff/catalog.json features must be a list")
+    else:
+        for position, feature in enumerate(features):
+            path = f"catalog.features[{position}]"
+            if not isinstance(feature, dict):
+                errors.append(f"{path} must be an object")
+                continue
+            feature_id = feature.get("feature_id")
+            if not isinstance(feature_id, str):
+                errors.append(f"{path}.feature_id must be a string")
+                continue
+            if FUTURE_FEATURE_ID.fullmatch(feature_id):
+                errors.append(f"Future feature identifier is already published at {path}: {feature_id}")
 
-    pipeline = domain.get("pipeline", {})
-    if pipeline.get("scientific_source") != "complete":
-        fail(f"{label}: scientific_source must be complete")
-    for state in DOWNSTREAM_STATES:
-        if pipeline.get(state) != "not_started":
-            fail(f"{label}: downstream state {state} must remain not_started")
+    summary = catalog.get("summary")
+    if not isinstance(summary, dict):
+        errors.append("handoff/catalog.json summary must be an object")
+    else:
+        if summary.get("domain_count") != 16:
+            errors.append("Global handoff catalog domain_count must remain 16 during phase 0")
+        if summary.get("feature_count") != 166:
+            errors.append("Global handoff catalog feature_count must remain 166 during phase 0")
 
-    dependencies = domain.get("dependencies", {})
-    confirmed = dependencies.get("confirmed", [])
-    provisional = dependencies.get("provisional", [])
-    for dependency in [*confirmed, *provisional]:
-        if not isinstance(dependency, int) or dependency < 0 or dependency > 35:
-            fail(f"{label}: invalid dependency index {dependency}")
-        if dependency == index:
-            fail(f"{label}: self-dependency is not allowed")
-    if set(confirmed) & set(provisional):
-        fail(f"{label}: a dependency cannot be both confirmed and provisional")
 
-manifest_text = MANIFEST_PATH.read_text(encoding="utf-8") if MANIFEST_PATH.is_file() else ""
-future_ids = sorted(set(FUTURE_FEATURE_ID.findall(manifest_text)))
-if future_ids:
-    fail(f"Future feature identifiers must not be instantiated in phase 0: {future_ids}")
-
-catalog = load_json(CATALOG_PATH)
-if catalog is not None:
-    scan_catalog_for_future_publication(catalog)
-
-if errors:
+def print_failure(errors: list[str]) -> int:
     print("Domains 16-35 extension validation: FAIL")
     for error in errors:
         print(f"- {error}")
-    sys.exit(1)
+    return 1
 
-print("Domains 16-35 extension validation: PASS (20 domains, exact coverage 16-35)")
+
+def main() -> int:
+    errors: list[str] = []
+    manifest = load_yaml(MANIFEST_PATH, errors)
+    if manifest is None:
+        return print_failure(errors)
+    if not isinstance(manifest, dict):
+        errors.append("Extension manifest must be a YAML mapping")
+        return print_failure(errors)
+
+    if manifest.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+
+    program = manifest.get("program")
+    if not isinstance(program, dict):
+        errors.append("program must be a mapping")
+    else:
+        if program.get("id") != "domains-16-35-extension":
+            errors.append("Unexpected program id")
+        if program.get("strategy") != "vertical-domain-completion":
+            errors.append("Program strategy must be vertical-domain-completion")
+        if program.get("publication_policy") != "complete-domain-only":
+            errors.append("Program publication policy must be complete-domain-only")
+        if program.get("pilot_domain") != 16:
+            errors.append("Pilot domain must be 16")
+
+    baseline = manifest.get("baseline")
+    if not isinstance(baseline, dict):
+        errors.append("baseline must be a mapping")
+    else:
+        if baseline.get("completed_domain_range") != "00-15":
+            errors.append("Baseline completed domain range must be 00-15")
+        if baseline.get("published_domain_count") != 16:
+            errors.append("Baseline published domain count must remain 16")
+        if baseline.get("published_feature_count") != 166:
+            errors.append("Baseline published feature count must remain 166")
+        if baseline.get("stable_catalog") != "handoff/catalog.json":
+            errors.append("Stable catalog must remain handoff/catalog.json")
+
+    domains = manifest.get("domains")
+    if not isinstance(domains, list):
+        errors.append("domains must be a list")
+        return print_failure(errors)
+    if len(domains) != 20:
+        errors.append(f"Expected 20 domains, found {len(domains)}")
+
+    typed_domains: list[dict] = []
+    indices: list[int] = []
+    slugs: list[str] = []
+    for position, domain in enumerate(domains):
+        if not isinstance(domain, dict):
+            errors.append(f"domains[{position}] must be a mapping")
+            continue
+        typed_domains.append(domain)
+        index = domain.get("index")
+        slug = domain.get("slug")
+        if isinstance(index, bool) or not isinstance(index, int):
+            errors.append(f"domains[{position}].index must be an integer")
+        else:
+            indices.append(index)
+        if not isinstance(slug, str) or not slug:
+            errors.append(f"domains[{position}].slug must be a non-empty string")
+        else:
+            slugs.append(slug)
+
+    if len(indices) != len(set(indices)):
+        errors.append("Domain indices must be unique")
+    if len(slugs) != len(set(slugs)):
+        errors.append("Domain slugs must be unique")
+    if set(indices) != EXPECTED_INDICES:
+        errors.append(f"Domain coverage must be exactly 16-35, got {sorted(set(indices))}")
+
+    waves = manifest.get("waves")
+    if not isinstance(waves, list):
+        errors.append("waves must be a list")
+        return print_failure(errors)
+
+    wave_domains: dict[str, set[int]] = {}
+    seen_wave_members: list[int] = []
+    manifest_analysis_groups: set[frozenset[int]] = set()
+    for position, wave in enumerate(waves):
+        if not isinstance(wave, dict):
+            errors.append(f"waves[{position}] must be a mapping")
+            continue
+        wave_id = wave.get("id")
+        members = wave.get("domains")
+        if not isinstance(wave_id, str) or not wave_id:
+            errors.append(f"waves[{position}].id must be a non-empty string")
+            continue
+        if wave_id in wave_domains:
+            errors.append(f"Duplicate wave id: {wave_id}")
+            continue
+        if not isinstance(members, list) or any(
+            isinstance(member, bool) or not isinstance(member, int) for member in members
+        ):
+            errors.append(f"Wave {wave_id} domains must be a list of integers")
+            continue
+        member_set = set(members)
+        if len(member_set) != len(members):
+            errors.append(f"Wave {wave_id} contains a duplicate domain")
+        wave_domains[wave_id] = member_set
+        seen_wave_members.extend(members)
+
+        groups = wave.get("analysis_groups", [])
+        if not isinstance(groups, list):
+            errors.append(f"Wave {wave_id} analysis_groups must be a list")
+            continue
+        for group in groups:
+            if (
+                not isinstance(group, list)
+                or len(group) < 2
+                or any(isinstance(member, bool) or not isinstance(member, int) for member in group)
+            ):
+                errors.append(f"Wave {wave_id} contains an invalid analysis group: {group}")
+                continue
+            manifest_analysis_groups.add(frozenset(group))
+
+    if wave_domains != EXPECTED_WAVES:
+        errors.append(f"Wave membership differs from the canonical plan: {wave_domains}")
+    if set(seen_wave_members) != EXPECTED_INDICES or len(seen_wave_members) != 20:
+        errors.append("Every domain index 16-35 must belong to exactly one wave")
+    if manifest_analysis_groups != EXPECTED_ANALYSIS_GROUPS:
+        errors.append("Analysis groups differ from the canonical pair/group plan")
+
+    expected_companions: dict[int, set[int]] = {index: set() for index in EXPECTED_INDICES}
+    for group in EXPECTED_ANALYSIS_GROUPS:
+        for member in group:
+            expected_companions[member].update(group - {member})
+
+    for domain in typed_domains:
+        index = domain.get("index")
+        slug = domain.get("slug")
+        label = f"domain {index} ({slug})"
+        if isinstance(index, bool) or not isinstance(index, int) or index not in EXPECTED_INDICES:
+            continue
+
+        declared_wave = domain.get("wave")
+        if declared_wave not in EXPECTED_WAVES or index not in EXPECTED_WAVES[declared_wave]:
+            errors.append(f"{label}: inconsistent wave {declared_wave}")
+
+        companions = domain.get("analysis_companions")
+        if not isinstance(companions, list) or any(
+            isinstance(companion, bool) or not isinstance(companion, int) for companion in companions
+        ):
+            errors.append(f"{label}: analysis_companions must be a list of integers")
+        elif set(companions) != expected_companions[index]:
+            errors.append(
+                f"{label}: analysis companions must be "
+                f"{sorted(expected_companions[index])}, got {sorted(companions)}"
+            )
+
+        scientific_directory = domain.get("scientific_directory")
+        if not isinstance(scientific_directory, str) or not (ROOT / scientific_directory).is_dir():
+            errors.append(f"{label}: missing scientific directory {scientific_directory}")
+
+        readme = domain.get("scientific_readme")
+        if not isinstance(readme, str) or not (ROOT / readme).is_file():
+            errors.append(f"{label}: missing scientific README {readme}")
+
+        sources = domain.get("scientific_sources")
+        if not isinstance(sources, list) or not sources:
+            errors.append(f"{label}: scientific_sources must be a non-empty list")
+        else:
+            for source in sources:
+                if not isinstance(source, str) or not (ROOT / source).is_file():
+                    errors.append(f"{label}: missing scientific source {source}")
+
+        if domain.get("feature_count") is not None:
+            errors.append(f"{label}: feature_count must remain null before decomposition")
+        if domain.get("handoff_publication") is not False:
+            errors.append(f"{label}: handoff_publication must remain false")
+
+        pipeline = domain.get("pipeline")
+        if not isinstance(pipeline, dict):
+            errors.append(f"{label}: pipeline must be a mapping")
+        else:
+            if pipeline.get("scientific_source") != "complete":
+                errors.append(f"{label}: scientific_source must be complete")
+            for state in DOWNSTREAM_STATES:
+                if pipeline.get(state) != "not_started":
+                    errors.append(f"{label}: downstream state {state} must remain not_started")
+
+        dependencies = domain.get("dependencies")
+        if not isinstance(dependencies, dict):
+            errors.append(f"{label}: dependencies must be a mapping")
+            continue
+        confirmed = dependencies.get("confirmed")
+        provisional = dependencies.get("provisional")
+        if not isinstance(confirmed, list) or any(
+            isinstance(item, bool) or not isinstance(item, int) for item in confirmed
+        ):
+            errors.append(f"{label}: dependencies.confirmed must be a list of integers")
+            confirmed = []
+        if not isinstance(provisional, list) or any(
+            isinstance(item, bool) or not isinstance(item, int) for item in provisional
+        ):
+            errors.append(f"{label}: dependencies.provisional must be a list of integers")
+            provisional = []
+        for dependency in [*confirmed, *provisional]:
+            if dependency < 0 or dependency > 35:
+                errors.append(f"{label}: invalid dependency index {dependency}")
+            if dependency == index:
+                errors.append(f"{label}: self-dependency is not allowed")
+        if set(confirmed) & set(provisional):
+            errors.append(f"{label}: a dependency cannot be both confirmed and provisional")
+
+    manifest_text = MANIFEST_PATH.read_text(encoding="utf-8")
+    future_ids = sorted(set(FUTURE_FEATURE_ID.findall(manifest_text)))
+    if future_ids:
+        errors.append(f"Future feature identifiers must not be instantiated in phase 0: {future_ids}")
+
+    catalog = load_json(CATALOG_PATH, errors)
+    if catalog is None:
+        return print_failure(errors)
+    validate_global_catalog(catalog, errors)
+
+    if errors:
+        return print_failure(errors)
+
+    print("Domains 16-35 extension validation: PASS (20 domains, exact coverage 16-35)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Registers exactly 20 future domains, covering indices 16–35.
- Adopts vertical domain completion as the production strategy.
- Defines the pilot and five dependency-oriented production waves.
- Establishes complete-domain-only publication policy and validation gates.
- Adds a minimal phase-0 validator for the extension registry.
- Invents no feature population or scientific functionality.
- Publishes no premature Handoff Package or future domain catalog.
- Does not modify any of the 166 existing Feature Handoff Packages.

## Scope

Exactly these files are added:

- `registry/domain-progress/extension-16-35.yaml`
- `reports/domain-extension/production-plan-16-35.md`
- `tools/domain-progress/validate_extension_16_35.py`

No `maths/`, domain-finalization, optimized-IR, algorithm, oracle, contract, handoff package, or catalog file is modified.

## Domain coverage

| Wave | Domains |
|---|---|
| Pilot | 16 — Cohort |
| Wave 1 — Temporal/context foundations | 22 — Temporality; 23 — Memory; 24 — Context; 25 — Culture; 26 — Identity; 27 — Reflexivity |
| Wave 2 — Measurement/control/fidelity | 18 — Evaluation; 19 — Regulation; 20 — Robustness; 21 — Fairness; 32 — Drift and Correction; 35 — Fidelity to the Invariant Core |
| Wave 3 — Finality/large-scale propagation | 28 — Finality and Evolutionary Teleology; 29 — Generational Propagation; 30 — Expansion; 31 — Institutionalization |
| Wave 4 — Transmission orchestration | 17 — Cascade Transmission; 34 — Transmission Lifecycle |
| Wave 5 — Specialized architecture | 33 — Low-Data Architecture |

Analysis groups are recorded separately from scientific, runtime, and shared-contract dependencies: `22+23`, `24+25`, `26+27`, `18+19`, `20+21`, `32+35`, and `29+30+31`.

## Validation

Repository inspection performed through the GitHub connector confirmed:

- default branch: `main`;
- phase-0 baseline / merge base: `2b32e5a49e57389d03b1f4958bf3ca5cae2dbf1b`;
- no competing open PR for this extension at branch creation time;
- exact branch diff: three added files only, with the branch `ahead 3 / behind 0` before PR creation;
- source filenames are taken from each domain README, including all eight scientific documents declared for domain 34;
- explicit source-backed scientific dependencies are distinguished from operational analysis groups;
- `feature_count` remains `null` for every domain and `handoff_publication` remains `false`;
- no instantiated `TLC-FC-16-*` identifier is introduced;
- `handoff/catalog.json` and the existing 166 Feature Handoff Packages are outside the diff.

A new minimal validator is included because the existing domain and handoff validators validate already-produced domain artifacts/catalogs rather than this pre-production extension registry. The repository already uses PyYAML in its validators, so no new Python dependency or validation framework is introduced.

No local command execution is claimed. GitHub checks associated with this PR/commit will be reviewed before merge; no temporary workflow is added.

## Next production step

`Domain 16 — Cohort, complete vertical pipeline to validated Handoff Packages.`

## Summary by Sourcery

Add a phase-0 extension manifest and validation guardrails to prepare production for domains 16–35 without changing existing handoff artifacts.

New Features:
- Introduce a machine-readable registry manifest describing the production program, waves, dependencies, and states for domains 16–35.
- Add a French-language production plan document detailing the vertical completion strategy, validation gates, and publication policy for domains 16–35.
- Provide a Python validator that enforces the extension manifest’s coverage, invariants, and absence of premature handoff publication or feature identifiers.

Enhancements:
- Codify strict publication and dependency policies to ensure only fully finalized domains enter the global handoff catalog and shared contracts remain justified.

Documentation:
- Document the production strategy, validation gates, wave ordering, and publication policy for the new domains 16–35 in a dedicated report.