### PR TITLE
Correct final Reflexivity publication report

### DIFF
--- a/reports/handoff/reflexivity/generation-report.md
+++ b/reports/handoff/reflexivity/generation-report.md
@@ -28,6 +28,42 @@ The packages do not invent a metacognitive state variable, crisis lifecycle, eta
 
 Each feature has a mathematical contract, candidate IR, registered IR, test plan, optimized IR, algorithm/guard, oracle, implementation task, and autonomous Feature Handoff Package containing `README.md`, `manifest.json`, `contract.json`, `acceptance.json`, and `traceability.json`. The domain catalog is `handoff/domains/reflexivity/catalog.json` and its authoritative population is `registry/domain-finalization/reflexivity/feature-status.yaml`.
 
-## Publication target
+## Culture reconciliation and final publication state
 
-The reconciled incoming global baseline is **21 domains / 227 features / 8 shared contracts** while Culture 25 remains unpublished. Publishing Reflexivity raises the model to **22 domains / 236 features / 8 shared contracts** unless `main` advances before the final gate, in which case the global artifacts are reconciled again before merge. The permanent Feature handoff and Global finalization workflows remain unchanged and read-only.
+Culture 25 was published before the final Reflexivity gate. Reflexivity was therefore reconciled onto `main@c31845a4104d74bfad3013294df0d249bf537ed5`, whose published model was **22 domains / 235 features / 8 shared contracts**. Culture remained published with 8 features while Reflexivity remained the only new domain introduced by PR #148.
+
+The reconciled Reflexivity model is **23 domains / 244 features / 8 shared contracts**. `DOMAIN_ORDER` preserves all prior publications and ends with `identity`, `context`, `culture`, `reflexivity`. `handoff/catalog.json` was materialized from the official deterministic generator for this exact combined population.
+
+## Review correction
+
+Sourcery identified one actionable naming inconsistency between the scientific gradient object `grad_R Phi_id` and relation `RFX-REL-002`. The relation target was aligned to the source-preserving object name `grad_R Phi_id`; no scientific formula was changed. The review thread was resolved before merge.
+
+## Final validation
+
+The exact final PR HEAD was `83ec2c9899483ec10690951c42ffbf849fee8527`.
+
+Both permanent workflows completed successfully on that same unchanged HEAD:
+
+- **Feature handoff validation** — run `31383509472` — SUCCESS;
+- **Global finalization validation** — run `31383508867` — SUCCESS.
+
+The deterministic checks validated a final global population of **23 domains / 244 features / 8 shared contracts**, extension publication state with 7 published extension domains and 78 extension features, logical self-tests A–K, and byte-for-byte deterministic standalone regeneration for all 244 feature bundles.
+
+The permanent handoff workflow remains read-only (`contents: read`), and `tools/handoff/generate_catalog.py` remains the official uninstrumented generator.
+
+## Merge and direct-main verification
+
+PR #148, **Finalize domain 27 Reflexivity to implementation-ready handoffs**, was squash-merged with commit:
+
+`442922bdf5b23be623eb2ec275cdb5981d2aef30`
+
+Direct reads from `main` after merge confirm:
+
+- `tools/handoff/model.py`: **23 domains / 244 features / 8 shared contracts**;
+- `registry/domain-progress/extension-16-35.yaml`: Culture 25 and Reflexivity 27 both published with complete pipelines; future domain 28 remains unpublished;
+- `handoff/domains/reflexivity/catalog.json`: exactly 9 finalized features, `TLC-FC-27-REFLEXIVITY-001` through `009`;
+- first and last Reflexivity packages are finalized and structural-only where specified;
+- `handoff/catalog.json` matches the validated branch catalog blob;
+- `maths/27-reflexivity/reflexivity.md` remains unchanged at source blob `dc33dd515b7728f7f9f23f84081cd40b637a4a3d`.
+
+Reflexivity 27 is therefore published as an implementation-ready handoff domain subject to its preserved scientific guards and unresolved boundaries.


### PR DESCRIPTION
## Summary

Correct the post-merge Reflexivity generation report so it records the **actual final reconciled publication state** rather than the pre-Culture scenario that remained in the original report.

## Correction

The report now records:

- incoming reconciled baseline: `main@c31845a4104d74bfad3013294df0d249bf537ed5`;
- Culture 25 already published with 8 features;
- final global model: **23 domains / 244 features / 8 shared contracts**;
- final validated PR HEAD: `83ec2c9899483ec10690951c42ffbf849fee8527`;
- Feature handoff validation run `31383509472` — SUCCESS;
- Global finalization validation run `31383508867` — SUCCESS;
- Sourcery gradient-name correction and resolved review thread;
- Reflexivity squash merge SHA `442922bdf5b23be623eb2ec275cdb5981d2aef30`;
- direct-main verification of model, extension state, packages, deterministic catalog, permanent generator, and unchanged scientific source.

## Scope

Documentation-only correction to `reports/handoff/reflexivity/generation-report.md`.

No scientific source, contracts, IR, packages, catalog, validator, generator, workflow, or runtime code is changed.

## Summary by Sourcery

Update the Reflexivity handoff generation report to reflect the final reconciled publication and validation state after Culture 25 and Reflexivity 27 were fully published and merged.

Documentation:
- Correct the Reflexivity generation report with the final reconciled domain/feature counts, publication state, and validation runs.
- Document the reviewed gradient-name correction and final deterministic verification of the Reflexivity handoff against main.